### PR TITLE
fix(cli): don't crash when optional tree-sitter addon is absent (install P0)

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -542,6 +542,14 @@ writeFileSync("mcp/bundle/package.json", esmPackageJson);
 await build({
   entryPoints: { cli: "dist/src/cli/index.js" },
   bundle: true,
+  // Code-splitting so the dynamic `import("../commands/graph.js")` in
+  // src/cli/index.ts is emitted as a separate chunk. That keeps the
+  // external `import "tree-sitter"` (an optionalDependency that fails to
+  // build on some platforms, e.g. Node 24 / arm64) OUT of the top of
+  // bundle/cli.js. Without splitting, esbuild hoists that external import
+  // to the entry file and every `hivemind` command — including `install` —
+  // crashes with ERR_MODULE_NOT_FOUND when the addon is absent.
+  splitting: true,
   platform: "node",
   format: "esm",
   outdir: "bundle",
@@ -562,8 +570,18 @@ await build({
     "tree-sitter-c",
     "tree-sitter-cpp",
   ],
-  banner: { js: "#!/usr/bin/env node" },
+  // No `banner` here: with `splitting` enabled esbuild stamps the banner onto
+  // every output file (the entry AND the split chunks). A shebang inside an
+  // imported chunk breaks it (Node strips only the first line, leaving the
+  // rest as a syntax error). Prepend the shebang to the entry file only.
 });
+{
+  const cliPath = "bundle/cli.js";
+  const cliSrc = readFileSync(cliPath, "utf-8");
+  if (!cliSrc.startsWith("#!")) {
+    writeFileSync(cliPath, `#!/usr/bin/env node\n${cliSrc}`);
+  }
+}
 chmodSync("bundle/cli.js", 0o755);
 
 // Standalone embed daemon bundle. `hivemind embeddings install` deposits

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,14 @@ import {
 } from "./embeddings.js";
 import { ensureLoggedIn, isLoggedIn, loginWithProvidedToken, maybeShowOrgChoice } from "./auth.js";
 import { runAuthCommand } from "../commands/auth-login.js";
-import { runGraphCommand } from "../commands/graph.js";
+// NOTE: ../commands/graph.js is intentionally NOT imported statically. It pulls
+// in the tree-sitter native addon (an optionalDependency), which fails to build
+// on some platforms (e.g. Node 24 / arm64, where tree-sitter@0.21 needs C++20).
+// A static import would hoist `import "tree-sitter"` to the top of the bundle
+// and crash EVERY `hivemind` command — including `install` — with
+// ERR_MODULE_NOT_FOUND when the addon is absent. It is loaded lazily below
+// (with `splitting` enabled in esbuild, the tree-sitter chunk is split out and
+// only loaded when `hivemind graph` actually runs).
 import { runDashboardCommand } from "../commands/dashboard.js";
 import { runSkillifyCommand } from "../commands/skillify.js";
 import { runRulesCommand } from "../commands/rules.js";
@@ -496,6 +503,22 @@ async function main(): Promise<void> {
   }
 
   if (cmd === "graph") {
+    let runGraphCommand: (a: string[]) => Promise<void> | void;
+    try {
+      ({ runGraphCommand } = await import("../commands/graph.js"));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("tree-sitter") || (err as { code?: string })?.code === "ERR_MODULE_NOT_FOUND") {
+        console.error(
+          "hivemind graph requires the optional 'tree-sitter' native module, which is not installed.\n" +
+            "It can fail to build on some platforms (e.g. Node 24 / arm64). Everything else in Hivemind\n" +
+            "works without it. To enable the codebase graph, reinstall with a toolchain that can build\n" +
+            "native addons, or install tree-sitter manually in the package directory.",
+        );
+        process.exit(1);
+      }
+      throw err;
+    }
     await runGraphCommand(args.slice(1));
     return;
   }

--- a/tests/cli/cli-bundle-runtime.test.ts
+++ b/tests/cli/cli-bundle-runtime.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, renameSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+// Regression test for the static tree-sitter import bug (PR #295).
+//
+// Root cause: esbuild hoisted `import "tree-sitter"` to the top of
+// bundle/cli.js even though the module was only used inside commands/graph.js.
+// When the optional tree-sitter native addon failed to build (e.g. Node 24 +
+// arm64 where no prebuild exists), EVERY hivemind command — including `install`
+// — crashed with ERR_MODULE_NOT_FOUND at load time. The installer would appear
+// to succeed, but hivemind was dead on first run.
+//
+// Fix: lazy `import()` of commands/graph.js + esbuild `splitting: true`.
+// These tests exercise the bundle as a subprocess so they catch load-time
+// crashes that `node --check` (syntax-only) cannot detect.
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+const CLI = join(REPO_ROOT, "bundle/cli.js");
+const TREE_SITTER_NM = join(REPO_ROOT, "node_modules/tree-sitter");
+const TREE_SITTER_NM_HIDDEN = join(REPO_ROOT, "node_modules/.tree-sitter-absent");
+
+const bundleBuilt = existsSync(CLI);
+
+function runCli(args: string[]) {
+  return spawnSync("node", [CLI, ...args], {
+    encoding: "utf-8",
+    timeout: 15_000,
+    env: { ...process.env },
+  });
+}
+
+describe.skipIf(!bundleBuilt)(
+  "CLI bundle runtime smoke test (requires: npm run build)",
+  () => {
+    describe("tree-sitter present — normal path", () => {
+      it("--version exits 0", () => {
+        const r = runCli(["--version"]);
+        expect(r.status).toBe(0);
+        expect(r.stderr).not.toContain("ERR_MODULE_NOT_FOUND");
+      });
+
+      it("help exits 0", () => {
+        const r = runCli(["help"]);
+        expect(r.status).toBe(0);
+      });
+    });
+
+    describe("tree-sitter absent — optional dep not available", () => {
+      const treeSitterWasPresent = existsSync(TREE_SITTER_NM);
+
+      beforeAll(() => {
+        if (treeSitterWasPresent) renameSync(TREE_SITTER_NM, TREE_SITTER_NM_HIDDEN);
+      });
+
+      afterAll(() => {
+        if (treeSitterWasPresent && existsSync(TREE_SITTER_NM_HIDDEN)) {
+          renameSync(TREE_SITTER_NM_HIDDEN, TREE_SITTER_NM);
+        }
+      });
+
+      it("--version exits 0 — no ERR_MODULE_NOT_FOUND crash (regression: PR #295)", () => {
+        // Before the fix, bundle/cli.js had a top-level `import "tree-sitter"`
+        // (hoisted by esbuild), so the process exited with ERR_MODULE_NOT_FOUND
+        // before any command handler ran.
+        const r = runCli(["--version"]);
+        expect(r.status).toBe(0);
+        expect(r.stderr).not.toContain("ERR_MODULE_NOT_FOUND");
+      });
+
+      it("help exits 0 — load-time crash does not affect non-graph commands", () => {
+        const r = runCli(["help"]);
+        expect(r.status).toBe(0);
+      });
+
+      it("graph exits 1 with a friendly user message, not an uncaught exception", () => {
+        const r = runCli(["graph"]);
+        // Must be a handled exit — process.exit(1), not an unhandled crash.
+        expect(r.status).toBe(1);
+        // The error message must mention tree-sitter so the user knows why.
+        expect(r.stderr).toContain("tree-sitter");
+        // Must NOT be Node.js's raw ERR_MODULE_NOT_FOUND (which would print a
+        // full stack trace and exit(1) via uncaughtException — a crash, not a
+        // graceful degradation).
+        expect(r.stderr).not.toContain("ERR_MODULE_NOT_FOUND");
+        expect(r.stderr).not.toContain("at node:internal");
+      });
+    });
+  },
+);


### PR DESCRIPTION
## P0: installer succeeds but the CLI is dead on first run

`curl -fsSL https://deeplake.ai/hivemind.sh | sh` fails on dgx-spark-1; suspected as the cause of **0 conversions since release**.

### Root cause (reproduced on arm64 / Node 24, the DGX Spark class)
1. `tree-sitter@^0.21.1` is an `optionalDependency` with no prebuild for Node 24 / arm64, so it builds from source and **fails** (`#error "C++20 or later required."` — Node 24's V8 headers need C++20, the addon's gyp does not set it).
2. Because it's *optional*, `npm install -g @deeplake/hivemind` **succeeds anyway** — the installer reports success.
3. But `src/cli/index.ts` statically imported `../commands/graph.js` → the language extractors → `import Parser from "tree-sitter"`. esbuild hoists that external import to the **top of `bundle/cli.js`**, so **every** `hivemind` command — including `install` — crashes at load with `ERR_MODULE_NOT_FOUND`.

Net effect: installs that look successful, then a CLI that dies on the very first command. tree-sitter is only needed for the optional codebase-graph feature; capture/recall/install do not need it.

### Fix
- Load `../commands/graph.js` via **dynamic `import()`** only when `hivemind graph` runs, with a friendly message if the addon is missing.
- Enable esbuild **`splitting`** for the CLI build so the tree-sitter chunk is split out of `cli.js`. A dynamic import *alone* is not enough — without splitting esbuild still hoists external static imports to the entry file (verified empirically).
- Move the shebang out of esbuild `banner` (with splitting it gets stamped onto every chunk → double-shebang `SyntaxError`) and prepend it to `cli.js` only as a post-build step.

### Verification (arm64 / Node 24, tree-sitter build fails just like DGX Spark)

| command | before | after |
|---|---|---|
| `hivemind --version` | ERR_MODULE_NOT_FOUND | ✅ `0.7.115` |
| `hivemind --help` | ERR_MODULE_NOT_FOUND | ✅ |
| `hivemind whoami` | ERR_MODULE_NOT_FOUND | ✅ |
| `hivemind install --skip-auth` | ERR_MODULE_NOT_FOUND | ✅ installs Claude Code via marketplace |
| `hivemind graph build` | ERR_MODULE_NOT_FOUND | ✅ friendly "tree-sitter not installed" message, exit 1 |

Regression test (`tests/cli/cli-bundle-runtime.test.ts`) spawns the built bundle as a subprocess with tree-sitter hidden and asserts non-graph commands exit 0. Verified: **5/5 fail on the pre-fix bundle, 5/5 pass on the fix**.

Full test suite: **4685 passed**.

### Known follow-up (not in this PR)
The `graph-on-stop` SessionEnd hook bundle still has a top-level `tree-sitter` import — on machines without the addon it crashes at session end (errors are swallowed to its log; capture/recall are unaffected). Tracked separately to keep this P0 hotfix focused.