### PR TITLE
fix(rules): skip doomed SELECT on `rules list` when hivemind_rules is absent

### DIFF
--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -188,6 +188,24 @@ export async function runRulesCommand(args: string[]): Promise<void> {
   if (sub === "list") {
     const status = parseStatus(args.slice(1));
     const limit = parseLimit(args.slice(1));
+
+    // Skip the SELECT entirely when we can prove the table doesn't exist.
+    // `list` (unlike the write subcommands) never runs ensureRulesTable, so an
+    // org that has only ever listed rules has no hivemind_rules table. Firing
+    // the doomed SELECT logs a 42P01 ERROR on the server for every list and
+    // SessionStart inject (fleet-wide: thousands/day), and because the server
+    // streams query results the missing-table error can reach the client as an
+    // opaque "fetch failed" instead of a clean empty list. A cheap table lookup
+    // avoids both. knownTablesOrNull() returns null when the lookup itself was
+    // untrustworthy (a network blip): in that case we fall through to the
+    // SELECT-then-catch path below so a transient hiccup never hides a table
+    // that really exists.
+    const knownTables = await api.knownTablesOrNull();
+    if (knownTables !== null && !knownTables.includes(tableName)) {
+      console.log(`(no rules with status=${status})`);
+      return;
+    }
+
     let rows: RuleRow[] = [];
     try {
       rows = await listRules(api.query.bind(api), tableName, { status, limit });

--- a/tests/claude-code/cli-rules.test.ts
+++ b/tests/claude-code/cli-rules.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureRulesTableMock = vi.fn();
 const queryMock = vi.fn();
+const knownTablesOrNullMock = vi.fn();
 
 vi.mock("../../src/config.js", () => ({
   loadConfig: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock("../../src/deeplake-api.js", () => ({
     ) { /* nothing */ }
     ensureRulesTable(name: string) { return ensureRulesTableMock(name); }
     query(sql: string) { return queryMock(sql); }
+    knownTablesOrNull() { return knownTablesOrNullMock(); }
   },
 }));
 
@@ -62,6 +64,10 @@ beforeEach(() => {
   erred = [];
   ensureRulesTableMock.mockReset().mockResolvedValue(undefined);
   queryMock.mockReset().mockResolvedValue([]);
+  // Default: table-existence lookup is "unknown" (null), so list falls through
+  // to the SELECT-then-catch path — the behavior the existing tests assert.
+  // Tests that exercise the skip-on-missing gate override this per-case.
+  knownTablesOrNullMock.mockReset().mockResolvedValue(null);
   loadConfigMock.mockReset().mockReturnValue(VALID_CONFIG);
   logSpy = vi.spyOn(console, "log").mockImplementation((...a: any[]) => { logged.push(a.join(" ")); });
   errSpy = vi.spyOn(console, "error").mockImplementation((...a: any[]) => { erred.push(a.join(" ")); });
@@ -220,6 +226,37 @@ describe("runRulesCommand — list", () => {
     queryMock.mockResolvedValueOnce([]);
     await runRulesCommand(["list"]);
     expect(logged.some(l => l.includes("(no rules with status=active)"))).toBe(true);
+  });
+
+  it("skips the SELECT and shows empty state when the rules table doesn't exist", async () => {
+    // Regression: an org that has only ever run `rules list` has no
+    // hivemind_rules table. The handler must NOT fire the doomed SELECT —
+    // that logs a 42P01 server-side and can surface to the user as a bare
+    // "fetch failed" through the streaming query path. A table-existence
+    // lookup that returns a list WITHOUT the rules table short-circuits.
+    knownTablesOrNullMock.mockResolvedValueOnce(["memory", "sessions"]);
+    await runRulesCommand(["list"]);
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(logged.some(l => l.includes("(no rules with status=active)"))).toBe(true);
+  });
+
+  it("still SELECTs when the table-existence lookup confirms the table exists", async () => {
+    knownTablesOrNullMock.mockResolvedValueOnce(["memory", "hivemind_rules"]);
+    queryMock.mockResolvedValueOnce([fakeRow()]);
+    await runRulesCommand(["list"]);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(logged.some(l => l.includes("[active]"))).toBe(true);
+  });
+
+  it("falls back to SELECT-then-catch when the table lookup is untrustworthy (null)", async () => {
+    // A transient lookup failure (null) must NOT be read as "no table" —
+    // otherwise a network blip would hide rules that really exist. Fall
+    // through to the SELECT, which here returns a real row.
+    knownTablesOrNullMock.mockResolvedValueOnce(null);
+    queryMock.mockResolvedValueOnce([fakeRow()]);
+    await runRulesCommand(["list"]);
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(logged.some(l => l.includes("rule-aaaa-bbbb"))).toBe(true);
   });
 
   it("honors --status done", async () => {


### PR DESCRIPTION
## Problem

`hivemind rules list` (and the SessionStart rules inject) issues `SELECT … FROM hivemind_rules` even for orgs that have never created the table. The `hivemind_rules` table is only created by a **write** subcommand (`add`/`edit`/`done`) — `list` deliberately skips `ensureRulesTable`. So any org that has only ever *listed* rules has no table, and every list fires a doomed SELECT.

Consequences observed in prod (pg-deeplake, last 24h):
- 42P01 ERROR log noise on the server: **thousands/day** across ≥14 orgs, top org **2931/day** (Alka `4b46bb3b…`: 169/day, all `hivemind_rules`).
- Because deeplake-api **streams** query results, the missing-table error doesn't always arrive as a clean error — it can surface to the user as a bare `hivemind: fetch failed`. This is the error report that kicked this off.

## Fix

Gate the SELECT on the existing `knownTablesOrNull()` helper:
- workspace table list known **and** missing the rules table → print `(no rules with status=…)` and return, **no query issued**;
- list contains the table → SELECT as before;
- lookup returns `null` (untrustworthy / network blip) → fall through to the existing SELECT-then-catch path, so a transient hiccup never hides a table that really exists.

This eliminates the 42P01 noise for the common case and removes the dependency on the client correctly classifying a streamed/aborted missing-table error.

## Tests

Added to `tests/claude-code/cli-rules.test.ts`:
- skip-on-missing → no SELECT, empty-state printed;
- confirmed-exists → SELECT runs;
- null-lookup → falls back to SELECT-then-catch.

Existing list tests default the lookup to `null`, so their SELECT assertions are unchanged. Full file: 29/29 green; `tsc --noEmit` clean.

## Paired server fix

deeplake-api#287 makes the streaming query path return a clean HTTP 400 for a missing-table (42P01) error instead of committing a 200 stream — fixing the root cause for **all** clients/SDKs, not just this CLI.

Not merging — handing back for review per the public-repo workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the rules list command so it no longer attempts a database lookup when the rules table is clearly unavailable.
  * Added safer fallback behavior for older or uncertain database environments, while still showing existing rules when available.
  * Updated test coverage to verify the empty-state message, normal rule listing, and fallback behavior across different database states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->