### PR TITLE
feat: integrate claude cowork via mcp connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  Auto-learning, cloud-backed shared brain for <b>Claude Code • OpenClaw • Codex • Cursor • Hermes • pi</b> agents.<br>
+  Auto-learning, cloud-backed shared brain for <b>Claude Code • OpenClaw • Codex • Cursor • Hermes • pi • Claude Cowork (Alpha)</b> agents.<br>
 </p>
 
 <p align="center">
@@ -90,6 +90,7 @@ hivemind claw install
 hivemind cursor install
 hivemind hermes install
 hivemind pi install
+hivemind claude_cowork install   # Alpha
 ```
 
 **Check what's wired up:**
@@ -108,6 +109,9 @@ hivemind status
 | **Cursor**       | Hooks (`hooks.json` 1.7+)                        | ✅           | ✅          |
 | **Hermes Agent** | Shell hooks (`config.yaml`) + skill + MCP server | ✅           | ✅          |
 | **pi**           | Extension API (`pi.on(...)`) + skill + AGENTS.md | ✅           | ✅          |
+| **Claude Cowork** 🅰️ | MCP server (Claude Desktop)                  | 🅰️ Alpha¹    | ✅          |
+
+🅰️ **Claude Cowork is Alpha.** Auto-recall (the `hivemind_search` / `read` / `index` tools) is solid. ¹Auto-capture covers **Local Agent Mode** sessions only — those write a transcript we can tail; plain desktop-chat turns leave no readable local trace and aren't captured ([why](#claude-cowork-alpha)).
 
 ### Alternative install paths
 
@@ -230,6 +234,21 @@ hivemind pi install
 Note: no per-agent SKILL.md is dropped under `~/.pi/agent/skills/`; pi reads skills from both that directory AND the shared `~/.agents/skills/` location. If the codex installer has run on the same machine, pi picks up the hivemind skill from the shared `~/.agents/skills/hivemind-memory` symlink automatically. The AGENTS.md block plus the registered tools cover the action surface in either case.
 </details>
 
+### Claude Cowork (Alpha)
+
+[Claude Cowork](https://support.claude.com/en/articles/11503834) is Anthropic's agentic assistant inside the Claude Desktop app. It has **no hook lifecycle** like the other agents — it only talks to Hivemind through MCP — so the integration works differently and ships as **Alpha**.
+
+```bash
+hivemind claude_cowork install
+```
+
+This registers the shared MCP server (`~/.hivemind/mcp/server.js`) under `mcpServers.hivemind` in Claude Desktop's `claude_desktop_config.json`. **Fully quit and reopen Claude Desktop** to load it.
+
+**Recall (stable).** Cowork gains `hivemind_search`, `hivemind_read`, and `hivemind_index` — the same shared memory every other agent reads. On the first tool use per host, a one-time data-collection notice is prepended to the result.
+
+**Auto-capture (Alpha) — how it works.** With no SessionStart/Stop hooks to capture from, the MCP server runs a background ingester that **tails Cowork's Local Agent Mode transcripts** (`~/Library/Application Support/Claude/local-agent-mode-sessions/**/.claude/projects/<enc>/<sessionId>.jsonl`). For each new line it writes a row to the `sessions` table with `agent="claude_cowork"` (user prompts, assistant messages, tool calls + results), de-duplicated by a per-transcript line watermark. When a transcript has been idle for 5 minutes it is treated as finished, and the same wiki-worker / skillify workers every other agent uses run for it (summary tagged `claude_cowork` → it shows up in `hivemind_index`).
+
+**Known limitation.** <a id="claude-cowork-alpha"></a>Only **Local Agent Mode** sessions (where Cowork opens its sandbox/agent and *works*) write a transcript we can read. Plain **desktop-chat** turns are not captured: by MCP design a server never sees the conversation (only the tool calls the model makes), and the chat itself lives in Anthropic's cloud + a compressed claude.ai IndexedDB cache with no supported read surface. Capturing those would need an official Anthropic export/hook.
 
 ### Uninstall
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -506,12 +506,25 @@ chmodSync("harnesses/openclaw/dist/skillify-worker.js", 0o755);
 // Hivemind MCP server (stdio). Reused by Cline / Roo / Kilo / any MCP-aware
 // agent. Lives at ~/.hivemind/mcp/server.js after install.
 await build({
-  // wiki-worker + skillify-worker ship alongside the server so the Cowork
-  // ingester can spawn them for idle Cowork sessions (Cowork has no SessionEnd
-  // hook). install copies the whole mcp/bundle dir, so adding the entries is
-  // enough to deliver them at ~/.hivemind/mcp/.
+  entryPoints: { server: "dist/src/mcp/server.js" },
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  outdir: "mcp/bundle",
+  external: ["node:*", "node-liblzma", "@mongodb-js/zstd"],
+  // server.js source has no shebang, so the banner supplies one.
+  banner: { js: "#!/usr/bin/env node" },
+});
+chmodSync("mcp/bundle/server.js", 0o755);
+
+// wiki-worker + skillify-worker ship alongside the server so the Cowork
+// ingester can spawn them for idle Cowork sessions (Cowork has no SessionEnd
+// hook). install copies the whole mcp/bundle dir, so shipping them here is
+// enough to deliver them at ~/.hivemind/mcp/. NO banner: these sources already
+// start with their own `#!/usr/bin/env node`, and a banner would double it
+// (a second shebang on line 2 is a SyntaxError).
+await build({
   entryPoints: {
-    server: "dist/src/mcp/server.js",
     "wiki-worker": "dist/src/hooks/wiki-worker.js",
     "skillify-worker": "dist/src/skillify/skillify-worker.js",
   },
@@ -520,9 +533,7 @@ await build({
   format: "esm",
   outdir: "mcp/bundle",
   external: ["node:*", "node-liblzma", "@mongodb-js/zstd"],
-  banner: { js: "#!/usr/bin/env node" },
 });
-chmodSync("mcp/bundle/server.js", 0o755);
 chmodSync("mcp/bundle/wiki-worker.js", 0o755);
 chmodSync("mcp/bundle/skillify-worker.js", 0o755);
 writeFileSync("mcp/bundle/package.json", esmPackageJson);

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -506,10 +506,15 @@ chmodSync("harnesses/openclaw/dist/skillify-worker.js", 0o755);
 // Hivemind MCP server (stdio). Reused by Cline / Roo / Kilo / any MCP-aware
 // agent. Lives at ~/.hivemind/mcp/server.js after install.
 await build({
-  // wiki-worker ships alongside the server so the Cowork ingester can spawn it
-  // to summarize idle Cowork sessions (Cowork has no SessionEnd hook). install
-  // copies the whole mcp/bundle dir, so adding the entry is enough to deliver it.
-  entryPoints: { server: "dist/src/mcp/server.js", "wiki-worker": "dist/src/hooks/wiki-worker.js" },
+  // wiki-worker + skillify-worker ship alongside the server so the Cowork
+  // ingester can spawn them for idle Cowork sessions (Cowork has no SessionEnd
+  // hook). install copies the whole mcp/bundle dir, so adding the entries is
+  // enough to deliver them at ~/.hivemind/mcp/.
+  entryPoints: {
+    server: "dist/src/mcp/server.js",
+    "wiki-worker": "dist/src/hooks/wiki-worker.js",
+    "skillify-worker": "dist/src/skillify/skillify-worker.js",
+  },
   bundle: true,
   platform: "node",
   format: "esm",
@@ -519,6 +524,7 @@ await build({
 });
 chmodSync("mcp/bundle/server.js", 0o755);
 chmodSync("mcp/bundle/wiki-worker.js", 0o755);
+chmodSync("mcp/bundle/skillify-worker.js", 0o755);
 writeFileSync("mcp/bundle/package.json", esmPackageJson);
 
 // Unified CLI (`npx hivemind install` … single entrypoint for all assistants)

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -506,7 +506,10 @@ chmodSync("harnesses/openclaw/dist/skillify-worker.js", 0o755);
 // Hivemind MCP server (stdio). Reused by Cline / Roo / Kilo / any MCP-aware
 // agent. Lives at ~/.hivemind/mcp/server.js after install.
 await build({
-  entryPoints: { server: "dist/src/mcp/server.js" },
+  // wiki-worker ships alongside the server so the Cowork ingester can spawn it
+  // to summarize idle Cowork sessions (Cowork has no SessionEnd hook). install
+  // copies the whole mcp/bundle dir, so adding the entry is enough to deliver it.
+  entryPoints: { server: "dist/src/mcp/server.js", "wiki-worker": "dist/src/hooks/wiki-worker.js" },
   bundle: true,
   platform: "node",
   format: "esm",
@@ -515,6 +518,7 @@ await build({
   banner: { js: "#!/usr/bin/env node" },
 });
 chmodSync("mcp/bundle/server.js", 0o755);
+chmodSync("mcp/bundle/wiki-worker.js", 0o755);
 writeFileSync("mcp/bundle/package.json", esmPackageJson);
 
 // Unified CLI (`npx hivemind install` … single entrypoint for all assistants)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { installCodex, uninstallCodex } from "./install-codex.js";
 import { installOpenclaw, uninstallOpenclaw } from "./install-openclaw.js";
 import { installCursor, uninstallCursor } from "./install-cursor.js";
 import { installHermes, uninstallHermes } from "./install-hermes.js";
+import { installCowork, uninstallCowork } from "./install-cowork.js";
 import { installPi, uninstallPi } from "./install-pi.js";
 import {
   disableEmbeddings,
@@ -65,6 +66,7 @@ Usage:
   hivemind claw    install | uninstall
   hivemind cursor  install | uninstall
   hivemind hermes  install | uninstall
+  hivemind claude_cowork install | uninstall
   hivemind pi      install | uninstall
       Install or remove hivemind for a specific assistant.
 
@@ -366,7 +368,7 @@ async function runInstallAll(args: string[]): Promise<void> {
 
   if (targets.length === 0) {
     log("No supported assistants detected.");
-    log("Supported: Claude Code, Codex, OpenClaw, Cursor, Hermes Agent.");
+    log("Supported: Claude Code, Codex, OpenClaw, Cursor, Hermes Agent, Claude Cowork.");
     log("Install one and rerun `hivemind install`, or target a specific assistant: `hivemind cursor install`.");
     return;
   }
@@ -410,6 +412,7 @@ function runSingleInstall(id: PlatformId): void {
     else if (id === "cursor") installCursor();
     else if (id === "hermes") installHermes();
     else if (id === "pi") installPi();
+    else if (id === "claude_cowork") installCowork();
   } catch (err) {
     warn(`  ${id.padEnd(14)} FAILED: ${(err as Error).message}`);
   }
@@ -423,6 +426,7 @@ function runSingleUninstall(id: PlatformId): void {
     else if (id === "cursor") uninstallCursor();
     else if (id === "hermes") uninstallHermes();
     else if (id === "pi") uninstallPi();
+    else if (id === "claude_cowork") uninstallCowork();
   } catch (err) {
     warn(`  ${id.padEnd(14)} FAILED: ${(err as Error).message}`);
   }
@@ -541,7 +545,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const platformCmds: PlatformId[] = ["claude", "codex", "claw", "cursor", "hermes", "pi"];
+  const platformCmds: PlatformId[] = ["claude", "codex", "claw", "cursor", "hermes", "pi", "claude_cowork"];
   if (platformCmds.includes(cmd as PlatformId)) {
     const sub = args[1];
     if (sub === "install") {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -368,7 +368,7 @@ async function runInstallAll(args: string[]): Promise<void> {
 
   if (targets.length === 0) {
     log("No supported assistants detected.");
-    log("Supported: Claude Code, Codex, OpenClaw, Cursor, Hermes Agent, Claude Cowork.");
+    log("Supported: Claude Code, Codex, OpenClaw, Cursor, Hermes Agent, Pi, Claude Cowork.");
     log("Install one and rerun `hivemind install`, or target a specific assistant: `hivemind cursor install`.");
     return;
   }

--- a/src/cli/install-cowork.ts
+++ b/src/cli/install-cowork.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { claudeDesktopConfigDir, ensureDir, log } from "./util.js";
+import { ensureMcpServerInstalled, buildMcpServerEntry } from "./install-mcp-shared.js";
+
+// Claude Cowork integration.
+//
+// Cowork is Anthropic's agentic desktop assistant, hosted inside the
+// Claude Desktop app. It reads MCP connectors from the SAME file as
+// Claude Desktop chat — claude_desktop_config.json, `mcpServers` key
+// (https://support.claude.com/en/articles/11503834). Local stdio servers
+// are supported, so we register the shared hivemind MCP server (the one
+// already installed at ~/.hivemind/mcp/server.js) and Cowork gains the
+// hivemind_search / read / index tools with zero manual setup.
+//
+// Note: this is the Claude DESKTOP config dir, NOT ~/.claude (that's the
+// Claude Code CLI, handled by install-claude.ts).
+
+const CONFIG_DIR = claudeDesktopConfigDir();
+const CONFIG_PATH = join(CONFIG_DIR, "claude_desktop_config.json");
+const SERVER_KEY = "hivemind";
+
+type Config = Record<string, unknown>;
+
+function readConfig(): Config {
+  if (!existsSync(CONFIG_PATH)) return {};
+  const txt = readFileSync(CONFIG_PATH, "utf-8").trim();
+  if (!txt) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(txt);
+  } catch {
+    // Malformed config — never clobber the user's file. Surface it so they
+    // can fix it rather than silently overwriting hand-edited connectors.
+    throw new Error(
+      `claude_desktop_config.json at ${CONFIG_PATH} is not valid JSON. Fix or remove it, then rerun.`,
+    );
+  }
+  return parsed && typeof parsed === "object" ? (parsed as Config) : {};
+}
+
+function writeConfig(cfg: Config): void {
+  ensureDir(CONFIG_DIR);
+  writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
+}
+
+export function installCowork(): void {
+  // 1. Shared stdio MCP server binary at ~/.hivemind/mcp/server.js.
+  ensureMcpServerInstalled();
+
+  // 2. Register it in Claude Desktop's connector config (shared by Cowork).
+  //    Non-destructive merge: preserve any servers the user already added.
+  const cfg = readConfig();
+  const servers =
+    cfg.mcpServers && typeof cfg.mcpServers === "object"
+      ? (cfg.mcpServers as Record<string, unknown>)
+      : {};
+  servers[SERVER_KEY] = buildMcpServerEntry();
+  cfg.mcpServers = servers;
+  writeConfig(cfg);
+  log(`  Claude Cowork  config updated -> ${CONFIG_PATH} (mcpServers.${SERVER_KEY})`);
+}
+
+export function uninstallCowork(): void {
+  if (!existsSync(CONFIG_PATH)) return;
+  let cfg: Config;
+  try {
+    cfg = readConfig();
+  } catch {
+    // Malformed file — leave it alone rather than fail the uninstall.
+    return;
+  }
+  const servers = cfg.mcpServers;
+  if (!servers || typeof servers !== "object" || !(SERVER_KEY in servers)) return;
+
+  delete (servers as Record<string, unknown>)[SERVER_KEY];
+  if (Object.keys(servers as Record<string, unknown>).length === 0) delete cfg.mcpServers;
+
+  if (Object.keys(cfg).length === 0) {
+    unlinkSync(CONFIG_PATH);
+  } else {
+    writeConfig(cfg);
+  }
+  log(`  Claude Cowork  hivemind entry removed from ${CONFIG_PATH}`);
+}

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -93,11 +93,21 @@ export function readVersionStamp(dir: string): string | null {
   try { return readFileSync(p, "utf-8").trim(); } catch { return null; }
 }
 
-export type PlatformId = "claude" | "codex" | "claw" | "cursor" | "hermes" | "pi";
+export type PlatformId = "claude" | "codex" | "claw" | "cursor" | "hermes" | "pi" | "claude_cowork";
 
 export interface DetectedPlatform {
   id: PlatformId;
   markerDir: string;
+}
+
+// Claude Desktop — host app for Claude Cowork — stores its connector config
+// in an OS-specific application-support dir, NOT in ~/.claude (that's the
+// Claude Code CLI). Cowork reads MCP servers from claude_desktop_config.json
+// inside this dir, shared with Claude Desktop chat.
+export function claudeDesktopConfigDir(): string {
+  if (process.platform === "darwin") return join(HOME, "Library", "Application Support", "Claude");
+  if (process.platform === "win32") return join(process.env.APPDATA ?? join(HOME, "AppData", "Roaming"), "Claude");
+  return join(HOME, ".config", "Claude");
 }
 
 // Hivemind's value is bidirectional shared memory — every supported agent
@@ -117,6 +127,11 @@ const PLATFORM_MARKERS: DetectedPlatform[] = [
   // a rich extension event API (session_start / input / tool_call /
   // tool_result / message_end / session_shutdown / etc.) — Tier 1 capable.
   { id: "pi", markerDir: join(HOME, ".pi") },
+  // claude_cowork — Anthropic's agentic desktop assistant, hosted in the
+  // Claude Desktop app. Registers the shared hivemind MCP server into
+  // claude_desktop_config.json (recall-only; capture is the desktop app's
+  // own concern). Marker is the OS-specific Claude Desktop config dir.
+  { id: "claude_cowork", markerDir: claudeDesktopConfigDir() },
 ];
 
 export function detectPlatforms(): DetectedPlatform[] {

--- a/src/hooks/session-queue.ts
+++ b/src/hooks/session-queue.ts
@@ -128,7 +128,12 @@ export function buildSessionInsertSql(sessionsTable: string, rows: QueuedSession
   if (rows.length === 0) throw new Error("buildSessionInsertSql: rows must not be empty");
   const table = sqlIdent(sessionsTable);
   const values = rows.map((row) => {
-    const jsonForSql = sqlStr(coerceJsonbPayload(row.message));
+    // Escape ONLY single quotes for the SQL literal. The payload is already
+    // valid JSON and Postgres (standard_conforming_strings) treats backslashes
+    // literally, so sqlStr()'s backslash-doubling and control-char stripping
+    // would corrupt the JSON and the jsonb cast would 400. Mirrors the
+    // capture.ts direct-INSERT path.
+    const jsonForSql = coerceJsonbPayload(row.message).replace(/'/g, "''");
     return (
       `('${sqlStr(row.id)}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', '${jsonForSql}'::jsonb, ` +
       `'${sqlStr(row.author)}', ${row.sizeBytes}, '${sqlStr(row.project)}', '${sqlStr(row.description)}', ` +

--- a/src/hooks/spawn-wiki-worker.ts
+++ b/src/hooks/spawn-wiki-worker.ts
@@ -89,6 +89,8 @@ export interface SpawnOptions {
   cwd: string;
   bundleDir: string;
   reason: string;
+  /** Value written to the summary's `agent` column. Defaults to "claude_code". */
+  agent?: string;
 }
 
 export function spawnWikiWorker(opts: SpawnOptions): void {
@@ -111,6 +113,7 @@ export function spawnWikiWorker(opts: SpawnOptions): void {
     sessionId,
     userName: config.userName,
     project: projectName,
+    agent: opts.agent ?? "claude_code",
     pluginVersion,
     tmpDir,
     claudeBin: findClaudeBin(),

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -31,6 +31,7 @@ interface WorkerConfig {
   sessionId: string;
   userName: string;
   project: string;
+  agent?: string;
   pluginVersion?: string;
   tmpDir: string;
   claudeBin: string;
@@ -243,7 +244,7 @@ async function main(): Promise<void> {
           vpath, fname,
           userName: cfg.userName,
           project: cfg.project,
-          agent: "claude_code",
+          agent: cfg.agent ?? "claude_code",
           sessionId: cfg.sessionId,
           text,
           embedding,

--- a/src/mcp/cowork-ingest.ts
+++ b/src/mcp/cowork-ingest.ts
@@ -28,6 +28,7 @@ import {
   readdirSync,
   rmSync,
   statSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -59,6 +60,9 @@ const LOCK_PATH = join(DEEPLAKE_DIR, ".cowork-ingest.lock");
 const COWORK_QUEUE_DIR = join(DEEPLAKE_DIR, "queue-cowork");
 const NOTICE_MARKER = join(DEEPLAKE_DIR, ".cowork-data-notice-shown");
 const LOCK_STALE_MS = 60_000;
+// Refresh the held lock's mtime well inside LOCK_STALE_MS so a long ingest is
+// never mistaken for a dead run and stolen mid-flight by a second process.
+const LOCK_HEARTBEAT_MS = 20_000;
 // A Cowork transcript untouched for this long is treated as a finished session
 // and gets a summary (Cowork has no SessionEnd hook to signal completion).
 const SUMMARY_IDLE_MS = 5 * 60_000;
@@ -246,7 +250,24 @@ function tryAcquireLock(): (() => void) | null {
     try {
       const fd = openSync(LOCK_PATH, "wx");
       closeSync(fd);
-      return () => rmSync(LOCK_PATH, { force: true });
+      // Heartbeat the lock mtime so a run that outlives LOCK_STALE_MS (many
+      // transcripts / slow upload) is not seen as abandoned and stolen by a
+      // second Cowork process — which would replay the same transcripts and
+      // duplicate session rows. Cleared on release; unref'd so it never keeps
+      // the process alive on its own.
+      const heartbeat = setInterval(() => {
+        try {
+          const t = new Date();
+          utimesSync(LOCK_PATH, t, t);
+        } catch {
+          /* lock vanished — nothing to refresh */
+        }
+      }, LOCK_HEARTBEAT_MS);
+      heartbeat.unref?.();
+      return () => {
+        clearInterval(heartbeat);
+        rmSync(LOCK_PATH, { force: true });
+      };
     } catch (e: unknown) {
       if ((e as { code?: string }).code !== "EEXIST") return null;
       try {
@@ -395,6 +416,11 @@ export async function ingestCoworkSessions(): Promise<{ ingested: number } | { s
         sessionsTable: config.sessionsTableName,
         queueDir: COWORK_QUEUE_DIR,
       });
+      // Persist the line watermark immediately after the upload, before the
+      // slow summarize step below. Rows carry random ids, so a crash between
+      // the insert and a later saveState would replay these lines under fresh
+      // ids and duplicate them. Saving here shrinks that window to this write.
+      saveState(state);
     }
 
     // Summarize sessions that have gone idle — Cowork has no SessionEnd hook,

--- a/src/mcp/cowork-ingest.ts
+++ b/src/mcp/cowork-ingest.ts
@@ -79,9 +79,16 @@ export function coworkDataNoticeOnce(): string {
   try {
     if (process.env.HIVEMIND_CAPTURE === "false") return "";
     if (!existsSync(coworkSessionsRoot())) return ""; // not a Cowork host → nothing captured
-    if (existsSync(NOTICE_MARKER)) return "";
     mkdirSync(DEEPLAKE_DIR, { recursive: true });
-    writeFileSync(NOTICE_MARKER, new Date().toISOString());
+    // Atomic create-exclusive: the first caller to win the `wx` open writes the
+    // marker and returns the notice; a racing Cowork process gets EEXIST and
+    // returns "". Replaces a check-then-write (existsSync + writeFileSync) that
+    // CodeQL flagged as a file-system race (js/file-system-race).
+    try {
+      writeFileSync(NOTICE_MARKER, new Date().toISOString(), { flag: "wx" });
+    } catch {
+      return ""; // marker already present (or unwritable) → notice already shown
+    }
     return `${DATA_NOTICE}\n\n`;
   } catch {
     return "";
@@ -129,7 +136,9 @@ function findTranscripts(root: string): string[] {
         walk(full);
       } else if (
         name.endsWith(".jsonl") &&
-        full.includes("/.claude/projects/") &&
+        // Separator-agnostic so Windows transcript paths (\\.claude\\projects\\)
+        // match too — otherwise ingest is a silent no-op on Windows hosts.
+        /[\\/]\.claude[\\/]projects[\\/]/.test(full) &&
         /^[0-9a-f-]{36}\.jsonl$/i.test(name)
       ) {
         out.push(full);

--- a/src/mcp/cowork-ingest.ts
+++ b/src/mcp/cowork-ingest.ts
@@ -44,6 +44,7 @@ import {
   drainSessionQueues,
 } from "../hooks/session-queue.js";
 import { spawnWikiWorker, bundleDirFromImportMeta } from "../hooks/spawn-wiki-worker.js";
+import { forceSessionEndTrigger } from "../skillify/triggers.js";
 import { basename } from "node:path";
 import { log } from "../utils/debug.js";
 
@@ -270,17 +271,23 @@ export function summarizeIdleSessions(
   now: number = Date.now(),
 ): void {
   const bundleDir = bundleDirFromImportMeta(import.meta.url);
+  // Default end-of-session work for a Cowork session: a wiki summary (so it
+  // shows up in hivemind_index) AND a skillify mining pass — exactly what the
+  // claude_code SessionEnd hook does. Each is independent and best-effort.
   const doSpawn: SpawnSummaryFn =
     spawn ??
-    ((sessionId) =>
-      spawnWikiWorker({
-        config,
-        sessionId,
-        cwd: `/${COWORK_PROJECT}`,
-        bundleDir,
-        reason: "CoworkIdle",
-        agent: COWORK_AGENT,
-      }));
+    ((sessionId) => {
+      try {
+        spawnWikiWorker({ config, sessionId, cwd: `/${COWORK_PROJECT}`, bundleDir, reason: "CoworkIdle", agent: COWORK_AGENT });
+      } catch (e: unknown) {
+        log("cowork-ingest", `summary spawn skipped for ${sessionId}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+      try {
+        forceSessionEndTrigger({ config, cwd: `/${COWORK_PROJECT}`, bundleDir, agent: COWORK_AGENT, sessionId });
+      } catch (e: unknown) {
+        log("cowork-ingest", `skillify trigger skipped for ${sessionId}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    });
   state.summarizedLines ??= {};
 
   for (const path of Object.keys(state.processedLines)) {
@@ -298,9 +305,9 @@ export function summarizeIdleSessions(
     try {
       doSpawn(sessionId);
       state.summarizedLines[path] = processed;
-      log("cowork-ingest", `spawned summary worker for idle Cowork session ${sessionId}`);
+      log("cowork-ingest", `ran end-of-session work (summary + skillify) for idle Cowork session ${sessionId}`);
     } catch (e: unknown) {
-      log("cowork-ingest", `summary spawn skipped for ${sessionId}: ${e instanceof Error ? e.message : String(e)}`);
+      log("cowork-ingest", `idle-session work failed for ${sessionId}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 }

--- a/src/mcp/cowork-ingest.ts
+++ b/src/mcp/cowork-ingest.ts
@@ -1,0 +1,282 @@
+/**
+ * Cowork session ingester.
+ *
+ * Claude Cowork (Anthropic's desktop Local Agent Mode) has no hook lifecycle
+ * like Claude Code — it only talks to us through the MCP server, and that
+ * channel is read-only (search/read/index). So Cowork conversations would
+ * never land in Deeplake on their own.
+ *
+ * Cowork's Local Agent Mode runs a real Claude Code instance under the hood
+ * and writes standard Claude-Code transcript JSONL to:
+ *   <claudeDesktopConfigDir>/local-agent-mode-sessions/**​/.claude/projects/<enc>/<sessionId>.jsonl
+ *
+ * This module tails those transcripts and writes each new user/assistant
+ * message into the shared `sessions` table with agent = "claude_cowork",
+ * so Cowork sessions become first-class shared memory like every other agent.
+ *
+ * It runs piggy-backed on the MCP server (which is spawned in every Cowork
+ * session), so no extra install step is needed. A per-transcript line
+ * watermark prevents re-ingesting old events; a lock file prevents the
+ * several concurrent MCP processes Cowork spawns from double-inserting.
+ */
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { loadCredentials } from "../commands/auth.js";
+import { loadConfig } from "../config.js";
+import { DeeplakeApi } from "../deeplake-api.js";
+import { claudeDesktopConfigDir } from "../cli/util.js";
+import { getVersion } from "../cli/version.js";
+import {
+  appendQueuedSessionRow,
+  buildQueuedSessionRow,
+  buildSessionPath,
+  drainSessionQueues,
+} from "../hooks/session-queue.js";
+import { log } from "../utils/debug.js";
+
+/** Value written to the `agent` column for Cowork-originated rows. */
+export const COWORK_AGENT = "claude_cowork";
+/** `project` column value — lets Cowork rows be filtered without a JSON dig. */
+const COWORK_PROJECT = "claude_cowork";
+
+const DEEPLAKE_DIR = join(homedir(), ".deeplake");
+const STATE_PATH = join(DEEPLAKE_DIR, "cowork-ingest-state.json");
+const LOCK_PATH = join(DEEPLAKE_DIR, ".cowork-ingest.lock");
+const COWORK_QUEUE_DIR = join(DEEPLAKE_DIR, "queue-cowork");
+const LOCK_STALE_MS = 60_000;
+
+interface IngestState {
+  /** transcript absolute path → number of lines already ingested. */
+  processedLines: Record<string, number>;
+}
+
+export interface TranscriptLine {
+  type?: string;
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  message?: { role?: string; content?: unknown };
+}
+
+function coworkSessionsRoot(): string {
+  return join(claudeDesktopConfigDir(), "local-agent-mode-sessions");
+}
+
+/** Recursively collect Claude-Code transcript JSONL files under a dir. */
+function findTranscripts(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      const full = join(dir, name);
+      let isDir = false;
+      try {
+        isDir = statSync(full).isDirectory();
+      } catch {
+        continue;
+      }
+      if (isDir) {
+        walk(full);
+      } else if (
+        name.endsWith(".jsonl") &&
+        full.includes("/.claude/projects/") &&
+        /^[0-9a-f-]{36}\.jsonl$/i.test(name)
+      ) {
+        out.push(full);
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+function loadState(): IngestState {
+  try {
+    const raw = JSON.parse(readFileSync(STATE_PATH, "utf-8"));
+    if (raw && typeof raw === "object" && raw.processedLines) return raw as IngestState;
+  } catch {
+    /* fresh state */
+  }
+  return { processedLines: {} };
+}
+
+function saveState(state: IngestState): void {
+  mkdirSync(DEEPLAKE_DIR, { recursive: true });
+  writeFileSync(STATE_PATH, JSON.stringify(state));
+}
+
+/** Flatten a Claude-Code message content into plain text. */
+export function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (block && typeof block === "object" && (block as { type?: string }).type === "text") {
+          return String((block as { text?: string }).text ?? "");
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+/** Map one transcript line to a sessions-table message entry, or null to skip. */
+export function entryForLine(line: TranscriptLine): Record<string, unknown> | null {
+  if (!line.sessionId) return null;
+  const ts = line.timestamp ?? new Date().toISOString();
+  const base = { session_id: line.sessionId, timestamp: ts, cwd: line.cwd, agent: COWORK_AGENT };
+
+  if (line.type === "user") {
+    const content = extractText(line.message?.content);
+    if (!content.trim()) return null;
+    return { id: crypto.randomUUID(), ...base, type: "user_message", content };
+  }
+  if (line.type === "assistant") {
+    const content = extractText(line.message?.content);
+    if (!content.trim()) return null; // pure thinking / tool_use turns carry no message
+    return { id: crypto.randomUUID(), ...base, type: "assistant_message", content };
+  }
+  return null;
+}
+
+function tryAcquireLock(): (() => void) | null {
+  mkdirSync(DEEPLAKE_DIR, { recursive: true });
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = openSync(LOCK_PATH, "wx");
+      closeSync(fd);
+      return () => rmSync(LOCK_PATH, { force: true });
+    } catch (e: unknown) {
+      if ((e as { code?: string }).code !== "EEXIST") return null;
+      try {
+        if (Date.now() - statSync(LOCK_PATH).mtimeMs >= LOCK_STALE_MS) {
+          rmSync(LOCK_PATH, { force: true });
+          continue;
+        }
+      } catch {
+        /* lock vanished — retry */
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Tail Cowork transcripts and write new messages to the sessions table.
+ * Safe to call repeatedly; never throws and never writes to stdout (which
+ * would corrupt the MCP stdio channel).
+ */
+export async function ingestCoworkSessions(): Promise<{ ingested: number } | { skipped: string }> {
+  if (process.env.HIVEMIND_CAPTURE === "false") return { skipped: "capture-disabled" };
+
+  const root = coworkSessionsRoot();
+  if (!existsSync(root)) return { skipped: "no-cowork-sessions" };
+
+  const creds = loadCredentials();
+  if (!creds?.token) return { skipped: "not-authenticated" };
+  const config = loadConfig();
+  if (!config) return { skipped: "no-config" };
+
+  const release = tryAcquireLock();
+  if (!release) return { skipped: "busy" };
+
+  let ingested = 0;
+  try {
+    const state = loadState();
+    const transcripts = findTranscripts(root);
+    let appendedAny = false;
+
+    for (const path of transcripts) {
+      let lines: string[];
+      try {
+        lines = readFileSync(path, "utf-8").split("\n").filter(Boolean);
+      } catch {
+        continue;
+      }
+      const already = state.processedLines[path] ?? 0;
+      if (lines.length <= already) continue;
+
+      for (const raw of lines.slice(already)) {
+        let parsed: TranscriptLine;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          continue;
+        }
+        const entry = entryForLine(parsed);
+        if (!entry) continue;
+
+        const serialized = JSON.stringify(entry);
+        const row = buildQueuedSessionRow({
+          sessionPath: buildSessionPath(config, String(entry.session_id)),
+          line: serialized,
+          userName: config.userName,
+          projectName: COWORK_PROJECT,
+          description: String(entry.type ?? ""),
+          agent: COWORK_AGENT,
+          pluginVersion: getVersion(),
+          timestamp: String(entry.timestamp),
+        });
+        appendQueuedSessionRow(row, COWORK_QUEUE_DIR);
+        appendedAny = true;
+        ingested += 1;
+      }
+      state.processedLines[path] = lines.length;
+    }
+
+    saveState(state);
+
+    if (appendedAny) {
+      const api = new DeeplakeApi(
+        config.token,
+        config.apiUrl,
+        config.orgId,
+        config.workspaceId,
+        config.sessionsTableName,
+      );
+      await drainSessionQueues(api, {
+        sessionsTable: config.sessionsTableName,
+        queueDir: COWORK_QUEUE_DIR,
+      });
+    }
+
+    if (ingested > 0) log("cowork-ingest", `ingested ${ingested} message(s) from Cowork transcripts`);
+    return { ingested };
+  } catch (e: unknown) {
+    log("cowork-ingest", `error: ${e instanceof Error ? e.message : String(e)}`);
+    return { ingested };
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Start background ingestion: once on startup, then on an interval. The timer
+ * is unref'd so it never keeps the MCP process alive on its own.
+ */
+export function startCoworkIngestLoop(intervalMs = 30_000): void {
+  void ingestCoworkSessions();
+  const timer = setInterval(() => {
+    void ingestCoworkSessions();
+  }, intervalMs);
+  timer.unref?.();
+}

--- a/src/mcp/cowork-ingest.ts
+++ b/src/mcp/cowork-ingest.ts
@@ -54,7 +54,33 @@ const DEEPLAKE_DIR = join(homedir(), ".deeplake");
 const STATE_PATH = join(DEEPLAKE_DIR, "cowork-ingest-state.json");
 const LOCK_PATH = join(DEEPLAKE_DIR, ".cowork-ingest.lock");
 const COWORK_QUEUE_DIR = join(DEEPLAKE_DIR, "queue-cowork");
+const NOTICE_MARKER = join(DEEPLAKE_DIR, ".cowork-data-notice-shown");
 const LOCK_STALE_MS = 60_000;
+
+const DATA_NOTICE =
+  "ℹ️ Hivemind data notice: this Cowork session is being saved to your team's shared Deeplake memory " +
+  "(your prompts, the assistant's responses, and tool calls) so agents and teammates can recall it later. " +
+  "Everyone in your Deeplake workspace can read it. To turn capture off, set HIVEMIND_CAPTURE=false. " +
+  "(This notice is shown once.)";
+
+/**
+ * One-time consent/data notice for Cowork. Cowork has no SessionStart banner,
+ * so the only place we can surface this is the first hivemind tool result.
+ * Returns the notice text exactly once (guarded by a marker file), and only
+ * when Cowork capture is actually active; "" otherwise.
+ */
+export function coworkDataNoticeOnce(): string {
+  try {
+    if (process.env.HIVEMIND_CAPTURE === "false") return "";
+    if (!existsSync(coworkSessionsRoot())) return ""; // not a Cowork host → nothing captured
+    if (existsSync(NOTICE_MARKER)) return "";
+    mkdirSync(DEEPLAKE_DIR, { recursive: true });
+    writeFileSync(NOTICE_MARKER, new Date().toISOString());
+    return `${DATA_NOTICE}\n\n`;
+  } catch {
+    return "";
+  }
+}
 
 interface IngestState {
   /** transcript absolute path → number of lines already ingested. */
@@ -138,23 +164,63 @@ export function extractText(content: unknown): string {
   return "";
 }
 
-/** Map one transcript line to a sessions-table message entry, or null to skip. */
-export function entryForLine(line: TranscriptLine): Record<string, unknown> | null {
-  if (!line.sessionId) return null;
+function isBlock(b: unknown): b is { type?: string; [k: string]: unknown } {
+  return !!b && typeof b === "object";
+}
+
+/**
+ * Map one transcript line to zero or more sessions-table message entries.
+ * Captures user prompts, assistant text, assistant tool calls, and the
+ * matching tool results — parity with the claude_code capture hook.
+ */
+export function entriesForLine(line: TranscriptLine): Record<string, unknown>[] {
+  if (!line.sessionId) return [];
   const ts = line.timestamp ?? new Date().toISOString();
   const base = { session_id: line.sessionId, timestamp: ts, cwd: line.cwd, agent: COWORK_AGENT };
+  const content = line.message?.content;
+  const out: Record<string, unknown>[] = [];
 
   if (line.type === "user") {
-    const content = extractText(line.message?.content);
-    if (!content.trim()) return null;
-    return { id: crypto.randomUUID(), ...base, type: "user_message", content };
+    // Tool results come back as user lines carrying tool_result blocks.
+    if (Array.isArray(content)) {
+      for (const b of content) {
+        if (isBlock(b) && b.type === "tool_result") {
+          out.push({
+            id: crypto.randomUUID(),
+            ...base,
+            type: "tool_result",
+            tool_use_id: b.tool_use_id,
+            tool_response: JSON.stringify(b.content ?? null),
+          });
+        }
+      }
+    }
+    const text = extractText(content);
+    if (text.trim()) out.push({ id: crypto.randomUUID(), ...base, type: "user_message", content: text });
+    return out;
   }
+
   if (line.type === "assistant") {
-    const content = extractText(line.message?.content);
-    if (!content.trim()) return null; // pure thinking / tool_use turns carry no message
-    return { id: crypto.randomUUID(), ...base, type: "assistant_message", content };
+    const text = extractText(content);
+    if (text.trim()) out.push({ id: crypto.randomUUID(), ...base, type: "assistant_message", content: text });
+    if (Array.isArray(content)) {
+      for (const b of content) {
+        if (isBlock(b) && b.type === "tool_use") {
+          out.push({
+            id: crypto.randomUUID(),
+            ...base,
+            type: "tool_call",
+            tool_name: b.name,
+            tool_use_id: b.id,
+            tool_input: JSON.stringify(b.input ?? null),
+          });
+        }
+      }
+    }
+    return out;
   }
-  return null;
+
+  return out;
 }
 
 function tryAcquireLock(): (() => void) | null {
@@ -222,23 +288,22 @@ export async function ingestCoworkSessions(): Promise<{ ingested: number } | { s
         } catch {
           continue;
         }
-        const entry = entryForLine(parsed);
-        if (!entry) continue;
-
-        const serialized = JSON.stringify(entry);
-        const row = buildQueuedSessionRow({
-          sessionPath: buildSessionPath(config, String(entry.session_id)),
-          line: serialized,
-          userName: config.userName,
-          projectName: COWORK_PROJECT,
-          description: String(entry.type ?? ""),
-          agent: COWORK_AGENT,
-          pluginVersion: getVersion(),
-          timestamp: String(entry.timestamp),
-        });
-        appendQueuedSessionRow(row, COWORK_QUEUE_DIR);
-        appendedAny = true;
-        ingested += 1;
+        for (const entry of entriesForLine(parsed)) {
+          const serialized = JSON.stringify(entry);
+          const row = buildQueuedSessionRow({
+            sessionPath: buildSessionPath(config, String(entry.session_id)),
+            line: serialized,
+            userName: config.userName,
+            projectName: COWORK_PROJECT,
+            description: String(entry.type ?? ""),
+            agent: COWORK_AGENT,
+            pluginVersion: getVersion(),
+            timestamp: String(entry.timestamp),
+          });
+          appendQueuedSessionRow(row, COWORK_QUEUE_DIR);
+          appendedAny = true;
+          ingested += 1;
+        }
       }
       state.processedLines[path] = lines.length;
     }

--- a/src/mcp/cowork-ingest.ts
+++ b/src/mcp/cowork-ingest.ts
@@ -33,7 +33,7 @@ import {
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { loadCredentials } from "../commands/auth.js";
-import { loadConfig } from "../config.js";
+import { loadConfig, type Config } from "../config.js";
 import { DeeplakeApi } from "../deeplake-api.js";
 import { claudeDesktopConfigDir } from "../cli/util.js";
 import { getVersion } from "../cli/version.js";
@@ -43,6 +43,8 @@ import {
   buildSessionPath,
   drainSessionQueues,
 } from "../hooks/session-queue.js";
+import { spawnWikiWorker, bundleDirFromImportMeta } from "../hooks/spawn-wiki-worker.js";
+import { basename } from "node:path";
 import { log } from "../utils/debug.js";
 
 /** Value written to the `agent` column for Cowork-originated rows. */
@@ -56,6 +58,9 @@ const LOCK_PATH = join(DEEPLAKE_DIR, ".cowork-ingest.lock");
 const COWORK_QUEUE_DIR = join(DEEPLAKE_DIR, "queue-cowork");
 const NOTICE_MARKER = join(DEEPLAKE_DIR, ".cowork-data-notice-shown");
 const LOCK_STALE_MS = 60_000;
+// A Cowork transcript untouched for this long is treated as a finished session
+// and gets a summary (Cowork has no SessionEnd hook to signal completion).
+const SUMMARY_IDLE_MS = 5 * 60_000;
 
 const DATA_NOTICE =
   "ℹ️ Hivemind data notice: this Cowork session is being saved to your team's shared Deeplake memory " +
@@ -82,9 +87,11 @@ export function coworkDataNoticeOnce(): string {
   }
 }
 
-interface IngestState {
+export interface IngestState {
   /** transcript absolute path → number of lines already ingested. */
   processedLines: Record<string, number>;
+  /** transcript absolute path → line count at last summary spawn. */
+  summarizedLines?: Record<string, number>;
 }
 
 export interface TranscriptLine {
@@ -247,6 +254,58 @@ function tryAcquireLock(): (() => void) | null {
 }
 
 /**
+ * Spawn a wiki-worker for each Cowork session whose transcript has gone idle
+ * and has un-summarized content. The worker reads the session rows we already
+ * wrote to the sessions table (keyed by sessionId) and uploads a summary to
+ * the memory table — same path every other agent uses, so Cowork sessions
+ * appear in hivemind_index / recall. Best-effort: a missing `claude` binary or
+ * a spawn failure is logged and skipped (the raw session is still captured).
+ */
+export type SpawnSummaryFn = (sessionId: string) => void;
+
+export function summarizeIdleSessions(
+  config: Config,
+  state: IngestState,
+  spawn?: SpawnSummaryFn,
+  now: number = Date.now(),
+): void {
+  const bundleDir = bundleDirFromImportMeta(import.meta.url);
+  const doSpawn: SpawnSummaryFn =
+    spawn ??
+    ((sessionId) =>
+      spawnWikiWorker({
+        config,
+        sessionId,
+        cwd: `/${COWORK_PROJECT}`,
+        bundleDir,
+        reason: "CoworkIdle",
+        agent: COWORK_AGENT,
+      }));
+  state.summarizedLines ??= {};
+
+  for (const path of Object.keys(state.processedLines)) {
+    const processed = state.processedLines[path] ?? 0;
+    if (processed === 0) continue;
+    if (processed <= (state.summarizedLines[path] ?? 0)) continue; // nothing new since last summary
+
+    try {
+      if (now - statSync(path).mtimeMs < SUMMARY_IDLE_MS) continue; // still active
+    } catch {
+      continue; // transcript vanished
+    }
+
+    const sessionId = basename(path).replace(/\.jsonl$/, "");
+    try {
+      doSpawn(sessionId);
+      state.summarizedLines[path] = processed;
+      log("cowork-ingest", `spawned summary worker for idle Cowork session ${sessionId}`);
+    } catch (e: unknown) {
+      log("cowork-ingest", `summary spawn skipped for ${sessionId}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+}
+
+/**
  * Tail Cowork transcripts and write new messages to the sessions table.
  * Safe to call repeatedly; never throws and never writes to stdout (which
  * would corrupt the MCP stdio channel).
@@ -308,8 +367,6 @@ export async function ingestCoworkSessions(): Promise<{ ingested: number } | { s
       state.processedLines[path] = lines.length;
     }
 
-    saveState(state);
-
     if (appendedAny) {
       const api = new DeeplakeApi(
         config.token,
@@ -323,6 +380,13 @@ export async function ingestCoworkSessions(): Promise<{ ingested: number } | { s
         queueDir: COWORK_QUEUE_DIR,
       });
     }
+
+    // Summarize sessions that have gone idle — Cowork has no SessionEnd hook,
+    // so "untouched for SUMMARY_IDLE_MS" is our completion signal. Reads the
+    // rows we just wrote to the sessions table (same as every other agent).
+    summarizeIdleSessions(config, state);
+
+    saveState(state);
 
     if (ingested > 0) log("cowork-ingest", `ingested ${ingested} message(s) from Cowork transcripts`);
     return { ingested };

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,7 +23,7 @@ import { isMissingTableError } from "../deeplake-schema.js";
 import { sqlStr, sqlLike } from "../utils/sql.js";
 import { searchDeeplakeTables, buildGrepSearchOptions, normalizeContent, TRUNCATION_NOTICE, type GrepMatchParams } from "../shell/grep-core.js";
 import { getVersion } from "../cli/version.js";
-import { startCoworkIngestLoop } from "./cowork-ingest.js";
+import { startCoworkIngestLoop, coworkDataNoticeOnce } from "./cowork-ingest.js";
 
 interface ServerContext {
   api: DeeplakeApi;
@@ -46,6 +46,14 @@ function getContext(): ServerContext | { error: string } {
 
 function errorResult(text: string): { content: Array<{ type: "text"; text: string }> } {
   return { content: [{ type: "text", text }] };
+}
+
+/**
+ * Successful tool result. Prepends the one-time Cowork data notice when
+ * running inside a Cowork host (no-op everywhere else and after first use).
+ */
+function okResult(text: string): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text", text: coworkDataNoticeOnce() + text }] };
 }
 
 /**
@@ -100,7 +108,7 @@ server.registerTool(
       // Tell the caller when the row cap was hit so it doesn't treat a capped
       // page as the complete set (consistent with the grep path).
       if (meta.truncated) lines.push(TRUNCATION_NOTICE);
-      return { content: [{ type: "text", text: lines.join("\n\n---\n\n") }] };
+      return okResult(lines.join("\n\n---\n\n"));
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (isMissingTableError(msg)) return errorResult(`No matches for "${query}". ${FRESH_ORG_HINT}`);
@@ -134,7 +142,7 @@ server.registerTool(
       const rows = await ctx.api.query(sql);
       if (rows.length === 0) return errorResult(`No content found at ${path}.`);
       const text = rows.map(r => normalizeContent(String(r["path"]), String(r["content"] ?? ""))).join("\n");
-      return { content: [{ type: "text", text }] };
+      return okResult(text);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (isMissingTableError(msg)) return errorResult(`No content found at ${path}. ${FRESH_ORG_HINT}`);
@@ -175,7 +183,7 @@ server.registerTool(
         const date = String(r["last_update_date"] ?? "");
         return `${path}\t${date}\t${project}\t${desc}`;
       });
-      return { content: [{ type: "text", text: `path\tlast_updated\tproject\tdescription\n${lines.join("\n")}` }] };
+      return okResult(`path\tlast_updated\tproject\tdescription\n${lines.join("\n")}`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (isMissingTableError(msg)) return errorResult(`No summaries found. ${FRESH_ORG_HINT}`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,6 +23,7 @@ import { isMissingTableError } from "../deeplake-schema.js";
 import { sqlStr, sqlLike } from "../utils/sql.js";
 import { searchDeeplakeTables, buildGrepSearchOptions, normalizeContent, TRUNCATION_NOTICE, type GrepMatchParams } from "../shell/grep-core.js";
 import { getVersion } from "../cli/version.js";
+import { startCoworkIngestLoop } from "./cowork-ingest.js";
 
 interface ServerContext {
   api: DeeplakeApi;
@@ -186,6 +187,10 @@ server.registerTool(
 async function main(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  // Cowork has no capture hooks — tail its local transcripts and write them
+  // to the sessions table so Cowork conversations become shared memory too.
+  // Best-effort and self-throttling; never touches the stdio channel.
+  startCoworkIngestLoop();
 }
 
 main().catch((err) => {

--- a/tests/claude-code/cowork-ingest.test.ts
+++ b/tests/claude-code/cowork-ingest.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { entryForLine, extractText, COWORK_AGENT } from "../../src/mcp/cowork-ingest.js";
+
+describe("extractText", () => {
+  it("returns a plain string unchanged", () => {
+    expect(extractText("hello world")).toBe("hello world");
+  });
+
+  it("joins text blocks and ignores thinking/tool_use", () => {
+    const content = [
+      { type: "thinking", thinking: "hmm", signature: "x" },
+      { type: "text", text: "first" },
+      { type: "tool_use", name: "hivemind_search", input: {} },
+      { type: "text", text: "second" },
+    ];
+    expect(extractText(content)).toBe("first\nsecond");
+  });
+
+  it("returns empty string for non-text content", () => {
+    expect(extractText(undefined)).toBe("");
+    expect(extractText([{ type: "thinking", thinking: "x" }])).toBe("");
+  });
+});
+
+describe("entryForLine", () => {
+  const base = {
+    sessionId: "b27efa59-a8bc-4ea3-8b02-18cbc608ae17",
+    timestamp: "2026-06-26T15:02:13.529Z",
+    cwd: "/some/cowork/outputs",
+  };
+
+  it("maps a user line to a user_message entry tagged as Cowork", () => {
+    const entry = entryForLine({ ...base, type: "user", message: { content: "ciao" } });
+    expect(entry).toMatchObject({
+      session_id: base.sessionId,
+      timestamp: base.timestamp,
+      type: "user_message",
+      content: "ciao",
+      agent: COWORK_AGENT,
+    });
+  });
+
+  it("maps an assistant line with text blocks to an assistant_message entry", () => {
+    const entry = entryForLine({
+      ...base,
+      type: "assistant",
+      message: { content: [{ type: "text", text: "risposta" }] },
+    });
+    expect(entry).toMatchObject({ type: "assistant_message", content: "risposta", agent: COWORK_AGENT });
+  });
+
+  it("skips assistant turns that carry no text (pure thinking / tool_use)", () => {
+    const entry = entryForLine({
+      ...base,
+      type: "assistant",
+      message: { content: [{ type: "thinking", thinking: "x" }] },
+    });
+    expect(entry).toBeNull();
+  });
+
+  it("skips empty user messages and non-message line types", () => {
+    expect(entryForLine({ ...base, type: "user", message: { content: "   " } })).toBeNull();
+    expect(entryForLine({ ...base, type: "queue-operation" })).toBeNull();
+    expect(entryForLine({ ...base, type: "attachment" })).toBeNull();
+  });
+
+  it("skips lines without a sessionId", () => {
+    expect(entryForLine({ type: "user", message: { content: "hi" } })).toBeNull();
+  });
+});

--- a/tests/claude-code/cowork-ingest.test.ts
+++ b/tests/claude-code/cowork-ingest.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { entryForLine, extractText, COWORK_AGENT } from "../../src/mcp/cowork-ingest.js";
+import { entriesForLine, extractText, coworkDataNoticeOnce, COWORK_AGENT } from "../../src/mcp/cowork-ingest.js";
+
+type Line = Parameters<typeof entriesForLine>[0];
+const firstEntry = (line: Line) => entriesForLine(line)[0] ?? null;
 
 describe("extractText", () => {
   it("returns a plain string unchanged", () => {
@@ -22,7 +25,7 @@ describe("extractText", () => {
   });
 });
 
-describe("entryForLine", () => {
+describe("entriesForLine", () => {
   const base = {
     sessionId: "b27efa59-a8bc-4ea3-8b02-18cbc608ae17",
     timestamp: "2026-06-26T15:02:13.529Z",
@@ -30,8 +33,7 @@ describe("entryForLine", () => {
   };
 
   it("maps a user line to a user_message entry tagged as Cowork", () => {
-    const entry = entryForLine({ ...base, type: "user", message: { content: "ciao" } });
-    expect(entry).toMatchObject({
+    expect(firstEntry({ ...base, type: "user", message: { content: "ciao" } })).toMatchObject({
       session_id: base.sessionId,
       timestamp: base.timestamp,
       type: "user_message",
@@ -41,30 +43,78 @@ describe("entryForLine", () => {
   });
 
   it("maps an assistant line with text blocks to an assistant_message entry", () => {
-    const entry = entryForLine({
+    expect(firstEntry({
       ...base,
       type: "assistant",
       message: { content: [{ type: "text", text: "risposta" }] },
-    });
-    expect(entry).toMatchObject({ type: "assistant_message", content: "risposta", agent: COWORK_AGENT });
+    })).toMatchObject({ type: "assistant_message", content: "risposta", agent: COWORK_AGENT });
   });
 
-  it("skips assistant turns that carry no text (pure thinking / tool_use)", () => {
-    const entry = entryForLine({
+  it("emits a tool_call entry for each assistant tool_use block", () => {
+    const entries = entriesForLine({
+      ...base,
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "let me search" },
+          { type: "tool_use", id: "toolu_1", name: "hivemind_search", input: { query: "x" } },
+        ],
+      },
+    });
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ type: "assistant_message", content: "let me search" });
+    expect(entries[1]).toMatchObject({
+      type: "tool_call",
+      tool_name: "hivemind_search",
+      tool_use_id: "toolu_1",
+      tool_input: JSON.stringify({ query: "x" }),
+      agent: COWORK_AGENT,
+    });
+  });
+
+  it("emits a tool_result entry for a user tool_result block", () => {
+    const entries = entriesForLine({
+      ...base,
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "rows=5" }] },
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "toolu_1",
+      tool_response: JSON.stringify("rows=5"),
+      agent: COWORK_AGENT,
+    });
+  });
+
+  it("skips assistant turns that carry no text and no tool calls (pure thinking)", () => {
+    expect(entriesForLine({
       ...base,
       type: "assistant",
       message: { content: [{ type: "thinking", thinking: "x" }] },
-    });
-    expect(entry).toBeNull();
+    })).toEqual([]);
   });
 
   it("skips empty user messages and non-message line types", () => {
-    expect(entryForLine({ ...base, type: "user", message: { content: "   " } })).toBeNull();
-    expect(entryForLine({ ...base, type: "queue-operation" })).toBeNull();
-    expect(entryForLine({ ...base, type: "attachment" })).toBeNull();
+    expect(entriesForLine({ ...base, type: "user", message: { content: "   " } })).toEqual([]);
+    expect(entriesForLine({ ...base, type: "queue-operation" })).toEqual([]);
+    expect(entriesForLine({ ...base, type: "attachment" })).toEqual([]);
   });
 
   it("skips lines without a sessionId", () => {
-    expect(entryForLine({ type: "user", message: { content: "hi" } })).toBeNull();
+    expect(entriesForLine({ type: "user", message: { content: "hi" } })).toEqual([]);
+  });
+});
+
+describe("coworkDataNoticeOnce", () => {
+  it("returns empty string when capture is disabled (no fs side effects)", () => {
+    const prev = process.env.HIVEMIND_CAPTURE;
+    process.env.HIVEMIND_CAPTURE = "false";
+    try {
+      expect(coworkDataNoticeOnce()).toBe("");
+    } finally {
+      if (prev === undefined) delete process.env.HIVEMIND_CAPTURE;
+      else process.env.HIVEMIND_CAPTURE = prev;
+    }
   });
 });

--- a/tests/claude-code/cowork-ingest.test.ts
+++ b/tests/claude-code/cowork-ingest.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { entriesForLine, extractText, coworkDataNoticeOnce, COWORK_AGENT } from "../../src/mcp/cowork-ingest.js";
+import { mkdtempSync, writeFileSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  entriesForLine,
+  extractText,
+  coworkDataNoticeOnce,
+  summarizeIdleSessions,
+  COWORK_AGENT,
+  type IngestState,
+} from "../../src/mcp/cowork-ingest.js";
+
+const fakeConfig = {} as Parameters<typeof summarizeIdleSessions>[0];
 
 type Line = Parameters<typeof entriesForLine>[0];
 const firstEntry = (line: Line) => entriesForLine(line)[0] ?? null;
@@ -103,6 +115,45 @@ describe("entriesForLine", () => {
 
   it("skips lines without a sessionId", () => {
     expect(entriesForLine({ type: "user", message: { content: "hi" } })).toEqual([]);
+  });
+});
+
+describe("summarizeIdleSessions", () => {
+  const now = 10_000_000;
+  const idleMtimeSec = (now - 6 * 60_000) / 1000; // older than the 5-min idle window
+  const freshMtimeSec = (now - 60_000) / 1000; // 1 min ago — still active
+
+  function transcript(mtimeSec: number): string {
+    const dir = mkdtempSync(join(tmpdir(), "cowork-idle-"));
+    const p = join(dir, "11111111-1111-1111-1111-111111111111.jsonl");
+    writeFileSync(p, "{}\n");
+    utimesSync(p, mtimeSec, mtimeSec);
+    return p;
+  }
+
+  it("spawns a summary for an idle session with un-summarized content", () => {
+    const p = transcript(idleMtimeSec);
+    const state: IngestState = { processedLines: { [p]: 5 }, summarizedLines: {} };
+    const spawned: string[] = [];
+    summarizeIdleSessions(fakeConfig, state, (sid) => spawned.push(sid), now);
+    expect(spawned).toEqual(["11111111-1111-1111-1111-111111111111"]);
+    expect(state.summarizedLines![p]).toBe(5);
+  });
+
+  it("does not re-spawn when there is no new content since the last summary", () => {
+    const p = transcript(idleMtimeSec);
+    const state: IngestState = { processedLines: { [p]: 5 }, summarizedLines: { [p]: 5 } };
+    const spawned: string[] = [];
+    summarizeIdleSessions(fakeConfig, state, (sid) => spawned.push(sid), now);
+    expect(spawned).toEqual([]);
+  });
+
+  it("does not summarize a session still being written (not idle)", () => {
+    const p = transcript(freshMtimeSec);
+    const state: IngestState = { processedLines: { [p]: 5 }, summarizedLines: {} };
+    const spawned: string[] = [];
+    summarizeIdleSessions(fakeConfig, state, (sid) => spawned.push(sid), now);
+    expect(spawned).toEqual([]);
   });
 });
 

--- a/tests/cli/cli-util.test.ts
+++ b/tests/cli/cli-util.test.ts
@@ -208,8 +208,8 @@ describe("readVersionStamp / writeVersionStamp", () => {
 });
 
 describe("detectPlatforms / allPlatformIds", () => {
-  it("allPlatformIds returns the canonical six-platform set", () => {
-    expect(allPlatformIds()).toEqual(["claude", "codex", "claw", "cursor", "hermes", "pi"]);
+  it("allPlatformIds returns the canonical platform set", () => {
+    expect(allPlatformIds()).toEqual(["claude", "codex", "claw", "cursor", "hermes", "pi", "claude_cowork"]);
   });
 
   it("detectPlatforms returns only platforms whose marker dir exists right now", () => {

--- a/tests/cli/install-cowork.test.ts
+++ b/tests/cli/install-cowork.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { setFakeHome, clearFakeHome } from "../shared/fake-home.js";
@@ -20,7 +20,11 @@ let tmpPkg: string;
 let configPath: string;
 
 beforeEach(() => {
-  tmpRoot = join(tmpdir(), `hm-cowork-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  // mkdtempSync atomically creates a uniquely-named dir under the OS temp dir.
+  // Using it (rather than join(tmpdir(), <handmade name>)) is the pattern CodeQL
+  // accepts — it sanitizes the predictable-path taint, clearing the "insecure
+  // temporary file" alerts for every path derived from this root.
+  tmpRoot = mkdtempSync(join(tmpdir(), "hm-cowork-"));
   tmpHome = join(tmpRoot, "home");
   tmpPkg = join(tmpRoot, "pkg");
   mkdirSync(tmpHome, { recursive: true });

--- a/tests/cli/install-cowork.test.ts
+++ b/tests/cli/install-cowork.test.ts
@@ -116,7 +116,11 @@ describe("installCowork", () => {
     writeFileSync(configPath, "{ not valid json ");
 
     const { installCowork } = await importCowork();
-    expect(() => installCowork()).toThrow(/not valid JSON/);
+    // Assert the full actionable message (path included), not just a substring —
+    // so a regression in the path-bearing guidance is caught too.
+    expect(() => installCowork()).toThrow(
+      `claude_desktop_config.json at ${configPath} is not valid JSON. Fix or remove it, then rerun.`,
+    );
     // The user's file is left untouched.
     expect(readFileSync(configPath, "utf-8")).toBe("{ not valid json ");
   });

--- a/tests/cli/install-cowork.test.ts
+++ b/tests/cli/install-cowork.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { setFakeHome, clearFakeHome } from "../shared/fake-home.js";
+
+/**
+ * Tests for src/cli/install-cowork.ts — the Claude Cowork integration.
+ *
+ * Cowork reads MCP connectors from Claude Desktop's claude_desktop_config.json
+ * (`mcpServers` key). The installer must MERGE non-destructively: a user may
+ * already have hand-added connectors and unrelated top-level config. The
+ * critical regressions to guard are (a) clobbering that file and (b) leaving
+ * a stale hivemind entry on uninstall.
+ */
+
+let tmpRoot: string;
+let tmpHome: string;
+let tmpPkg: string;
+let configPath: string;
+
+beforeEach(() => {
+  tmpRoot = join(tmpdir(), `hm-cowork-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  tmpHome = join(tmpRoot, "home");
+  tmpPkg = join(tmpRoot, "pkg");
+  mkdirSync(tmpHome, { recursive: true });
+  mkdirSync(join(tmpPkg, "mcp", "bundle"), { recursive: true });
+  writeFileSync(join(tmpPkg, "mcp", "bundle", "server.js"), "// fake server");
+  writeFileSync(join(tmpPkg, "package.json"), JSON.stringify({ version: "5.5.5" }));
+
+  setFakeHome(tmpHome);
+  // Linux/macOS test runners: config dir is ~/.config/Claude. (On Windows CI
+  // os.homedir() + the helper keep this under tmpHome too.)
+  configPath = join(tmpHome, ".config", "Claude", "claude_desktop_config.json");
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  clearFakeHome();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+async function importCowork(): Promise<typeof import("../../src/cli/install-cowork.js")> {
+  vi.resetModules();
+  vi.doMock("../../src/cli/util.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../src/cli/util.js")>();
+    return { ...actual, pkgRoot: () => tmpPkg };
+  });
+  return await import("../../src/cli/install-cowork.js");
+}
+
+function readConfig(): Record<string, any> {
+  return JSON.parse(readFileSync(configPath, "utf-8"));
+}
+
+describe("installCowork", () => {
+  it("creates the config and registers the hivemind stdio MCP server", async () => {
+    const { installCowork } = await importCowork();
+    // Only run on platforms where the path math matches our assertion. On the
+    // POSIX CI runner process.platform is linux/darwin → ~/.config|Library.
+    if (process.platform === "win32") return;
+
+    installCowork();
+
+    expect(existsSync(configPath)).toBe(true);
+    const cfg = readConfig();
+    expect(cfg.mcpServers.hivemind).toEqual({
+      command: "node",
+      args: [join(tmpHome, ".hivemind", "mcp", "server.js")],
+    });
+    // The shared MCP server binary must also have been installed.
+    expect(existsSync(join(tmpHome, ".hivemind", "mcp", "server.js"))).toBe(true);
+  });
+
+  it("merges non-destructively — preserves other servers and top-level keys", async () => {
+    if (process.platform === "win32") return;
+    mkdirSync(join(tmpHome, ".config", "Claude"), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: { other: { command: "other-bin", args: ["--x"] } },
+        globalShortcut: "Cmd+Shift+Space",
+      }),
+    );
+
+    const { installCowork } = await importCowork();
+    installCowork();
+
+    const cfg = readConfig();
+    expect(cfg.mcpServers.other).toEqual({ command: "other-bin", args: ["--x"] });
+    expect(cfg.mcpServers.hivemind.command).toBe("node");
+    expect(cfg.globalShortcut).toBe("Cmd+Shift+Space");
+  });
+
+  it("is idempotent — twice yields exactly one hivemind entry", async () => {
+    if (process.platform === "win32") return;
+    const { installCowork } = await importCowork();
+    installCowork();
+    const first = readConfig();
+    installCowork();
+    const second = readConfig();
+    expect(second).toEqual(first);
+    expect(Object.keys(second.mcpServers)).toEqual(["hivemind"]);
+  });
+
+  it("refuses to clobber a malformed config and surfaces a clear error", async () => {
+    if (process.platform === "win32") return;
+    mkdirSync(join(tmpHome, ".config", "Claude"), { recursive: true });
+    writeFileSync(configPath, "{ not valid json ");
+
+    const { installCowork } = await importCowork();
+    expect(() => installCowork()).toThrow(/not valid JSON/);
+    // The user's file is left untouched.
+    expect(readFileSync(configPath, "utf-8")).toBe("{ not valid json ");
+  });
+});
+
+describe("uninstallCowork", () => {
+  it("removes only the hivemind entry, preserving other servers", async () => {
+    if (process.platform === "win32") return;
+    mkdirSync(join(tmpHome, ".config", "Claude"), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          hivemind: { command: "node", args: ["/x/server.js"] },
+          other: { command: "other-bin", args: [] },
+        },
+        theme: "dark",
+      }),
+    );
+
+    const { uninstallCowork } = await importCowork();
+    uninstallCowork();
+
+    const cfg = readConfig();
+    expect(cfg.mcpServers.hivemind).toBeUndefined();
+    expect(cfg.mcpServers.other).toEqual({ command: "other-bin", args: [] });
+    expect(cfg.theme).toBe("dark");
+  });
+
+  it("deletes the file when hivemind was its only content", async () => {
+    if (process.platform === "win32") return;
+    mkdirSync(join(tmpHome, ".config", "Claude"), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { hivemind: { command: "node", args: ["/x"] } } }),
+    );
+
+    const { uninstallCowork } = await importCowork();
+    uninstallCowork();
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  it("is a no-op when no config file exists", async () => {
+    const { uninstallCowork } = await importCowork();
+    expect(() => uninstallCowork()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Adds a `claude_cowork` integration so Claude Cowork (Anthropic's agentic desktop assistant, hosted in the Claude Desktop app) gains Hivemind recall with zero manual setup.

Cowork reads MCP connectors from the same file as Claude Desktop chat — `claude_desktop_config.json`, `mcpServers` key — and supports local stdio servers. So no new server is needed: we register the existing shared Hivemind MCP server (`~/.hivemind/mcp/server.js`, tools `hivemind_search` / `read` / `index`) into that config.

Scope is **recall only**. Capture of Cowork's own sessions is intentionally out of scope (the desktop app exposes no Claude Code-style hooks).

## How

- `src/cli/install-cowork.ts` (new) — `installCowork()` / `uninstallCowork()`. Reuses `ensureMcpServerInstalled()` + `buildMcpServerEntry()` and does a **non-destructive** JSON merge into `mcpServers.hivemind` (preserves existing connectors and top-level keys; refuses to clobber a malformed config). Uninstall removes only our key and deletes the file if it becomes empty.
- `src/cli/util.ts` — adds `claude_cowork` to `PlatformId`, an OS-aware `claudeDesktopConfigDir()` (macOS `~/Library/Application Support/Claude`, Windows `%APPDATA%/Claude`, Linux `~/.config/Claude`), and a detection marker.
- `src/cli/index.ts` — install/uninstall routing, `hivemind claude_cowork install | uninstall` subcommand, help + supported-list text.

Zero-config: because it is in `detectPlatforms()`, `hivemind install` registers Cowork automatically whenever Claude Desktop is present.

## Testing

- `tests/cli/install-cowork.test.ts` (new) — fresh install, non-destructive merge, idempotency, malformed-config refusal, uninstall (key-only removal, file deletion, no-op when absent).
- `tests/cli/cli-util.test.ts` — updated canonical platform-set assertion.
- Verified end-to-end against the real org: install writes the config + MCP binary, idempotent, uninstall removes; `detectPlatforms()` auto-detects Cowork; the MCP server returns real saved session summaries over a live stdio handshake.

Note: pre-existing `tree-sitter-*` optional-native-dep failures in fresh worktrees are unrelated to this change (graph extractors, untouched here).

## Session Context

[Session transcript](https://gist.github.com/efenocchi/4e09c132003d56ff27a37fd9a234a71f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Claude Cowork” support end-to-end: CLI install/uninstall, platform detection, MCP Cowork transcript ingestion, and a one-time data notice.
  * Documented “Claude Cowork (Alpha)” and auto-capture behavior/limitations.
* **Bug Fixes**
  * Improved queued session payload embedding for more reliable `jsonb` inserts (escaping behavior preserved).
* **Tests**
  * Added coverage for the Cowork installer/uninstaller and Cowork ingestion behavior (idempotency, malformed config, idle summarization).
* **Chores**
  * Updated MCP bundling to ensure executable shebang/permissions; aligned wiki worker agent handling defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->