### PR TITLE
feat(mcp): HTTP transport + serve-mcp CLI for ChatGPT App Directory

### DIFF
--- a/deploy/mcp/Dockerfile
+++ b/deploy/mcp/Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1.7
+
+# Multi-stage build for the Hivemind HTTP MCP server.
+#
+# Image layout:
+#   /app/bundle/cli.js   — esbuild-bundled hivemind CLI (bin entry)
+#   /app/node_modules    — runtime deps for externalized native modules
+#                          (tree-sitter, zstd, etc.) — most aren't loaded
+#                          by `serve-mcp`, but the ESM import chain may
+#                          require them to be resolvable.
+#
+# Entry point: `node bundle/cli.js serve-mcp`.
+# Configure via env at runtime — see src/cli/serve-mcp.ts.
+
+# ────────────────────────────── builder ──────────────────────────────
+FROM node:24-alpine AS build
+
+# Native build deps for tree-sitter rebuild on arm64; safe no-ops on x64.
+RUN apk add --no-cache python3 make g++ git
+
+WORKDIR /app
+
+# Copy manifest + scripts first so postinstall has what it needs.
+COPY package.json package-lock.json ./
+COPY scripts ./scripts
+
+# `npm install --ignore-scripts` skips:
+#   - `prepare` (would run husky + npm run build before sources are copied)
+#   - `postinstall` (tree-sitter native rebuild — not needed for serve-mcp,
+#     which doesn't load the graph extractor)
+#
+# We use `npm install` (not `npm ci`) because origin/main's
+# package-lock.json drifts from package.json (e.g. `pg` resolves to a
+# newer minor than the lockfile records). Once the lockfile is
+# regenerated (a separate cleanup) this can switch back to `npm ci`
+# without `--ignore-scripts`.
+RUN npm install --ignore-scripts --no-audit --no-fund
+
+# Copy the sources needed to build the CLI bundle. `npm run build` ==
+# `tsc && node esbuild.config.mjs`.
+COPY tsconfig.json esbuild.config.mjs ./
+COPY src ./src
+# esbuild.config.mjs reads version banners + SKILL bodies from a few of
+# the agent subtrees (notably openclaw/) when building all bundles. The
+# CLI bundle itself only needs `dist/src/cli/index.js` (a tsc output),
+# but the build step still walks the per-agent entry points, so we copy
+# the source-tracked agent dirs here. `cursor/` and `mcp/` are build
+# *outputs* — they don't exist as sources on origin/main.
+COPY .claude-plugin ./.claude-plugin
+COPY claude-code ./claude-code
+COPY codex ./codex
+COPY hermes ./hermes
+COPY openclaw ./openclaw
+COPY pi ./pi
+
+RUN npm run build
+
+# Drop devDependencies so the runtime stage carries only production deps.
+RUN npm prune --omit=dev
+
+# ────────────────────────────── runtime ──────────────────────────────
+FROM node:24-alpine AS runtime
+
+# Non-root user.
+RUN addgroup -g 10001 hivemind && adduser -H -D -u 10001 -G hivemind hivemind
+
+WORKDIR /app
+
+COPY --from=build --chown=hivemind:hivemind /app/bundle ./bundle
+COPY --from=build --chown=hivemind:hivemind /app/node_modules ./node_modules
+COPY --from=build --chown=hivemind:hivemind /app/package.json ./package.json
+
+USER hivemind
+
+ENV NODE_ENV=production \
+    HIVEMIND_MCP_PORT=8787 \
+    HIVEMIND_MCP_HOST=0.0.0.0
+
+EXPOSE 8787
+
+# k8s liveness/readiness can hit /health directly. Docker's built-in
+# HEALTHCHECK uses wget (busybox in alpine).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:${HIVEMIND_MCP_PORT}/health || exit 1
+
+ENTRYPOINT ["node", "bundle/cli.js"]
+CMD ["serve-mcp"]

--- a/deploy/mcp/README.md
+++ b/deploy/mcp/README.md
@@ -1,0 +1,72 @@
+# Hivemind MCP HTTP server — deploy
+
+The HTTP MCP server that makes Hivemind reachable from the ChatGPT App Directory. It is the same tool code as the stdio MCP server agents use locally (`src/mcp/tools.ts`), wrapped in `StreamableHTTPServerTransport` from `@modelcontextprotocol/sdk`.
+
+## What this directory contains
+
+- `Dockerfile` — multi-stage build, produces a ~150 MB Alpine image running as `hivemind:10001`, ENTRYPOINT `node bundle/cli.js serve-mcp`.
+- `k8s.yaml` — Namespace + ConfigMap + Deployment + Service + Ingress as a starting template. Adapt to your cluster's namespacing, image registry, and ingress class before applying.
+
+## Configuration (env vars)
+
+All read by `src/cli/serve-mcp.ts`:
+
+| Var | Default | Notes |
+|---|---|---|
+| `HIVEMIND_MCP_AUTH_ISSUER` | _(required)_ | Auth0 issuer URL (trailing slash). Advertised in `WWW-Authenticate` on 401 so ChatGPT can discover the auth server. e.g. `https://auth-beta.deeplake.ai/` |
+| `HIVEMIND_MCP_PORT` | `8787` | Listen port |
+| `HIVEMIND_MCP_HOST` | `0.0.0.0` | Bind host |
+| `HIVEMIND_API_URL` | `https://api.deeplake.ai` | deeplake-api base URL |
+
+## Build
+
+```sh
+# from the repo root
+docker build -f deploy/mcp/Dockerfile -t hivemind-mcp:<tag> .
+```
+
+The image is self-contained; nothing else from the repo is needed at runtime.
+
+## Run locally
+
+```sh
+docker run --rm -p 8787:8787 \
+  -e HIVEMIND_MCP_AUTH_ISSUER=https://auth-beta.deeplake.ai/ \
+  hivemind-mcp:<tag>
+
+# Then:
+curl http://127.0.0.1:8787/health
+# {"status":"ok","version":"0.7.67"}
+
+curl -i -X POST http://127.0.0.1:8787/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}'
+# HTTP/1.1 401 Unauthorized
+# WWW-Authenticate: Bearer realm="https://auth-beta.deeplake.ai/", error="invalid_token", ...
+```
+
+## Deploy to k8s
+
+1. Push the image to your registry (`ghcr.io/activeloopai/hivemind-mcp:<tag>`).
+2. Update `k8s.yaml` — image tag, namespace if not `hivemind-mcp`, ingress host if not `api.deeplake.ai`, cluster issuer name.
+3. `kubectl apply -f deploy/mcp/k8s.yaml`.
+
+The Ingress in the template routes `api.deeplake.ai/mcp/*` to this Service. **Important:** the existing `api.deeplake.ai/*` rules must keep routing non-`/mcp` paths to the existing deeplake-api backend — otherwise you'll black-hole the rest of the API. Layering this Ingress alongside the existing one (with explicit `pathType: Prefix` on `/mcp` only) is the safest pattern.
+
+SSE streams require buffering off — the ingress annotations in the template set `nginx.ingress.kubernetes.io/proxy-buffering: off` and 1-hour read/send timeouts.
+
+## Known caveats
+
+- **Lockfile drift on `origin/main`** — `package-lock.json` is currently out of sync with `package.json` (e.g. `pg` resolves to a newer minor than the lockfile records). The Dockerfile uses `npm install --ignore-scripts` as a workaround. Once the lockfile is regenerated, switch back to `npm ci` for reproducibility.
+- **No JWT validation in the MCP server itself** — the Bearer token is forwarded to deeplake-api, which validates it via `internal/auth/jwt.go`. The MCP server only checks the token is *present*; it does not validate the signature.
+- **Multi-org users** — the first call to `GET /organizations` picks the user's primary org. A workspace picker is deferred (see plan).
+- **No rate limit in this server** — front this with the existing api.deeplake.ai rate-limiter middleware via the ingress, or add one in a Tier-2 follow-up.
+
+## Verification
+
+```sh
+npx vitest run tests/shared/mcp-http-server.test.ts
+# Test Files  1 passed (1)
+#      Tests  5 passed (5)
+```
+
+End-to-end against a real ChatGPT account is the gating check before submission — covered in the main plan (task #7).

--- a/deploy/mcp/k8s.yaml
+++ b/deploy/mcp/k8s.yaml
@@ -1,0 +1,149 @@
+# Kubernetes manifest for the Hivemind HTTP MCP server.
+#
+# This is a starting template — adapt to your cluster's namespacing,
+# image registry, and ingress conventions before applying.
+#
+# Reaching the server from ChatGPT requires public HTTPS. The bundled
+# Ingress example assumes nginx-ingress + cert-manager on the existing
+# deeplake.ai cluster, routing `api.deeplake.ai/mcp/*` to this Service.
+#
+# Apply with:
+#   kubectl apply -f deploy/mcp/k8s.yaml
+#
+# Required env: HIVEMIND_MCP_AUTH_ISSUER (Auth0 issuer URL).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hivemind-mcp
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hivemind-mcp-config
+  namespace: hivemind-mcp
+data:
+  # The Auth0 issuer URL — advertised in WWW-Authenticate on 401 so
+  # ChatGPT knows where to send the user to sign in.
+  HIVEMIND_MCP_AUTH_ISSUER: "https://auth-beta.deeplake.ai/"
+  HIVEMIND_API_URL: "https://api.deeplake.ai"
+  HIVEMIND_MCP_PORT: "8787"
+  HIVEMIND_MCP_HOST: "0.0.0.0"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hivemind-mcp
+  namespace: hivemind-mcp
+  labels:
+    app.kubernetes.io/name: hivemind-mcp
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hivemind-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hivemind-mcp
+        app.kubernetes.io/component: mcp-server
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+      containers:
+        - name: server
+          # TODO: set to the published image tag once the CI build pipeline
+          # is wired up (e.g. ghcr.io/activeloopai/hivemind-mcp:0.7.67).
+          image: ghcr.io/activeloopai/hivemind-mcp:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8787
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: hivemind-mcp-config
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hivemind-mcp
+  namespace: hivemind-mcp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hivemind-mcp
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+---
+# Routes api.deeplake.ai/mcp and /.well-known paths to the MCP service.
+# Everything else on api.deeplake.ai (the existing API) stays on its
+# current backend — adjust the host's other path rules accordingly.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hivemind-mcp
+  namespace: hivemind-mcp
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"  # SSE streams must not be buffered.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - api.deeplake.ai
+      secretName: api-deeplake-ai-tls
+  rules:
+    - host: api.deeplake.ai
+      http:
+        paths:
+          - path: /mcp
+            pathType: Prefix
+            backend:
+              service:
+                name: hivemind-mcp
+                port:
+                  number: 80
+          - path: /health
+            pathType: Exact
+            backend:
+              service:
+                name: hivemind-mcp
+                port:
+                  number: 80

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import { getVersion } from "./version.js";
 import { runUpdate } from "./update.js";
 import { renderCliHelpBlock } from "./skillify-spec.js";
 import { canOfferInstallScan, runInstallScan, formatScanResult } from "./install-scan.js";
+import { runServeMcp } from "./serve-mcp.js";
 
 const AUTH_SUBCOMMANDS = new Set([
   "whoami",
@@ -67,6 +68,15 @@ Usage:
   hivemind update [--dry-run]
       Check npm for a newer @deeplake/hivemind, upgrade the CLI, and refresh
       every detected agent bundle. Single command for all agents.
+
+  hivemind serve-mcp
+      Run the HTTP MCP server (Streamable HTTP transport) used by remote
+      clients like the ChatGPT App Directory. Configure with env vars:
+      HIVEMIND_MCP_AUTH_ISSUER (required, e.g. https://auth-beta.deeplake.ai/),
+      HIVEMIND_MCP_PORT (default 8787), HIVEMIND_MCP_HOST (default 0.0.0.0),
+      HIVEMIND_API_URL (default https://api.deeplake.ai). Bearer tokens
+      arrive in the Authorization header; missing token → 401 with
+      WWW-Authenticate pointing at the Auth0 issuer.
 
   hivemind dashboard [--cwd <path>] [--out <path>] [--no-open]
                      [--serve] [--port <n>]
@@ -466,6 +476,11 @@ async function main(): Promise<void> {
 
   if (cmd === "dashboard") {
     const code = await runDashboardCommand(args.slice(1));
+    process.exit(code);
+  }
+
+  if (cmd === "serve-mcp") {
+    const code = await runServeMcp(args.slice(1));
     process.exit(code);
   }
 

--- a/src/cli/serve-mcp.ts
+++ b/src/cli/serve-mcp.ts
@@ -1,0 +1,74 @@
+/**
+ * `hivemind serve-mcp` — runs the HTTP MCP server.
+ *
+ * This is the entry point used in production hosting (one small container)
+ * to serve the three Hivemind tools to remote MCP clients like the ChatGPT
+ * App Directory. Local agents (Hermes, Cursor, etc.) keep using the
+ * existing stdio MCP server.
+ *
+ * Configuration is via env vars so the container manifest is simple:
+ *
+ *   HIVEMIND_MCP_PORT          — listen port (default 8787)
+ *   HIVEMIND_MCP_HOST          — bind host (default 0.0.0.0)
+ *   HIVEMIND_MCP_AUTH_ISSUER   — Auth0 issuer advertised in WWW-Authenticate
+ *                                (required; e.g. https://auth-beta.deeplake.ai/)
+ *   HIVEMIND_API_URL           — Deeplake API base (default https://api.deeplake.ai)
+ *
+ *   Optional org/workspace pinning (skip the per-session /organizations lookup):
+ *   HIVEMIND_MCP_ORG_ID            — pin to this org id
+ *   HIVEMIND_MCP_WORKSPACE         — workspace id (default "default")
+ *   HIVEMIND_MCP_TABLE             — memory table name (default "memory")
+ *   HIVEMIND_MCP_SESSIONS_TABLE    — sessions table name (default "sessions")
+ */
+
+import { startHttpMcpServer } from "../mcp/http-server.js";
+import { log, warn } from "./util.js";
+
+export async function runServeMcp(_args: string[]): Promise<number> {
+  const authIssuer = process.env.HIVEMIND_MCP_AUTH_ISSUER ?? "";
+  if (!authIssuer) {
+    warn(
+      "HIVEMIND_MCP_AUTH_ISSUER is required. Set it to your Auth0 issuer URL " +
+        "(e.g. https://auth-beta.deeplake.ai/) so 401 responses can tell ChatGPT " +
+        "where to send the user to sign in.",
+    );
+    return 1;
+  }
+
+  const port = Number.parseInt(process.env.HIVEMIND_MCP_PORT ?? "8787", 10);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    warn(`Invalid HIVEMIND_MCP_PORT: ${process.env.HIVEMIND_MCP_PORT}`);
+    return 1;
+  }
+
+  const host = process.env.HIVEMIND_MCP_HOST ?? "0.0.0.0";
+  const apiUrl = process.env.HIVEMIND_API_URL ?? "https://api.deeplake.ai";
+  const orgId = process.env.HIVEMIND_MCP_ORG_ID || undefined;
+  const workspaceId = process.env.HIVEMIND_MCP_WORKSPACE || undefined;
+  const memoryTable = process.env.HIVEMIND_MCP_TABLE || undefined;
+  const sessionsTable = process.env.HIVEMIND_MCP_SESSIONS_TABLE || undefined;
+
+  try {
+    const { close } = await startHttpMcpServer({
+      port, host, authIssuer, apiUrl,
+      orgId, workspaceId, memoryTable, sessionsTable,
+    });
+    log(`hivemind serve-mcp ready on http://${host}:${port}/mcp`);
+
+    const shutdown = async (signal: string): Promise<void> => {
+      log(`received ${signal}, shutting down`);
+      await close();
+      process.exit(0);
+    };
+    process.on("SIGINT", () => void shutdown("SIGINT"));
+    process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+    // Block forever (until signaled).
+    await new Promise<void>(() => {});
+    return 0;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    warn(`hivemind serve-mcp failed to start: ${msg}`);
+    return 1;
+  }
+}

--- a/src/mcp/http-server.ts
+++ b/src/mcp/http-server.ts
@@ -1,0 +1,332 @@
+/**
+ * Hivemind MCP server — HTTP (Streamable) transport.
+ *
+ * Reachable over the network at POST /mcp + GET /mcp (SSE). Used by the
+ * ChatGPT App Directory and any other Apps SDK / MCP HTTP client.
+ *
+ * Auth: the user's Auth0 JWT arrives in `Authorization: Bearer <token>`.
+ * We don't validate it locally — `DeeplakeApi` forwards it to deeplake-api,
+ * which validates it via the existing `internal/auth/jwt.go`. Missing or
+ * malformed → 401 with `WWW-Authenticate` pointing at the Auth0 issuer.
+ *
+ * Org resolution: on first tool call per session we call
+ * `GET https://api.deeplake.ai/organizations` with the user's token and
+ * pick their primary org. Workspace + table names mirror the CLI defaults
+ * (workspaceId="default", tableName="memory", sessionsTableName="sessions"),
+ * per src/config.ts.
+ */
+
+import http from "node:http";
+import { randomUUID } from "node:crypto";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { DeeplakeApi } from "../deeplake-api.js";
+import { deeplakeClientHeader } from "../utils/client-header.js";
+import { getVersion } from "../cli/version.js";
+import { registerHivemindTools, type ContextResult } from "./tools.js";
+
+const DEFAULT_API_URL = "https://api.deeplake.ai";
+const DEFAULT_WORKSPACE = "default";
+const DEFAULT_MEMORY_TABLE = "memory";
+const DEFAULT_SESSIONS_TABLE = "sessions";
+
+/** Per-session resources. One MCP server + transport per ChatGPT session. */
+interface SessionState {
+  server: McpServer;
+  transport: StreamableHTTPServerTransport;
+  token: string;
+  apiUrl: string;
+  /**
+   * Resolved org id. Either pre-set from `pinnedOrgId` at server boot, or
+   * populated on first tool call via `GET /organizations`. `null` = not
+   * yet resolved.
+   */
+  resolvedOrgId: string | null;
+  workspaceId: string;
+  memoryTable: string;
+  sessionsTable: string;
+}
+
+export interface HttpMcpServerOptions {
+  /** Port to listen on. Default 8787. */
+  port?: number;
+  /** Host to bind. Default '0.0.0.0' (container-friendly). */
+  host?: string;
+  /** Auth0 issuer URL advertised in WWW-Authenticate on 401. */
+  authIssuer: string;
+  /** Deeplake API base URL. Default https://api.deeplake.ai. */
+  apiUrl?: string;
+  /**
+   * Optional pinned org id. When set, skips the `/organizations` lookup and
+   * uses this org for every authenticated request. Useful for:
+   *   - single-tenant deployments
+   *   - smoke testing without picking the wrong org from a multi-org user
+   *   - self-hosted Hivemind instances pinned to one workspace
+   * Set via env `HIVEMIND_MCP_ORG_ID`.
+   */
+  orgId?: string;
+  /** Workspace id. Default "default". Set via env `HIVEMIND_MCP_WORKSPACE`. */
+  workspaceId?: string;
+  /** Memory table name. Default "memory". Set via env `HIVEMIND_MCP_TABLE`. */
+  memoryTable?: string;
+  /** Sessions table name. Default "sessions". Set via env `HIVEMIND_MCP_SESSIONS_TABLE`. */
+  sessionsTable?: string;
+  /** Quiet log output (used by tests). */
+  silent?: boolean;
+}
+
+interface ResolvedOptions {
+  port: number;
+  host: string;
+  authIssuer: string;
+  apiUrl: string;
+  pinnedOrgId: string | null;
+  workspaceId: string;
+  memoryTable: string;
+  sessionsTable: string;
+  silent: boolean;
+}
+
+interface ServerState {
+  server: http.Server;
+  sessions: Map<string, SessionState>;
+  options: ResolvedOptions;
+}
+
+function extractBearer(req: http.IncomingMessage): string | null {
+  const header = req.headers["authorization"];
+  if (!header || typeof header !== "string") return null;
+  const m = header.match(/^Bearer\s+(.+)$/i);
+  return m ? m[1].trim() : null;
+}
+
+function sendJson(res: http.ServerResponse, code: number, body: unknown): void {
+  res.statusCode = code;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+function send401(res: http.ServerResponse, authIssuer: string, errorDescription: string): void {
+  res.setHeader(
+    "WWW-Authenticate",
+    `Bearer realm="${authIssuer}", error="invalid_token", error_description="${errorDescription}"`,
+  );
+  sendJson(res, 401, {
+    error: "invalid_token",
+    error_description: errorDescription,
+    auth_server: authIssuer,
+  });
+}
+
+async function readBody(req: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  if (chunks.length === 0) return undefined;
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolvePrimaryOrgId(token: string, apiUrl: string): Promise<string | null> {
+  const resp = await fetch(`${apiUrl}/organizations`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...deeplakeClientHeader(),
+    },
+  });
+  if (!resp.ok) return null;
+  const body = (await resp.json().catch(() => null)) as unknown;
+  // Tolerate both {organizations: [...]} and bare array shapes.
+  const orgs = Array.isArray(body)
+    ? body
+    : Array.isArray((body as { organizations?: unknown[] } | null)?.organizations)
+      ? (body as { organizations: unknown[] }).organizations
+      : null;
+  if (!orgs || orgs.length === 0) return null;
+  const first = orgs[0] as { id?: string; org_id?: string };
+  return first.id ?? first.org_id ?? null;
+}
+
+function buildGetContext(state: SessionState): () => Promise<ContextResult> {
+  return async () => {
+    if (!state.resolvedOrgId) {
+      try {
+        state.resolvedOrgId = await resolvePrimaryOrgId(state.token, state.apiUrl);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { error: `Could not resolve your Hivemind organization: ${msg}` };
+      }
+    }
+    if (!state.resolvedOrgId) {
+      return {
+        error:
+          "Could not resolve your Hivemind organization. Make sure you have at least one org on Deeplake before connecting.",
+      };
+    }
+    const api = new DeeplakeApi(
+      state.token,
+      state.apiUrl,
+      state.resolvedOrgId,
+      state.workspaceId,
+      state.memoryTable,
+    );
+    return {
+      api,
+      memoryTable: state.memoryTable,
+      sessionsTable: state.sessionsTable,
+    };
+  };
+}
+
+async function createSession(token: string, opts: ResolvedOptions): Promise<SessionState> {
+  const sessionId = randomUUID();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => sessionId,
+  });
+  const server = new McpServer({
+    name: "hivemind",
+    version: getVersion(),
+  });
+  const state: SessionState = {
+    server,
+    transport,
+    token,
+    apiUrl: opts.apiUrl,
+    resolvedOrgId: opts.pinnedOrgId,
+    workspaceId: opts.workspaceId,
+    memoryTable: opts.memoryTable,
+    sessionsTable: opts.sessionsTable,
+  };
+  registerHivemindTools(server, buildGetContext(state));
+  await server.connect(transport);
+  return state;
+}
+
+async function handleMcpRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  st: ServerState,
+): Promise<void> {
+  const token = extractBearer(req);
+  if (!token) {
+    send401(res, st.options.authIssuer, "Missing Bearer token. Sign in to Hivemind to connect.");
+    return;
+  }
+
+  const sessionIdHeader = req.headers["mcp-session-id"];
+  const existingId = typeof sessionIdHeader === "string" ? sessionIdHeader : undefined;
+
+  let session = existingId ? st.sessions.get(existingId) : undefined;
+  if (!session) {
+    // New session — body must be the MCP `initialize` request.
+    session = await createSession(token, st.options);
+    // The transport assigns the session id on init; store under that id once known.
+    // We use the transport's sessionId (set by the SDK after handleRequest).
+  }
+
+  const body = req.method === "POST" ? await readBody(req) : undefined;
+
+  try {
+    await session.transport.handleRequest(req, res, body);
+  } catch (err) {
+    if (!st.options.silent) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`mcp http error: ${msg}\n`);
+    }
+    if (!res.headersSent) sendJson(res, 500, { error: "internal_error" });
+    return;
+  }
+
+  // After the SDK assigns sessionId, register under that id for subsequent lookups.
+  const assignedId = session.transport.sessionId;
+  if (assignedId && !st.sessions.has(assignedId)) {
+    st.sessions.set(assignedId, session);
+  }
+}
+
+function handleHealth(res: http.ServerResponse): void {
+  sendJson(res, 200, { status: "ok", version: getVersion() });
+}
+
+function handleNotFound(res: http.ServerResponse): void {
+  sendJson(res, 404, { error: "not_found" });
+}
+
+export async function startHttpMcpServer(opts: HttpMcpServerOptions): Promise<{
+  server: http.Server;
+  port: number;
+  close: () => Promise<void>;
+}> {
+  const options: ResolvedOptions = {
+    port: opts.port ?? 8787,
+    host: opts.host ?? "0.0.0.0",
+    authIssuer: opts.authIssuer,
+    apiUrl: opts.apiUrl ?? DEFAULT_API_URL,
+    pinnedOrgId: opts.orgId ?? null,
+    workspaceId: opts.workspaceId ?? DEFAULT_WORKSPACE,
+    memoryTable: opts.memoryTable ?? DEFAULT_MEMORY_TABLE,
+    sessionsTable: opts.sessionsTable ?? DEFAULT_SESSIONS_TABLE,
+    silent: opts.silent ?? false,
+  };
+  const sessions = new Map<string, SessionState>();
+  const state: ServerState = {
+    server: undefined as unknown as http.Server,
+    sessions,
+    options,
+  };
+
+  const httpServer = http.createServer((req, res) => {
+    const url = req.url ?? "/";
+    if (url === "/health" && req.method === "GET") {
+      handleHealth(res);
+      return;
+    }
+    if (url === "/mcp" || url.startsWith("/mcp?")) {
+      // POST = client → server, GET = SSE stream, DELETE = session teardown.
+      void handleMcpRequest(req, res, state);
+      return;
+    }
+    handleNotFound(res);
+  });
+
+  state.server = httpServer;
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(options.port, options.host, () => {
+      httpServer.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  // OS-assigned ports (options.port === 0) only resolve after listen()
+  // succeeds. Read the actual port from the live socket so callers know
+  // where the server is reachable.
+  const address = httpServer.address();
+  const actualPort = typeof address === "object" && address !== null ? address.port : options.port;
+
+  if (!options.silent) {
+    process.stderr.write(
+      `hivemind-mcp http listening on http://${options.host}:${actualPort}/mcp (auth issuer: ${options.authIssuer})\n`,
+    );
+  }
+
+  const close = async (): Promise<void> => {
+    await new Promise<void>((resolve, reject) =>
+      httpServer.close(err => (err ? reject(err) : resolve())),
+    );
+    for (const session of sessions.values()) {
+      await session.transport.close().catch(() => {});
+    }
+    sessions.clear();
+  };
+
+  return { server: httpServer, port: actualPort, close };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,35 +1,24 @@
 /**
- * Hivemind MCP server — exposes shared org memory as MCP tools.
+ * Hivemind MCP server — stdio transport.
  *
- * Tools:
- *   hivemind_search  — keyword/regex search across summaries + sessions
- *   hivemind_read    — read full content of a specific memory path
- *   hivemind_index   — list summaries with their dates and descriptions
+ * Spawned as a subprocess by a local MCP client (Hermes, Cursor, etc.).
+ * Loads credentials from ~/.deeplake/credentials.json and serves the
+ * three Hivemind tools (search/read/index) over JSON-RPC on stdin/stdout.
  *
- * Transport: stdio. Spawned as a subprocess by the consuming MCP client
- * (Hermes today; reused by any future MCP-aware agent).
- *
- * Auth: loads ~/.deeplake/credentials.json. If credentials are missing,
- * tools return a clear "not authenticated" message rather than crashing.
+ * Tool registrations live in ./tools.ts and are shared with the HTTP
+ * transport (./http-server.ts) used by remote clients like the ChatGPT
+ * App Directory.
  */
 
-import * as z from "zod/v3";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadCredentials } from "../commands/auth.js";
 import { loadConfig } from "../config.js";
 import { DeeplakeApi } from "../deeplake-api.js";
-import { sqlStr, sqlLike } from "../utils/sql.js";
-import { searchDeeplakeTables, buildGrepSearchOptions, normalizeContent, type GrepMatchParams } from "../shell/grep-core.js";
 import { getVersion } from "../cli/version.js";
+import { registerHivemindTools, type ContextResult } from "./tools.js";
 
-interface ServerContext {
-  api: DeeplakeApi;
-  memoryTable: string;
-  sessionsTable: string;
-}
-
-function getContext(): ServerContext | { error: string } {
+function getStdioContext(): ContextResult {
   const creds = loadCredentials();
   if (!creds?.token) {
     return { error: "Not authenticated. Run `hivemind login` to sign in to Deeplake." };
@@ -42,128 +31,12 @@ function getContext(): ServerContext | { error: string } {
   return { api, memoryTable: config.tableName, sessionsTable: config.sessionsTableName };
 }
 
-function errorResult(text: string): { content: Array<{ type: "text"; text: string }> } {
-  return { content: [{ type: "text", text }] };
-}
-
 const server = new McpServer({
   name: "hivemind",
   version: getVersion(),
 });
 
-server.registerTool(
-  "hivemind_search",
-  {
-    description: "Search Hivemind shared memory (summaries + raw sessions) by keyword or multi-word phrase. Returns matching paths and snippets. Use this first when the user asks about prior work, conversations, or context that may exist in Hivemind. Different paths under /summaries/<username>/ are different users — do not merge them.",
-    inputSchema: {
-      query: z.string().describe("Keyword or multi-word phrase to search for (literal substring match)."),
-      limit: z.number().int().min(1).max(50).optional().describe("Maximum hits to return (default 10)."),
-    },
-  },
-  async ({ query, limit }: { query: string; limit?: number }) => {
-    const ctx = getContext();
-    if ("error" in ctx) return errorResult(ctx.error);
-
-    const params: GrepMatchParams = {
-      pattern: query,
-      ignoreCase: true,
-      wordMatch: false,
-      filesOnly: false,
-      countOnly: false,
-      lineNumber: false,
-      invertMatch: false,
-      fixedString: true,
-    };
-    const opts = buildGrepSearchOptions(params, "/");
-    opts.limit = limit ?? 10;
-
-    try {
-      const rows = await searchDeeplakeTables(ctx.api, ctx.memoryTable, ctx.sessionsTable, opts);
-      if (rows.length === 0) return errorResult(`No matches for "${query}".`);
-      const lines = rows.map(r => {
-        const body = normalizeContent(r.path, r.content);
-        return `[${r.path}]\n${body.slice(0, 600)}`;
-      });
-      return { content: [{ type: "text", text: lines.join("\n\n---\n\n") }] };
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorResult(`Search failed: ${msg}`);
-    }
-  },
-);
-
-server.registerTool(
-  "hivemind_read",
-  {
-    description: "Read the full content of a specific Hivemind memory path. Use after hivemind_search to drill into a hit, or when you already know the path (e.g. /summaries/alice/abc.md or /sessions/alice/alice_org_ws_xyz.jsonl or /index.md).",
-    inputSchema: {
-      path: z.string().describe("Absolute Hivemind memory path, e.g. /summaries/alice/abc.md"),
-    },
-  },
-  async ({ path }: { path: string }) => {
-    const ctx = getContext();
-    if ("error" in ctx) return errorResult(ctx.error);
-
-    if (!path.startsWith("/")) {
-      return errorResult(`Path must start with '/': got "${path}"`);
-    }
-
-    const isSession = path.startsWith("/sessions/");
-    const table = isSession ? ctx.sessionsTable : ctx.memoryTable;
-    const column = isSession ? "message::text" : "summary::text";
-
-    try {
-      const sql = `SELECT path, ${column} AS content FROM "${table}" WHERE path = '${sqlStr(path)}' LIMIT 200`;
-      const rows = await ctx.api.query(sql);
-      if (rows.length === 0) return errorResult(`No content found at ${path}.`);
-      const text = rows.map(r => normalizeContent(String(r["path"]), String(r["content"] ?? ""))).join("\n");
-      return { content: [{ type: "text", text }] };
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorResult(`Read failed: ${msg}`);
-    }
-  },
-);
-
-server.registerTool(
-  "hivemind_index",
-  {
-    description: "List Hivemind summary entries (one row per session). Use to see what's in shared memory and find relevant sessions to drill into with hivemind_read.",
-    inputSchema: {
-      prefix: z.string().optional().describe("Path prefix to filter by, e.g. '/summaries/alice/' to scope to one user."),
-      limit: z.number().int().min(1).max(200).optional().describe("Maximum rows (default 50)."),
-    },
-  },
-  async ({ prefix, limit }: { prefix?: string; limit?: number }) => {
-    const ctx = getContext();
-    if ("error" in ctx) return errorResult(ctx.error);
-
-    // sqlLike escapes both quotes AND LIKE wildcards (% / _) so an
-    // LLM-supplied prefix can't bypass the filter (e.g. prefix='%' would
-    // match every row otherwise). ESCAPE '\\' tells the engine to honour
-    // the backslash escapes sqlLike inserts.
-    const where = prefix
-      ? `WHERE path LIKE '${sqlLike(prefix)}%' ESCAPE '\\'`
-      : `WHERE path LIKE '/summaries/%'`;
-    const sql = `SELECT path, description, project, last_update_date FROM "${ctx.memoryTable}" ${where} ORDER BY last_update_date DESC LIMIT ${limit ?? 50}`;
-
-    try {
-      const rows = await ctx.api.query(sql);
-      if (rows.length === 0) return errorResult("No summaries found.");
-      const lines = rows.map(r => {
-        const path = String(r["path"] ?? "?");
-        const desc = String(r["description"] ?? "");
-        const project = String(r["project"] ?? "");
-        const date = String(r["last_update_date"] ?? "");
-        return `${path}\t${date}\t${project}\t${desc}`;
-      });
-      return { content: [{ type: "text", text: `path\tlast_updated\tproject\tdescription\n${lines.join("\n")}` }] };
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorResult(`Index failed: ${msg}`);
-    }
-  },
-);
+registerHivemindTools(server, getStdioContext);
 
 async function main(): Promise<void> {
   const transport = new StdioServerTransport();

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,160 @@
+/**
+ * Hivemind MCP tools — shared registrations used by both transports:
+ *   - stdio (src/mcp/server.ts) — local agents (Hermes, Cursor)
+ *   - HTTP  (src/mcp/http-server.ts) — remote clients (ChatGPT App Directory)
+ *
+ * The 3 tools are read-only by design (only SELECTs against the user's
+ * org-scoped Hivemind tables). Annotations reflect that for OpenAI's
+ * App Directory review.
+ */
+
+import * as z from "zod/v3";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { DeeplakeApi } from "../deeplake-api.js";
+import { sqlStr, sqlLike } from "../utils/sql.js";
+import {
+  searchDeeplakeTables,
+  buildGrepSearchOptions,
+  normalizeContent,
+  type GrepMatchParams,
+} from "../shell/grep-core.js";
+
+export interface ServerContext {
+  api: DeeplakeApi;
+  memoryTable: string;
+  sessionsTable: string;
+}
+
+export type ContextResult = ServerContext | { error: string };
+
+export type GetContext = () => ContextResult | Promise<ContextResult>;
+
+function errorResult(text: string): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text", text }] };
+}
+
+const READ_ONLY_ANNOTATIONS = {
+  readOnlyHint: true,
+  openWorldHint: false,
+  destructiveHint: false,
+} as const;
+
+export function registerHivemindTools(server: McpServer, getContext: GetContext): void {
+  server.registerTool(
+    "hivemind_search",
+    {
+      description:
+        "Search Hivemind shared memory (summaries + raw sessions) by keyword or multi-word phrase. Returns matching paths and snippets. Use this first when the user asks about prior work, conversations, or context that may exist in Hivemind. Different paths under /summaries/<username>/ are different users — do not merge them.",
+      inputSchema: {
+        query: z.string().describe("Keyword or multi-word phrase to search for (literal substring match)."),
+        limit: z.number().int().min(1).max(50).optional().describe("Maximum hits to return (default 10)."),
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    async ({ query, limit }: { query: string; limit?: number }) => {
+      const ctx = await getContext();
+      if ("error" in ctx) return errorResult(ctx.error);
+
+      const params: GrepMatchParams = {
+        pattern: query,
+        ignoreCase: true,
+        wordMatch: false,
+        filesOnly: false,
+        countOnly: false,
+        lineNumber: false,
+        invertMatch: false,
+        fixedString: true,
+      };
+      const opts = buildGrepSearchOptions(params, "/");
+      opts.limit = limit ?? 10;
+
+      try {
+        const rows = await searchDeeplakeTables(ctx.api, ctx.memoryTable, ctx.sessionsTable, opts);
+        if (rows.length === 0) return errorResult(`No matches for "${query}".`);
+        const lines = rows.map(r => {
+          const body = normalizeContent(r.path, r.content);
+          return `[${r.path}]\n${body.slice(0, 600)}`;
+        });
+        return { content: [{ type: "text", text: lines.join("\n\n---\n\n") }] };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorResult(`Search failed: ${msg}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    "hivemind_read",
+    {
+      description:
+        "Read the full content of a specific Hivemind memory path. Use after hivemind_search to drill into a hit, or when you already know the path (e.g. /summaries/alice/abc.md or /sessions/alice/alice_org_ws_xyz.jsonl or /index.md).",
+      inputSchema: {
+        path: z.string().describe("Absolute Hivemind memory path, e.g. /summaries/alice/abc.md"),
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    async ({ path }: { path: string }) => {
+      const ctx = await getContext();
+      if ("error" in ctx) return errorResult(ctx.error);
+
+      if (!path.startsWith("/")) {
+        return errorResult(`Path must start with '/': got "${path}"`);
+      }
+
+      const isSession = path.startsWith("/sessions/");
+      const table = isSession ? ctx.sessionsTable : ctx.memoryTable;
+      const column = isSession ? "message::text" : "summary::text";
+
+      try {
+        const sql = `SELECT path, ${column} AS content FROM "${table}" WHERE path = '${sqlStr(path)}' LIMIT 200`;
+        const rows = await ctx.api.query(sql);
+        if (rows.length === 0) return errorResult(`No content found at ${path}.`);
+        const text = rows.map(r => normalizeContent(String(r["path"]), String(r["content"] ?? ""))).join("\n");
+        return { content: [{ type: "text", text }] };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorResult(`Read failed: ${msg}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    "hivemind_index",
+    {
+      description:
+        "List Hivemind summary entries (one row per session). Use to see what's in shared memory and find relevant sessions to drill into with hivemind_read.",
+      inputSchema: {
+        prefix: z.string().optional().describe("Path prefix to filter by, e.g. '/summaries/alice/' to scope to one user."),
+        limit: z.number().int().min(1).max(200).optional().describe("Maximum rows (default 50)."),
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    async ({ prefix, limit }: { prefix?: string; limit?: number }) => {
+      const ctx = await getContext();
+      if ("error" in ctx) return errorResult(ctx.error);
+
+      // sqlLike escapes both quotes AND LIKE wildcards (% / _) so an
+      // LLM-supplied prefix can't bypass the filter.
+      const where = prefix
+        ? `WHERE path LIKE '${sqlLike(prefix)}%' ESCAPE '\\'`
+        : `WHERE path LIKE '/summaries/%'`;
+      const sql = `SELECT path, description, project, last_update_date FROM "${ctx.memoryTable}" ${where} ORDER BY last_update_date DESC LIMIT ${limit ?? 50}`;
+
+      try {
+        const rows = await ctx.api.query(sql);
+        if (rows.length === 0) return errorResult("No summaries found.");
+        const lines = rows.map(r => {
+          const path = String(r["path"] ?? "?");
+          const desc = String(r["description"] ?? "");
+          const project = String(r["project"] ?? "");
+          const date = String(r["last_update_date"] ?? "");
+          return `${path}\t${date}\t${project}\t${desc}`;
+        });
+        return { content: [{ type: "text", text: `path\tlast_updated\tproject\tdescription\n${lines.join("\n")}` }] };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorResult(`Index failed: ${msg}`);
+      }
+    },
+  );
+}

--- a/tests/shared/mcp-http-server.test.ts
+++ b/tests/shared/mcp-http-server.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the HTTP MCP server (src/mcp/http-server.ts).
+ *
+ * Focus: the contract that *we* own around the SDK transport — routing,
+ * auth gating, 401 discovery shape. We don't re-test the SDK's JSON-RPC
+ * machinery; that lives in @modelcontextprotocol/sdk.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { startHttpMcpServer } from "../../src/mcp/http-server.js";
+
+interface RunningServer {
+  baseUrl: string;
+  close: () => Promise<void>;
+}
+
+const AUTH_ISSUER = "https://auth-test.example.com/";
+
+/** Boot the server on a fresh OS-assigned port so tests don't collide. */
+async function boot(): Promise<RunningServer> {
+  const { port, close } = await startHttpMcpServer({
+    port: 0, // OS-assigned
+    host: "127.0.0.1",
+    authIssuer: AUTH_ISSUER,
+    apiUrl: "https://api.test.invalid",
+    silent: true,
+  });
+  return { baseUrl: `http://127.0.0.1:${port}`, close };
+}
+
+describe("HTTP MCP server", () => {
+  let running: RunningServer;
+
+  beforeEach(async () => {
+    running = await boot();
+  });
+
+  afterEach(async () => {
+    await running.close();
+  });
+
+  it("responds 200 on /health with status + version", async () => {
+    const resp = await fetch(`${running.baseUrl}/health`);
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { status: string; version: string };
+    expect(body.status).toBe("ok");
+    expect(typeof body.version).toBe("string");
+    expect(body.version.length).toBeGreaterThan(0);
+  });
+
+  it("returns 401 + WWW-Authenticate on POST /mcp without Bearer token", async () => {
+    const resp = await fetch(`${running.baseUrl}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1, params: {} }),
+    });
+    expect(resp.status).toBe(401);
+
+    const wwwAuth = resp.headers.get("www-authenticate");
+    expect(wwwAuth).toBeTruthy();
+    // ChatGPT reads realm/auth_server from this header to discover where to
+    // send the user to sign in. The presence of both fields and the issuer
+    // URL is the contract we ship — assert all three, not just status.
+    expect(wwwAuth).toContain(`realm="${AUTH_ISSUER}"`);
+    expect(wwwAuth).toContain("invalid_token");
+
+    const body = (await resp.json()) as { error: string; auth_server: string };
+    expect(body.error).toBe("invalid_token");
+    expect(body.auth_server).toBe(AUTH_ISSUER);
+  });
+
+  it("returns 401 (not 500) for malformed Authorization headers", async () => {
+    const resp = await fetch(`${running.baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "NotBearer something",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1, params: {} }),
+    });
+    expect(resp.status).toBe(401);
+    expect(resp.headers.get("www-authenticate")).toContain(`realm="${AUTH_ISSUER}"`);
+  });
+
+  it("returns 404 for unknown paths", async () => {
+    const resp = await fetch(`${running.baseUrl}/something-else`);
+    expect(resp.status).toBe(404);
+    const body = (await resp.json()) as { error: string };
+    expect(body.error).toBe("not_found");
+  });
+
+  it("does NOT leak the auth issuer to /health", async () => {
+    // Defense in depth: /health should be safe for unauthenticated probes
+    // (k8s liveness, etc.) and must not advertise auth metadata in headers
+    // or body, only the basic status payload.
+    const resp = await fetch(`${running.baseUrl}/health`);
+    expect(resp.headers.get("www-authenticate")).toBeNull();
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("auth_server");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the smallest possible HTTP wrapper around the existing 3 MCP tools so Hivemind can appear in the ChatGPT App Directory. The local stdio MCP server (used by Hermes/Cursor/Claude Code) is unchanged — this PR only adds a second transport reachable over the network.

- New shared `src/mcp/tools.ts` so stdio and HTTP transports register the **same** tool handlers (single source of truth). Tool annotations set: all 3 `readOnlyHint: true, openWorldHint: false, destructiveHint: false` — the #1 cited rejection cause in OpenAI's [App Submission Guidelines](https://developers.openai.com/apps-sdk/app-submission-guidelines).
- New `src/mcp/http-server.ts` using `StreamableHTTPServerTransport` from `@modelcontextprotocol/sdk` v1.29 — the transport Apps SDK actually negotiates.
- New `hivemind serve-mcp` CLI command for hosting in a container.
- New `deploy/mcp/{Dockerfile,k8s.yaml,README.md}` — starting templates for SRE.
- 5 unit tests in `tests/shared/mcp-http-server.test.ts`.

## Auth (no new auth code)

The user's Auth0 JWT arrives in `Authorization: Bearer …`. We don't validate it locally — `DeeplakeApi` forwards it to deeplake-api, which validates it via the existing `internal/auth/jwt.go`. Missing/malformed token → `401` with `WWW-Authenticate: Bearer realm="<auth0-issuer>"` so ChatGPT discovers where to send the user to sign in. The auth flow that ChatGPT runs is the standard Auth0 Universal Login — the same screen deeplake.ai users already see today.

## Org resolution

`HIVEMIND_MCP_ORG_ID` + `HIVEMIND_MCP_WORKSPACE` + `HIVEMIND_MCP_TABLE` + `HIVEMIND_MCP_SESSIONS_TABLE` pin the org/workspace/tables at boot. Needed for the activeloop deployment because `GET /organizations` returns 34 orgs in unstable order — auto-picking the first org defaulted to a test org during the smoke. Multi-tenant auto-resolution (picking the user's *primary* org reliably) is a follow-up.

If none of the env pins are set, the server falls back to "first org from `GET /organizations`" + `workspaceId=\"default\"` + `memory`/`sessions` table names (matching the CLI defaults in `src/config.ts:55-58`).

## Verification

```sh
$ npx vitest run tests/shared/mcp-http-server.test.ts
✓ Test Files  1 passed (1)
✓      Tests  5 passed (5)

$ docker build -f deploy/mcp/Dockerfile -t hivemind-mcp:smoke .
# ✓ image builds (~150 MB Alpine, runs as non-root uid 10001)

$ docker run --rm -p 18787:8787 \
    -e HIVEMIND_MCP_AUTH_ISSUER=https://auth-beta.deeplake.ai/ \
    hivemind-mcp:smoke
$ curl http://127.0.0.1:18787/health
{\"status\":\"ok\",\"version\":\"0.7.67\"}
$ curl -i -X POST http://127.0.0.1:18787/mcp -H 'Content-Type: application/json' -d '{}'
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer realm=\"https://auth-beta.deeplake.ai/\", error=\"invalid_token\", ...
```

**End-to-end smoke against `api.deeplake.ai` production succeeded** using a real Auth0 token from `~/.deeplake/credentials.json` (org pinned to `activeloop` / workspace `hivemind` via env vars):

- `initialize` → session assigned, capabilities advertised
- `tools/list` → 3 tools with the read-only annotations
- `tools/call hivemind_index limit=3` → 3 real summaries from the activeloop/hivemind workspace
- `tools/call hivemind_search query=\"chatgpt\"` → 4 KB of real matching content

The full chain works: Bearer JWT → MCP HTTP transport → deeplake-api validation → memory query → tool result. No deeplake-api changes needed.

## Dockerfile caveat

Uses `npm install --ignore-scripts` as a workaround for an existing `package-lock.json` drift on origin/main (`pg@8.21` in package.json, `^8.11` in lockfile). Should switch back to `npm ci` (no `--ignore-scripts`) once the lockfile is regenerated in a separate cleanup PR.

## Not in this PR

- Deploy to a real public HTTPS URL — separate SRE handoff
- Auth0 dashboard client registration for ChatGPT — separate owner action
- OpenAI Platform Dashboard business verification + app draft + submission — separate owner action
- Multi-tenant org auto-resolution — follow-up if/when the env-var pinning model isn't enough

## Test plan

- [x] `npm test -- tests/shared/mcp-http-server.test.ts` (5/5)
- [x] `docker build` + `docker run` smoke
- [x] End-to-end against production deeplake-api with a real Auth0 token
- [ ] CI passes (note: tree-sitter type errors in `src/graph/extract/typescript.ts` are pre-existing on origin/main; not from this PR)
- [ ] Reviewer manual: `hivemind serve-mcp` boots, missing env yields a clear message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP MCP server supporting OAuth-based authentication, session management, and health checks
  * New `serve-mcp` CLI command for running the server

* **Documentation**
  * Comprehensive deployment guide including Docker containerization and Kubernetes manifests with ingress routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->