### PR TITLE
fix: stop wiki summary worker crash on long sessions

### DIFF
--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -176,7 +176,14 @@ async function main(): Promise<void> {
         writeFileSync(tmpSummary, existing);
         hasExistingSummary = true;
       }
-    } catch { /* no existing summary */ }
+    } catch (e: any) {
+      // A genuine lookup failure (query() throws only after its own retries) is
+      // NOT the same as "no summary". Treating it as absent would slice to the
+      // newest rows and overwrite the canonical summary with a base-less one, so
+      // bail and retry on the next run instead.
+      wlog(`existing summary lookup failed: ${e.message}; skipping to avoid overwriting the base summary`);
+      return;
+    }
     // The offset only means something if we actually loaded the summary it
     // refers to. If the summary row is gone (or the read failed), slicing by a
     // stale sidecar count would drop old rows with no base summary to extend,

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -190,7 +190,7 @@ async function main(): Promise<void> {
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
     const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
-      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -12,7 +12,8 @@ import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { finalizeSummary, releaseLock } from "../summary-state.js";
+import { finalizeSummary, releaseLock, readState } from "../summary-state.js";
+import { capLinesByBytes, stampOffset, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
 import { EmbedClient } from "../../embeddings/client.js";
@@ -145,9 +146,6 @@ async function main(): Promise<void> {
       return;
     }
 
-    const jsonlContent = rows
-      .map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message))
-      .join("\n");
     const jsonlLines = rows.length;
 
     const pathRows = await query(
@@ -158,10 +156,12 @@ async function main(): Promise<void> {
       ? pathRows[0].path as string
       : `/sessions/unknown/${cfg.sessionId}.jsonl`;
 
-    writeFileSync(tmpJsonl, jsonlContent);
-    wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
-
-    // 2. Check for existing summary (resumed session)
+    // 2. Determine how many rows were already summarized (resumed session).
+    // The sidecar count is authoritative: finalizeSummary writes it after every
+    // successful run and it never depends on the LLM echoing a bookkeeping line
+    // back into the summary. The regex over the stored summary is only a
+    // fallback for a session first summarized on another machine (the sidecar
+    // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
     try {
       const sumRows = await query(
@@ -173,9 +173,28 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
-        wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch { /* no existing summary */ }
+    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+
+    // Feed codex only the rows added since the last summary. Reprocessing the
+    // full session on every run is what drove the ENOBUFS / 120s-timeout
+    // failures on long (4000+ event) sessions — a stuck offset meant every run
+    // re-summarized everything from scratch.
+    const newRows = prevOffset > 0 ? rows.slice(prevOffset) : rows;
+    if (prevOffset > 0 && newRows.length === 0) {
+      wlog(`no new events since last summary (offset=${prevOffset}, total=${jsonlLines}) — skipping`);
+      return;
+    }
+    const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
+    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    if (dropped > 0) {
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+    }
+
+    writeFileSync(tmpJsonl, kept.join("\n"));
+    wlog(`found ${jsonlLines} events (${kept.length} new since offset ${prevOffset}) at ${jsonlServerPath}`);
 
     // 3. Build prompt and run codex exec
     const prompt = cfg.promptTemplate
@@ -198,6 +217,11 @@ async function main(): Promise<void> {
       execFileSync(inv.file, inv.args, {
         ...inv.options,
         timeout: 120_000,
+        // codex exec streams its reasoning to stdout, which execFileSync
+        // buffers. The Node default (1 MB) overflows to ENOBUFS on a verbose
+        // run, killing the summary. The summary is written to a file, not read
+        // from stdout, so we only need headroom to drain it.
+        maxBuffer: 64 * 1024 * 1024,
         env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" },
       });
       execSucceeded = true;
@@ -209,13 +233,16 @@ async function main(): Promise<void> {
 
     // 4. Upload summary to memory table
     if (existsSync(tmpSummary)) {
-      const text = readFileSync(tmpSummary, "utf-8");
-      const summaryChanged = summaryBeforeExec === null ? text.trim().length > 0 : text !== summaryBeforeExec;
+      const raw = readFileSync(tmpSummary, "utf-8");
+      const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
       if (!execSucceeded && !summaryChanged) {
         wlog("codex exec failed without producing a new summary; skipping upload");
         return;
       }
-      if (text.trim()) {
+      if (raw.trim()) {
+        // Stamp the offset ourselves so the persisted summary is authoritative
+        // and never depends on the LLM echoing the bookkeeping line.
+        const text = stampOffset(raw, jsonlLines);
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         // Embed the summary so it ranks in the semantic retrieval branch.

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -163,6 +163,7 @@ async function main(): Promise<void> {
     // fallback for a session first summarized on another machine (the sidecar
     // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
+    let hasExistingSummary = false;
     try {
       const sumRows = await query(
         `SELECT summary FROM "${cfg.memoryTable}" ` +
@@ -173,10 +174,20 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
+        hasExistingSummary = true;
       }
     } catch { /* no existing summary */ }
-    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
-    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    // The offset only means something if we actually loaded the summary it
+    // refers to. If the summary row is gone (or the read failed), slicing by a
+    // stale sidecar count would drop old rows with no base summary to extend,
+    // then overwrite the canonical summary with tail-only content. No base ⇒
+    // regenerate from scratch.
+    if (!hasExistingSummary) {
+      prevOffset = 0;
+    } else {
+      const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+      if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    }
 
     // Feed codex only the rows added since the last summary. Reprocessing the
     // full session on every run is what drove the ENOBUFS / 120s-timeout
@@ -188,9 +199,12 @@ async function main(): Promise<void> {
       return;
     }
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
-    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    const { kept, dropped, truncated } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
       wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
+    }
+    if (truncated) {
+      wlog(`a single event exceeded ${WIKI_JSONL_MAX_BYTES}B — truncated it to stay within the buffer`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));
@@ -235,8 +249,10 @@ async function main(): Promise<void> {
     if (existsSync(tmpSummary)) {
       const raw = readFileSync(tmpSummary, "utf-8");
       const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
-      if (!execSucceeded && !summaryChanged) {
-        wlog("codex exec failed without producing a new summary; skipping upload");
+      if (!execSucceeded) {
+        wlog(summaryChanged
+          ? "codex exec failed after a partial summary write; skipping upload to avoid advancing the offset"
+          : "codex exec failed without producing a new summary; skipping upload");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -156,7 +156,14 @@ async function main(): Promise<void> {
         writeFileSync(tmpSummary, existing);
         hasExistingSummary = true;
       }
-    } catch { /* no existing summary */ }
+    } catch (e: any) {
+      // A genuine lookup failure (query() throws only after its own retries) is
+      // NOT the same as "no summary". Treating it as absent would slice to the
+      // newest rows and overwrite the canonical summary with a base-less one, so
+      // bail and retry on the next run instead.
+      wlog(`existing summary lookup failed: ${e.message}; skipping to avoid overwriting the base summary`);
+      return;
+    }
     // The offset only means something if we actually loaded the summary it
     // refers to. If the summary row is gone (or the read failed), slicing by a
     // stale sidecar count would drop old rows with no base summary to extend,

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -170,7 +170,7 @@ async function main(): Promise<void> {
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
     const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
-      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -143,6 +143,7 @@ async function main(): Promise<void> {
     // fallback for a session first summarized on another machine (the sidecar
     // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
+    let hasExistingSummary = false;
     try {
       const sumRows = await query(
         `SELECT summary FROM "${cfg.memoryTable}" ` +
@@ -153,10 +154,20 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
+        hasExistingSummary = true;
       }
     } catch { /* no existing summary */ }
-    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
-    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    // The offset only means something if we actually loaded the summary it
+    // refers to. If the summary row is gone (or the read failed), slicing by a
+    // stale sidecar count would drop old rows with no base summary to extend,
+    // then overwrite the canonical summary with tail-only content. No base ⇒
+    // regenerate from scratch.
+    if (!hasExistingSummary) {
+      prevOffset = 0;
+    } else {
+      const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+      if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    }
 
     // Feed the agent only the rows added since the last summary. Reprocessing
     // the full session on every run is what drives ENOBUFS / 120s-timeout
@@ -168,9 +179,12 @@ async function main(): Promise<void> {
       return;
     }
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
-    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    const { kept, dropped, truncated } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
       wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
+    }
+    if (truncated) {
+      wlog(`a single event exceeded ${WIKI_JSONL_MAX_BYTES}B — truncated it to stay within the buffer`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));
@@ -221,8 +235,10 @@ async function main(): Promise<void> {
     if (existsSync(tmpSummary)) {
       const raw = readFileSync(tmpSummary, "utf-8");
       const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
-      if (!execSucceeded && !summaryChanged) {
-        wlog("cursor-agent --print failed without producing a new summary; skipping upload");
+      if (!execSucceeded) {
+        wlog(summaryChanged
+          ? "cursor-agent --print failed after a partial summary write; skipping upload to avoid advancing the offset"
+          : "cursor-agent --print failed without producing a new summary; skipping upload");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -17,7 +17,8 @@ import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { finalizeSummary, releaseLock } from "../summary-state.js";
+import { finalizeSummary, releaseLock, readState } from "../summary-state.js";
+import { capLinesByBytes, stampOffset, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
 import { EmbedClient } from "../../embeddings/client.js";
@@ -125,9 +126,6 @@ async function main(): Promise<void> {
       return;
     }
 
-    const jsonlContent = rows
-      .map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message))
-      .join("\n");
     const jsonlLines = rows.length;
 
     const pathRows = await query(
@@ -138,10 +136,12 @@ async function main(): Promise<void> {
       ? pathRows[0].path as string
       : `/sessions/unknown/${cfg.sessionId}.jsonl`;
 
-    writeFileSync(tmpJsonl, jsonlContent);
-    wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
-
-    // 2. Check for existing summary (resumed session)
+    // 2. Determine how many rows were already summarized (resumed session).
+    // The sidecar count is authoritative: finalizeSummary writes it after every
+    // successful run and it never depends on the LLM echoing a bookkeeping line
+    // back into the summary. The regex over the stored summary is only a
+    // fallback for a session first summarized on another machine (the sidecar
+    // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
     try {
       const sumRows = await query(
@@ -153,9 +153,28 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
-        wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch { /* no existing summary */ }
+    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+
+    // Feed the agent only the rows added since the last summary. Reprocessing
+    // the full session on every run is what drives ENOBUFS / 120s-timeout
+    // failures on long (4000+ event) sessions — a stuck offset re-summarizes
+    // everything from scratch.
+    const newRows = prevOffset > 0 ? rows.slice(prevOffset) : rows;
+    if (prevOffset > 0 && newRows.length === 0) {
+      wlog(`no new events since last summary (offset=${prevOffset}, total=${jsonlLines}) — skipping`);
+      return;
+    }
+    const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
+    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    if (dropped > 0) {
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+    }
+
+    writeFileSync(tmpJsonl, kept.join("\n"));
+    wlog(`found ${jsonlLines} events (${kept.length} new since offset ${prevOffset}) at ${jsonlServerPath}`);
 
     // 3. Build prompt and run codex exec
     const prompt = cfg.promptTemplate
@@ -168,6 +187,8 @@ async function main(): Promise<void> {
       .replace(/__JSONL_SERVER_PATH__/g, jsonlServerPath);
 
     wlog(`running cursor-agent --print (model=${cfg.cursorModel})`);
+    let execSucceeded = false;
+    const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
     try {
       // cursor-agent --print is the non-interactive headless mode. --force
       // auto-allows tools (matches the bypass-approvals semantic codex used).
@@ -180,17 +201,34 @@ async function main(): Promise<void> {
       execFileSync(inv.file, inv.args, {
         ...inv.options,
         timeout: 120_000,
+        // The agent streams to stdout, which execFileSync buffers. The Node
+        // default (1 MB) overflows to ENOBUFS on a verbose run, killing the
+        // summary. The summary is written to a file, not read from stdout, so
+        // we only need headroom to drain it.
+        maxBuffer: 64 * 1024 * 1024,
         env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" },
       });
+      execSucceeded = true;
       wlog("cursor-agent --print exited (code 0)");
     } catch (e: any) {
       wlog(`cursor-agent --print failed: ${e.status ?? e.message}`);
     }
 
-    // 4. Upload summary to memory table
+    // 4. Upload summary to memory table. Only advance the offset (stamp +
+    // finalize) when the agent actually produced a summary — otherwise a failed
+    // run on a resumed session would re-upload the pre-seeded old summary and
+    // slice away the new rows forever.
     if (existsSync(tmpSummary)) {
-      const text = readFileSync(tmpSummary, "utf-8");
-      if (text.trim()) {
+      const raw = readFileSync(tmpSummary, "utf-8");
+      const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
+      if (!execSucceeded && !summaryChanged) {
+        wlog("cursor-agent --print failed without producing a new summary; skipping upload");
+        return;
+      }
+      if (raw.trim()) {
+        // Stamp the offset ourselves so the persisted summary is authoritative
+        // and never depends on the LLM echoing the bookkeeping line.
+        const text = stampOffset(raw, jsonlLines);
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         // Embed the summary so it ranks in the semantic retrieval branch.

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -156,7 +156,14 @@ async function main(): Promise<void> {
         writeFileSync(tmpSummary, existing);
         hasExistingSummary = true;
       }
-    } catch { /* no existing summary */ }
+    } catch (e: any) {
+      // A genuine lookup failure (query() throws only after its own retries) is
+      // NOT the same as "no summary". Treating it as absent would slice to the
+      // newest rows and overwrite the canonical summary with a base-less one, so
+      // bail and retry on the next run instead.
+      wlog(`existing summary lookup failed: ${e.message}; skipping to avoid overwriting the base summary`);
+      return;
+    }
     // The offset only means something if we actually loaded the summary it
     // refers to. If the summary row is gone (or the read failed), slicing by a
     // stale sidecar count would drop old rows with no base summary to extend,

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -170,7 +170,7 @@ async function main(): Promise<void> {
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
     const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
-      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -143,6 +143,7 @@ async function main(): Promise<void> {
     // fallback for a session first summarized on another machine (the sidecar
     // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
+    let hasExistingSummary = false;
     try {
       const sumRows = await query(
         `SELECT summary FROM "${cfg.memoryTable}" ` +
@@ -153,10 +154,20 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
+        hasExistingSummary = true;
       }
     } catch { /* no existing summary */ }
-    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
-    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    // The offset only means something if we actually loaded the summary it
+    // refers to. If the summary row is gone (or the read failed), slicing by a
+    // stale sidecar count would drop old rows with no base summary to extend,
+    // then overwrite the canonical summary with tail-only content. No base ⇒
+    // regenerate from scratch.
+    if (!hasExistingSummary) {
+      prevOffset = 0;
+    } else {
+      const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+      if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    }
 
     // Feed the agent only the rows added since the last summary. Reprocessing
     // the full session on every run is what drives ENOBUFS / 120s-timeout
@@ -168,9 +179,12 @@ async function main(): Promise<void> {
       return;
     }
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
-    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    const { kept, dropped, truncated } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
       wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
+    }
+    if (truncated) {
+      wlog(`a single event exceeded ${WIKI_JSONL_MAX_BYTES}B — truncated it to stay within the buffer`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));
@@ -228,8 +242,10 @@ async function main(): Promise<void> {
     if (existsSync(tmpSummary)) {
       const raw = readFileSync(tmpSummary, "utf-8");
       const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
-      if (!execSucceeded && !summaryChanged) {
-        wlog("hermes -z failed without producing a new summary; skipping upload");
+      if (!execSucceeded) {
+        wlog(summaryChanged
+          ? "hermes -z failed after a partial summary write; skipping upload to avoid advancing the offset"
+          : "hermes -z failed without producing a new summary; skipping upload");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -16,7 +16,8 @@ import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmS
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { finalizeSummary, releaseLock } from "../summary-state.js";
+import { finalizeSummary, releaseLock, readState } from "../summary-state.js";
+import { capLinesByBytes, stampOffset, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
 import { EmbedClient } from "../../embeddings/client.js";
@@ -125,9 +126,6 @@ async function main(): Promise<void> {
       return;
     }
 
-    const jsonlContent = rows
-      .map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message))
-      .join("\n");
     const jsonlLines = rows.length;
 
     const pathRows = await query(
@@ -138,10 +136,12 @@ async function main(): Promise<void> {
       ? pathRows[0].path as string
       : `/sessions/unknown/${cfg.sessionId}.jsonl`;
 
-    writeFileSync(tmpJsonl, jsonlContent);
-    wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
-
-    // 2. Check for existing summary (resumed session)
+    // 2. Determine how many rows were already summarized (resumed session).
+    // The sidecar count is authoritative: finalizeSummary writes it after every
+    // successful run and it never depends on the LLM echoing a bookkeeping line
+    // back into the summary. The regex over the stored summary is only a
+    // fallback for a session first summarized on another machine (the sidecar
+    // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
     try {
       const sumRows = await query(
@@ -153,9 +153,28 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
-        wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch { /* no existing summary */ }
+    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+
+    // Feed the agent only the rows added since the last summary. Reprocessing
+    // the full session on every run is what drives ENOBUFS / 120s-timeout
+    // failures on long (4000+ event) sessions — a stuck offset re-summarizes
+    // everything from scratch.
+    const newRows = prevOffset > 0 ? rows.slice(prevOffset) : rows;
+    if (prevOffset > 0 && newRows.length === 0) {
+      wlog(`no new events since last summary (offset=${prevOffset}, total=${jsonlLines}) — skipping`);
+      return;
+    }
+    const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
+    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    if (dropped > 0) {
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+    }
+
+    writeFileSync(tmpJsonl, kept.join("\n"));
+    wlog(`found ${jsonlLines} events (${kept.length} new since offset ${prevOffset}) at ${jsonlServerPath}`);
 
     // 3. Build prompt and run codex exec
     const prompt = cfg.promptTemplate
@@ -168,6 +187,8 @@ async function main(): Promise<void> {
       .replace(/__JSONL_SERVER_PATH__/g, jsonlServerPath);
 
     wlog(`running hermes -z (provider=${cfg.hermesProvider}, model=${cfg.hermesModel})`);
+    let execSucceeded = false;
+    const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
     try {
       // hermes -z (--oneshot) is the non-interactive mode. --yolo
       // auto-approves tool use within the spawned hermes process.
@@ -187,17 +208,34 @@ async function main(): Promise<void> {
       ], {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 120_000,
+        // hermes streams to stdout, which execFileSync buffers. The Node
+        // default (1 MB) overflows to ENOBUFS on a verbose run, killing the
+        // summary. The summary is written to a file, not read from stdout, so
+        // we only need headroom to drain it.
+        maxBuffer: 64 * 1024 * 1024,
         env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" },
       });
+      execSucceeded = true;
       wlog("hermes -z exited (code 0)");
     } catch (e: any) {
       wlog(`hermes -z failed: ${e.status ?? e.message}`);
     }
 
-    // 4. Upload summary to memory table
+    // 4. Upload summary to memory table. Only advance the offset (stamp +
+    // finalize) when the agent actually produced a summary — otherwise a failed
+    // run on a resumed session would re-upload the pre-seeded old summary and
+    // slice away the new rows forever.
     if (existsSync(tmpSummary)) {
-      const text = readFileSync(tmpSummary, "utf-8");
-      if (text.trim()) {
+      const raw = readFileSync(tmpSummary, "utf-8");
+      const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
+      if (!execSucceeded && !summaryChanged) {
+        wlog("hermes -z failed without producing a new summary; skipping upload");
+        return;
+      }
+      if (raw.trim()) {
+        // Stamp the offset ourselves so the persisted summary is authoritative
+        // and never depends on the LLM echoing the bookkeeping line.
+        const text = stampOffset(raw, jsonlLines);
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         // Embed the summary so it ranks in the semantic retrieval branch.

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -175,7 +175,7 @@ async function main(): Promise<void> {
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
     const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
-      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -161,7 +161,14 @@ async function main(): Promise<void> {
         writeFileSync(tmpSummary, existing);
         hasExistingSummary = true;
       }
-    } catch { /* no existing summary */ }
+    } catch (e: any) {
+      // A genuine lookup failure (query() throws only after its own retries) is
+      // NOT the same as "no summary". Treating it as absent would slice to the
+      // newest rows and overwrite the canonical summary with a base-less one, so
+      // bail and retry on the next run instead.
+      wlog(`existing summary lookup failed: ${e.message}; skipping to avoid overwriting the base summary`);
+      return;
+    }
     // The offset only means something if we actually loaded the summary it
     // refers to. If the summary row is gone (or the read failed), slicing by a
     // stale sidecar count would drop old rows with no base summary to extend,

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -148,6 +148,7 @@ async function main(): Promise<void> {
     // fallback for a session first summarized on another machine (the sidecar
     // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
+    let hasExistingSummary = false;
     try {
       const sumRows = await query(
         `SELECT summary FROM "${cfg.memoryTable}" ` +
@@ -158,10 +159,20 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
+        hasExistingSummary = true;
       }
     } catch { /* no existing summary */ }
-    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
-    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    // The offset only means something if we actually loaded the summary it
+    // refers to. If the summary row is gone (or the read failed), slicing by a
+    // stale sidecar count would drop old rows with no base summary to extend,
+    // then overwrite the canonical summary with tail-only content. No base ⇒
+    // regenerate from scratch.
+    if (!hasExistingSummary) {
+      prevOffset = 0;
+    } else {
+      const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+      if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    }
 
     // Feed the agent only the rows added since the last summary. Reprocessing
     // the full session on every run is what drives ENOBUFS / 120s-timeout
@@ -173,9 +184,12 @@ async function main(): Promise<void> {
       return;
     }
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
-    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    const { kept, dropped, truncated } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
       wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
+    }
+    if (truncated) {
+      wlog(`a single event exceeded ${WIKI_JSONL_MAX_BYTES}B — truncated it to stay within the buffer`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));
@@ -227,8 +241,10 @@ async function main(): Promise<void> {
     if (existsSync(tmpSummary)) {
       const raw = readFileSync(tmpSummary, "utf-8");
       const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
-      if (!execSucceeded && !summaryChanged) {
-        wlog("pi --print failed without producing a new summary; skipping upload");
+      if (!execSucceeded) {
+        wlog(summaryChanged
+          ? "pi --print failed after a partial summary write; skipping upload to avoid advancing the offset"
+          : "pi --print failed without producing a new summary; skipping upload");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -21,7 +21,8 @@ import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { finalizeSummary, releaseLock } from "../summary-state.js";
+import { finalizeSummary, releaseLock, readState } from "../summary-state.js";
+import { capLinesByBytes, stampOffset, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
 import { EmbedClient } from "../../embeddings/client.js";
@@ -130,9 +131,6 @@ async function main(): Promise<void> {
       return;
     }
 
-    const jsonlContent = rows
-      .map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message))
-      .join("\n");
     const jsonlLines = rows.length;
 
     const pathRows = await query(
@@ -143,10 +141,12 @@ async function main(): Promise<void> {
       ? pathRows[0].path as string
       : `/sessions/unknown/${cfg.sessionId}.jsonl`;
 
-    writeFileSync(tmpJsonl, jsonlContent);
-    wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
-
-    // 2. Check for existing summary (resumed session)
+    // 2. Determine how many rows were already summarized (resumed session).
+    // The sidecar count is authoritative: finalizeSummary writes it after every
+    // successful run and it never depends on the LLM echoing a bookkeeping line
+    // back into the summary. The regex over the stored summary is only a
+    // fallback for a session first summarized on another machine (the sidecar
+    // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
     try {
       const sumRows = await query(
@@ -158,9 +158,28 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
-        wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch { /* no existing summary */ }
+    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+
+    // Feed the agent only the rows added since the last summary. Reprocessing
+    // the full session on every run is what drives ENOBUFS / 120s-timeout
+    // failures on long (4000+ event) sessions — a stuck offset re-summarizes
+    // everything from scratch.
+    const newRows = prevOffset > 0 ? rows.slice(prevOffset) : rows;
+    if (prevOffset > 0 && newRows.length === 0) {
+      wlog(`no new events since last summary (offset=${prevOffset}, total=${jsonlLines}) — skipping`);
+      return;
+    }
+    const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
+    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    if (dropped > 0) {
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+    }
+
+    writeFileSync(tmpJsonl, kept.join("\n"));
+    wlog(`found ${jsonlLines} events (${kept.length} new since offset ${prevOffset}) at ${jsonlServerPath}`);
 
     // 3. Build prompt and run codex exec
     const prompt = cfg.promptTemplate
@@ -173,6 +192,8 @@ async function main(): Promise<void> {
       .replace(/__JSONL_SERVER_PATH__/g, jsonlServerPath);
 
     wlog(`running pi --print (provider=${cfg.piProvider}, model=${cfg.piModel})`);
+    let execSucceeded = false;
+    const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
     try {
       // pi --print is the non-interactive mode; it bypasses extension
       // discovery (modes/print-mode.js doesn't import ExtensionRunner),
@@ -186,17 +207,34 @@ async function main(): Promise<void> {
       execFileSync(inv.file, inv.args, {
         ...inv.options,
         timeout: 120_000,
+        // pi streams to stdout, which execFileSync buffers. The Node default
+        // (1 MB) overflows to ENOBUFS on a verbose run, killing the summary.
+        // The summary is written to a file, not read from stdout, so we only
+        // need headroom to drain it.
+        maxBuffer: 64 * 1024 * 1024,
         env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" },
       });
+      execSucceeded = true;
       wlog("pi --print exited (code 0)");
     } catch (e: any) {
       wlog(`pi --print failed: ${e.status ?? e.message}`);
     }
 
-    // 4. Upload summary to memory table
+    // 4. Upload summary to memory table. Only advance the offset (stamp +
+    // finalize) when the agent actually produced a summary — otherwise a failed
+    // run on a resumed session would re-upload the pre-seeded old summary and
+    // slice away the new rows forever.
     if (existsSync(tmpSummary)) {
-      const text = readFileSync(tmpSummary, "utf-8");
-      if (text.trim()) {
+      const raw = readFileSync(tmpSummary, "utf-8");
+      const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
+      if (!execSucceeded && !summaryChanged) {
+        wlog("pi --print failed without producing a new summary; skipping upload");
+        return;
+      }
+      if (raw.trim()) {
+        // Stamp the offset ourselves so the persisted summary is authoritative
+        // and never depends on the LLM echoing the bookkeeping line.
+        const text = stampOffset(raw, jsonlLines);
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         // Embed the summary so it ranks in the semantic retrieval branch.

--- a/src/hooks/wiki-offset.ts
+++ b/src/hooks/wiki-offset.ts
@@ -46,6 +46,15 @@ export function stampOffset(summary: string, offset: number): string {
  * line even if it alone exceeds the budget. Returns the kept lines (in original
  * order) and how many were dropped, so the caller can log it — never a silent
  * truncation.
+ *
+ * INTENTIONAL TRADEOFF: the workers advance the offset to the full row total
+ * even when `dropped > 0`, so the dropped (oldest) rows are NOT re-summarized on
+ * a later run. This only fires in a degenerate case — a single increment over
+ * `maxBytes`, i.e. the first summary of an already-huge backlog (offset 0) or a
+ * lone giant row. With a correct offset, normal increments are tiny and nothing
+ * is ever dropped. In the rare overflow we deliberately keep the most RECENT
+ * content (the useful "current state" for resuming) over exhaustive coverage of
+ * ancient rows, and log the skip.
  */
 export function capLinesByBytes(lines: string[], maxBytes: number): { kept: string[]; dropped: number } {
   if (lines.length === 0) return { kept: [], dropped: 0 };

--- a/src/hooks/wiki-offset.ts
+++ b/src/hooks/wiki-offset.ts
@@ -18,12 +18,14 @@
 /** Max bytes of session JSONL fed to the summarizer in one run. */
 export const WIKI_JSONL_MAX_BYTES = 4 * 1024 * 1024;
 
-/** Matches the offset line in a stored summary, regardless of leading bullet. */
-const OFFSET_RE = /\*\*JSONL offset\*\*:\s*\d+/;
+/** Matches the offset line in a stored summary, regardless of leading bullet.
+ *  Single source of truth for both detection (stampOffset) and extraction
+ *  (parseOffset) so the round-trip contract can't drift. */
+const OFFSET_RE = /\*\*JSONL offset\*\*:\s*(\d+)/;
 
 /** Same pattern used by the workers to READ the offset back. */
 export function parseOffset(summary: string): number | null {
-  const m = summary.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
+  const m = summary.match(OFFSET_RE);
   return m ? parseInt(m[1], 10) : null;
 }
 
@@ -55,9 +57,15 @@ export function stampOffset(summary: string, offset: number): string {
  * is ever dropped. In the rare overflow we deliberately keep the most RECENT
  * content (the useful "current state" for resuming) over exhaustive coverage of
  * ancient rows, and log the skip.
+ *
+ * A single retained line can itself exceed `maxBytes` (one giant event, e.g. a
+ * huge tool output). We keep it but truncate its bytes so the JSONL handed to
+ * the agent is always bounded — otherwise a lone oversized row would reopen the
+ * timeout risk this cap exists to prevent. `truncated` reports whether that
+ * happened so the caller can log it.
  */
-export function capLinesByBytes(lines: string[], maxBytes: number): { kept: string[]; dropped: number } {
-  if (lines.length === 0) return { kept: [], dropped: 0 };
+export function capLinesByBytes(lines: string[], maxBytes: number): { kept: string[]; dropped: number; truncated: boolean } {
+  if (lines.length === 0) return { kept: [], dropped: 0, truncated: false };
   let start = lines.length - 1;
   let total = Buffer.byteLength(lines[start], "utf8");
   for (let i = lines.length - 2; i >= 0; i--) {
@@ -66,5 +74,22 @@ export function capLinesByBytes(lines: string[], maxBytes: number): { kept: stri
     total += size;
     start = i;
   }
-  return { kept: lines.slice(start), dropped: start };
+  const kept = lines.slice(start);
+  // Only a lone retained line can still exceed the budget (the loop keeps
+  // cumulative size within maxBytes for every other case). Truncate it.
+  let truncated = false;
+  if (kept.length === 1 && Buffer.byteLength(kept[0], "utf8") > maxBytes) {
+    kept[0] = truncateUtf8(kept[0], maxBytes);
+    truncated = true;
+  }
+  return { kept, dropped: start, truncated };
+}
+
+/** Truncate `s` to at most `maxBytes` UTF-8 bytes, dropping any partial
+ *  trailing multibyte character cleanly. */
+function truncateUtf8(s: string, maxBytes: number): string {
+  const buf = Buffer.from(s, "utf8");
+  if (buf.length <= maxBytes) return s;
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  return decoder.decode(buf.subarray(0, maxBytes)).replace(/�+$/, "");
 }

--- a/src/hooks/wiki-offset.ts
+++ b/src/hooks/wiki-offset.ts
@@ -1,0 +1,61 @@
+/**
+ * Offset bookkeeping for the wiki summary workers.
+ *
+ * The summary is regenerated incrementally: each run reads how many session
+ * rows were already summarized (the offset) and feeds the agent only the rows
+ * after it. Two helpers keep that offset stable and the input bounded:
+ *
+ *  - `stampOffset` writes the offset into the persisted summary itself, so the
+ *    value never depends on the LLM echoing a bookkeeping line back. The
+ *    sidecar (summary-state) is the primary source of truth; this keeps the
+ *    stored summary's offset authoritative too (the cross-machine fallback).
+ *  - `capLinesByBytes` bounds the JSONL handed to the agent by byte size,
+ *    keeping the MOST RECENT rows. The offset already bounds a normal run to
+ *    its increment; this is the safety net for the first summary of an
+ *    already-huge session, or a single giant row.
+ */
+
+/** Max bytes of session JSONL fed to the summarizer in one run. */
+export const WIKI_JSONL_MAX_BYTES = 4 * 1024 * 1024;
+
+/** Matches the offset line in a stored summary, regardless of leading bullet. */
+const OFFSET_RE = /\*\*JSONL offset\*\*:\s*\d+/;
+
+/** Same pattern used by the workers to READ the offset back. */
+export function parseOffset(summary: string): number | null {
+  const m = summary.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/**
+ * Return `summary` with its `**JSONL offset**: N` line set to `offset`.
+ * Replaces an existing line (preserving its leading bullet) or, if none is
+ * present, inserts one right after the title line.
+ */
+export function stampOffset(summary: string, offset: number): string {
+  const line = `**JSONL offset**: ${offset}`;
+  if (OFFSET_RE.test(summary)) return summary.replace(OFFSET_RE, line);
+  const nl = summary.indexOf("\n");
+  if (nl === -1) return `${summary}\n- ${line}\n`;
+  return `${summary.slice(0, nl + 1)}- ${line}\n${summary.slice(nl + 1)}`;
+}
+
+/**
+ * Keep the newest lines whose total serialized size (with `\n` separators)
+ * stays within `maxBytes`, dropping the oldest. Always keeps at least the last
+ * line even if it alone exceeds the budget. Returns the kept lines (in original
+ * order) and how many were dropped, so the caller can log it — never a silent
+ * truncation.
+ */
+export function capLinesByBytes(lines: string[], maxBytes: number): { kept: string[]; dropped: number } {
+  if (lines.length === 0) return { kept: [], dropped: 0 };
+  let start = lines.length - 1;
+  let total = Buffer.byteLength(lines[start], "utf8");
+  for (let i = lines.length - 2; i >= 0; i--) {
+    const size = Buffer.byteLength(lines[i], "utf8") + 1;
+    if (total + size > maxBytes) break;
+    total += size;
+    start = i;
+  }
+  return { kept: lines.slice(start), dropped: start };
+}

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -210,7 +210,7 @@ async function main(): Promise<void> {
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
     const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
-      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -196,7 +196,14 @@ async function main(): Promise<void> {
         writeFileSync(tmpSummary, existing);
         hasExistingSummary = true;
       }
-    } catch { /* no existing summary */ }
+    } catch (e: any) {
+      // A genuine lookup failure (query() throws only after its own retries) is
+      // NOT the same as "no summary". Treating it as absent would slice to the
+      // newest rows and overwrite the canonical summary with a base-less one, so
+      // bail and retry on the next run instead.
+      wlog(`existing summary lookup failed: ${e.message}; skipping to avoid overwriting the base summary`);
+      return;
+    }
     // The offset only means something if we actually loaded the summary it
     // refers to. If the summary row is gone (or the read failed), slicing by a
     // stale sidecar count would drop old rows with no base summary to extend,

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -183,6 +183,7 @@ async function main(): Promise<void> {
     // fallback for a session first summarized on another machine (the sidecar
     // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
+    let hasExistingSummary = false;
     try {
       const sumRows = await query(
         `SELECT summary FROM "${cfg.memoryTable}" ` +
@@ -193,10 +194,20 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
+        hasExistingSummary = true;
       }
     } catch { /* no existing summary */ }
-    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
-    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    // The offset only means something if we actually loaded the summary it
+    // refers to. If the summary row is gone (or the read failed), slicing by a
+    // stale sidecar count would drop old rows with no base summary to extend,
+    // then overwrite the canonical summary with tail-only content. No base ⇒
+    // regenerate from scratch.
+    if (!hasExistingSummary) {
+      prevOffset = 0;
+    } else {
+      const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+      if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+    }
 
     // Feed claude only the rows added since the last summary. Reprocessing the
     // full session on every run is what drives ENOBUFS / 120s-timeout failures
@@ -208,9 +219,12 @@ async function main(): Promise<void> {
       return;
     }
     const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
-    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    const { kept, dropped, truncated } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
     if (dropped > 0) {
       wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — summarizing newest ${kept.length}, permanently skipping ${dropped} older rows`);
+    }
+    if (truncated) {
+      wlog(`a single event exceeded ${WIKI_JSONL_MAX_BYTES}B — truncated it to stay within the buffer`);
     }
 
     writeFileSync(tmpJsonl, kept.join("\n"));
@@ -254,8 +268,10 @@ async function main(): Promise<void> {
     if (existsSync(tmpSummary)) {
       const raw = readFileSync(tmpSummary, "utf-8");
       const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
-      if (!execSucceeded && !summaryChanged) {
-        wlog("claude -p failed without producing a new summary; skipping upload");
+      if (!execSucceeded) {
+        wlog(summaryChanged
+          ? "claude -p failed after a partial summary write; skipping upload to avoid advancing the offset"
+          : "claude -p failed without producing a new summary; skipping upload");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -16,7 +16,8 @@ import { utcTimestamp, log as _log } from "../utils/debug.js";
 import { deeplakeClientHeader } from "../utils/client-header.js";
 
 const dlog = (msg: string) => _log("wiki-worker", msg);
-import { finalizeSummary, releaseLock } from "./summary-state.js";
+import { finalizeSummary, releaseLock, readState } from "./summary-state.js";
+import { capLinesByBytes, stampOffset, WIKI_JSONL_MAX_BYTES } from "./wiki-offset.js";
 import { uploadSummary } from "./upload-summary.js";
 import { embedSummaryWithWarmup } from "../embeddings/embed-summary.js";
 import { embeddingsDisabled } from "../embeddings/disable.js";
@@ -164,10 +165,6 @@ async function main(): Promise<void> {
       return;
     }
 
-    // Reconstruct JSONL from individual rows (message is JSONB — may be object or string)
-    const jsonlContent = rows
-      .map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message))
-      .join("\n");
     const jsonlLines = rows.length;
 
     // Derive the server path
@@ -179,10 +176,12 @@ async function main(): Promise<void> {
       ? pathRows[0].path as string
       : `/sessions/unknown/${cfg.sessionId}.jsonl`;
 
-    writeFileSync(tmpJsonl, jsonlContent);
-    wlog(`found ${jsonlLines} events at ${jsonlServerPath}`);
-
-    // 2. Check for existing summary in memory table (resumed session)
+    // 2. Determine how many rows were already summarized (resumed session).
+    // The sidecar count is authoritative: finalizeSummary writes it after every
+    // successful run and it never depends on the LLM echoing a bookkeeping line
+    // back into the summary. The regex over the stored summary is only a
+    // fallback for a session first summarized on another machine (the sidecar
+    // lives under ~/.claude/hooks and does not travel).
     let prevOffset = 0;
     try {
       const sumRows = await query(
@@ -194,9 +193,28 @@ async function main(): Promise<void> {
         const match = existing.match(/\*\*JSONL offset\*\*:\s*(\d+)/);
         if (match) prevOffset = parseInt(match[1], 10);
         writeFileSync(tmpSummary, existing);
-        wlog(`existing summary found, offset=${prevOffset}`);
       }
     } catch { /* no existing summary */ }
+    const sidecarCount = readState(cfg.sessionId)?.lastSummaryCount ?? 0;
+    if (sidecarCount > prevOffset) prevOffset = sidecarCount;
+
+    // Feed claude only the rows added since the last summary. Reprocessing the
+    // full session on every run is what drives ENOBUFS / 120s-timeout failures
+    // on long (4000+ event) sessions — a stuck offset re-summarizes everything.
+    // Reconstruct JSONL from individual rows (message is JSONB — may be object or string)
+    const newRows = prevOffset > 0 ? rows.slice(prevOffset) : rows;
+    if (prevOffset > 0 && newRows.length === 0) {
+      wlog(`no new events since last summary (offset=${prevOffset}, total=${jsonlLines}) — skipping`);
+      return;
+    }
+    const newLines = newRows.map(r => typeof r.message === "string" ? r.message : JSON.stringify(r.message));
+    const { kept, dropped } = capLinesByBytes(newLines, WIKI_JSONL_MAX_BYTES);
+    if (dropped > 0) {
+      wlog(`new rows exceed ${WIKI_JSONL_MAX_BYTES}B — kept newest ${kept.length}, dropped ${dropped} oldest`);
+    }
+
+    writeFileSync(tmpJsonl, kept.join("\n"));
+    wlog(`found ${jsonlLines} events (${kept.length} new since offset ${prevOffset}) at ${jsonlServerPath}`);
 
     // 3. Build prompt and run claude -p
     const prompt = cfg.promptTemplate
@@ -209,22 +227,41 @@ async function main(): Promise<void> {
       .replace(/__JSONL_SERVER_PATH__/g, jsonlServerPath);
 
     wlog("running claude -p");
+    let execSucceeded = false;
+    const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
     try {
       const inv = buildClaudeInvocation(cfg.claudeBin, prompt);
       execFileSync(inv.file, inv.args, {
         ...inv.options,
         timeout: 120_000,
+        // claude -p streams to stdout, which execFileSync buffers. The Node
+        // default (1 MB) overflows to ENOBUFS on a verbose run, killing the
+        // summary. The summary is written to a file, not read from stdout, so
+        // we only need headroom to drain it.
+        maxBuffer: 64 * 1024 * 1024,
         env: { ...process.env, HIVEMIND_WIKI_WORKER: "1", HIVEMIND_CAPTURE: "false" },
       });
+      execSucceeded = true;
       wlog("claude -p exited (code 0)");
     } catch (e: any) {
       wlog(`claude -p failed: ${e.status ?? e.message}`);
     }
 
-    // 4. Upload summary to memory table
+    // 4. Upload summary to memory table. Only advance the offset (stamp +
+    // finalize) when claude actually produced a summary — otherwise a failed
+    // run on a resumed session would re-upload the pre-seeded old summary and
+    // slice away the new rows forever.
     if (existsSync(tmpSummary)) {
-      const text = readFileSync(tmpSummary, "utf-8");
-      if (text.trim()) {
+      const raw = readFileSync(tmpSummary, "utf-8");
+      const summaryChanged = summaryBeforeExec === null ? raw.trim().length > 0 : raw !== summaryBeforeExec;
+      if (!execSucceeded && !summaryChanged) {
+        wlog("claude -p failed without producing a new summary; skipping upload");
+        return;
+      }
+      if (raw.trim()) {
+        // Stamp the offset ourselves so the persisted summary is authoritative
+        // and never depends on the LLM echoing the bookkeeping line.
+        const text = stampOffset(raw, jsonlLines);
         const fname = `${cfg.sessionId}.md`;
         const vpath = `/summaries/${cfg.userName}/${fname}`;
         // Embed the summary so it ranks in the semantic retrieval branch.

--- a/tests/claude-code/wiki-worker-plugin-version.test.ts
+++ b/tests/claude-code/wiki-worker-plugin-version.test.ts
@@ -24,6 +24,7 @@ import { join } from "node:path";
 
 const finalizeSummaryMock = vi.fn();
 const releaseLockMock = vi.fn();
+const readStateMock = vi.fn();
 const uploadSummaryMock = vi.fn();
 const execFileSyncMock = vi.fn();
 const embedSummaryMock = vi.fn();
@@ -34,6 +35,7 @@ const originalArgv2 = process.argv[2];
 vi.mock("../../src/hooks/summary-state.js", () => ({
   finalizeSummary: (...a: any[]) => finalizeSummaryMock(...a),
   releaseLock: (...a: any[]) => releaseLockMock(...a),
+  readState: (...a: any[]) => readStateMock(...a),
 }));
 vi.mock("../../src/hooks/upload-summary.js", () => ({
   uploadSummary: (...a: any[]) => uploadSummaryMock(...a),
@@ -100,6 +102,7 @@ beforeEach(() => {
   fetchMock.mockReset();
   finalizeSummaryMock.mockReset();
   releaseLockMock.mockReset();
+  readStateMock.mockReset().mockReturnValue(null);
   uploadSummaryMock.mockReset().mockResolvedValue({ path: "insert", summaryLength: 100, descLength: 20, sql: "..." });
   embedSummaryMock.mockReset().mockResolvedValue([0.1, 0.2, 0.3]);
   // execFileSync stub: simulate the LLM by writing the summary file the
@@ -296,9 +299,14 @@ describe("wiki-worker resume + embeddings-disabled branches — per agent", () =
       fetchMock.mockImplementation(async (_url: string, init: any) => {
         const sql = JSON.parse(init.body).query as string;
         if (sql.startsWith("SELECT message, creation_date")) {
+          // 43 rows so the offset-42 resume baseline still leaves 1 new row to
+          // summarize (otherwise the worker correctly skips a no-new-rows run).
           return jsonResp({
             columns: ["message", "creation_date"],
-            rows: [[JSON.stringify({ type: "user_message", content: "hi" }), "2026-04-20T00:00:00Z"]],
+            rows: Array.from({ length: 43 }, (_, i) => [
+              JSON.stringify({ type: "user_message", content: `hi ${i}` }),
+              "2026-04-20T00:00:00Z",
+            ]),
           });
         }
         if (sql.startsWith("SELECT DISTINCT path")) {

--- a/tests/claude-code/wiki-worker.test.ts
+++ b/tests/claude-code/wiki-worker.test.ts
@@ -25,6 +25,7 @@ import { join } from "node:path";
 
 const finalizeSummaryMock = vi.fn();
 const releaseLockMock = vi.fn();
+const readStateMock = vi.fn();
 const uploadSummaryMock = vi.fn();
 const execFileSyncMock = vi.fn();
 const embedSummaryMock = vi.fn();
@@ -32,6 +33,7 @@ const embedSummaryMock = vi.fn();
 vi.mock("../../src/hooks/summary-state.js", () => ({
   finalizeSummary: (...a: any[]) => finalizeSummaryMock(...a),
   releaseLock: (...a: any[]) => releaseLockMock(...a),
+  readState: (...a: any[]) => readStateMock(...a),
 }));
 vi.mock("../../src/hooks/upload-summary.js", () => ({
   uploadSummary: (...a: any[]) => uploadSummaryMock(...a),
@@ -111,6 +113,7 @@ beforeEach(() => {
   fetchMock.mockReset();
   finalizeSummaryMock.mockReset();
   releaseLockMock.mockReset();
+  readStateMock.mockReset().mockReturnValue(null);
   uploadSummaryMock.mockReset().mockResolvedValue({ path: "insert", summaryLength: 100, descLength: 20, sql: "..." });
   embedSummaryMock.mockReset().mockResolvedValue([0.1, 0.2, 0.3]);
   execFileSyncMock.mockReset();
@@ -222,12 +225,16 @@ describe("wiki-worker — happy path", () => {
     { message: JSON.stringify({ type: "assistant_message", content: "hello" }), creation_date: "2026-04-20T00:00:01Z" },
   ];
 
-  const mkFetch = (eventsCol: string[] = ["message", "creation_date"], pathRows = 1, hasSummary = false) => {
+  const mkFetch = (eventsCol: string[] = ["message", "creation_date"], pathRows = 1, hasSummary = false, eventCount = 0) => {
+    const manyRows = Array.from({ length: eventCount }, (_, i) => [
+      JSON.stringify({ type: "user_message", content: `event ${i}` }),
+      "2026-04-20T00:00:00Z",
+    ]);
     let call = 0;
     return fetchMock.mockImplementation(async (_url: string, init: any) => {
       const sql = JSON.parse(init.body).query as string;
       if (sql.startsWith("SELECT message, creation_date")) {
-        return jsonResp({ columns: eventsCol, rows: eventRows.map(r => [r.message, r.creation_date]) });
+        return jsonResp({ columns: eventsCol, rows: eventCount > 0 ? manyRows : eventRows.map(r => [r.message, r.creation_date]) });
       }
       if (sql.startsWith("SELECT DISTINCT path")) {
         return jsonResp({
@@ -302,20 +309,64 @@ describe("wiki-worker — happy path", () => {
     expect(releaseLockMock).toHaveBeenCalledWith("sid-worker");
   });
 
-  it("parses JSONL offset from an existing summary on a resumed session", async () => {
-    mkFetch(undefined, 1, true);
+  it("parses JSONL offset from an existing summary and feeds only new rows", async () => {
+    // 14 total rows, existing summary offset 12 → only rows 13 and 14 are new.
+    mkFetch(undefined, 1, true, 14);
+    let capturedJsonl: string | null = null;
     execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
-      const summaryPath = args[1].match(/SUMMARY=(\S+)/)![1];
+      const prompt = args[args.indexOf("-p") + 1];
+      capturedJsonl = readFileSync(prompt.match(/JSONL=(\S+)/)![1], "utf-8");
+      const summaryPath = prompt.match(/SUMMARY=(\S+)/)![1];
       writeFileSync(summaryPath, "# Session sid-worker\n\n## What Happened\ndone.\n");
       return Buffer.from("");
     });
     await runWorker();
-    const prompt = execFileSyncMock.mock.calls[0][1][1] as string;
+    const prompt = execFileSyncMock.mock.calls[0][1][execFileSyncMock.mock.calls[0][1].indexOf("-p") + 1] as string;
     expect(prompt).toContain("OFFSET=12");
-    // tmpSummary was pre-seeded with the existing summary so claude -p
-    // can merge on top. Verify the worker did write it.
+    // Only the rows after the offset reach the JSONL — not the full session.
+    expect(capturedJsonl!.trim().split("\n")).toHaveLength(2);
+    expect(capturedJsonl).toContain("event 12");
+    expect(capturedJsonl).toContain("event 13");
+    expect(capturedJsonl).not.toContain("event 0");
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("existing summary found, offset=12");
+    expect(log).toContain("14 events (2 new since offset 12)");
+  });
+
+  it("caps the claude -p output buffer so a verbose run can't ENOBUFS", async () => {
+    mkFetch();
+    execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
+      writeFileSync(args[args.indexOf("-p") + 1].match(/SUMMARY=(\S+)/)![1], "# s\n\n## What Happened\nx\n");
+      return Buffer.from("");
+    });
+    await runWorker();
+    const execOpts = execFileSyncMock.mock.calls[0][2];
+    expect(execOpts.maxBuffer).toBeGreaterThanOrEqual(64 * 1024 * 1024);
+  });
+
+  it("skips claude -p when the sidecar offset already covers every row", async () => {
+    mkFetch(undefined, 1, false, 5);
+    readStateMock.mockReturnValue({ lastSummaryAt: 0, lastSummaryCount: 5, totalCount: 5 });
+    await runWorker();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("no new events since last summary");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-worker");
+  });
+
+  it("does NOT advance the offset when claude -p fails on a resumed session", async () => {
+    // 14 rows, existing summary offset 12 → 2 new rows (so it doesn't skip),
+    // but claude -p throws. The pre-seeded old summary must NOT be re-uploaded
+    // and finalizeSummary must NOT run — otherwise the 2 new rows would be
+    // sliced away forever on the next run.
+    mkFetch(undefined, 1, true, 14);
+    execFileSyncMock.mockImplementation(() => { throw new Error("boom"); });
+    await runWorker();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    expect(finalizeSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("failed without producing a new summary");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-worker");
   });
 
   it("defaults to /sessions/unknown/ when the path SELECT returns no rows", async () => {

--- a/tests/claude-code/wiki-worker.test.ts
+++ b/tests/claude-code/wiki-worker.test.ts
@@ -343,9 +343,9 @@ describe("wiki-worker — happy path", () => {
     expect(execOpts.maxBuffer).toBeGreaterThanOrEqual(64 * 1024 * 1024);
   });
 
-  it("skips claude -p when the sidecar offset already covers every row", async () => {
-    mkFetch(undefined, 1, false, 5);
-    readStateMock.mockReturnValue({ lastSummaryAt: 0, lastSummaryCount: 5, totalCount: 5 });
+  it("skips claude -p when the resumed offset already covers every row", async () => {
+    // Existing summary (offset 12) present + only 5 rows → nothing new to add.
+    mkFetch(undefined, 1, true, 5);
     await runWorker();
     expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(uploadSummaryMock).not.toHaveBeenCalled();

--- a/tests/codex/codex-wiki-worker.test.ts
+++ b/tests/codex/codex-wiki-worker.test.ts
@@ -286,6 +286,27 @@ describe("codex wiki-worker — happy path", () => {
     expect(prompt).toContain("OFFSET=0");
   });
 
+  it("skips the run when the existing-summary lookup fails (no overwrite)", async () => {
+    // A transient failure of the summary SELECT must NOT be read as "no summary"
+    // — that would regenerate from scratch and overwrite the canonical summary.
+    fetchMock.mockImplementation(async (_url: string, init: any) => {
+      const sql = JSON.parse(init.body).query as string;
+      if (sql.startsWith("SELECT message, creation_date")) {
+        return jsonResp({ columns: ["message", "creation_date"], rows: [[JSON.stringify({ type: "user_message", content: "hi" }), "t"]] });
+      }
+      if (sql.startsWith("SELECT DISTINCT path")) return jsonResp({ columns: ["path"], rows: [["/x.jsonl"]] });
+      if (sql.startsWith("SELECT summary FROM")) throw new Error("db down");
+      return jsonResp({ columns: [], rows: [] });
+    });
+    await runWorker();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    expect(finalizeSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("existing summary lookup failed");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
+  });
+
   it("falls back to /sessions/unknown/ when path SELECT empty", async () => {
     mkFetch(0);
     execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {

--- a/tests/codex/codex-wiki-worker.test.ts
+++ b/tests/codex/codex-wiki-worker.test.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 
 const finalizeSummaryMock = vi.fn();
 const releaseLockMock = vi.fn();
+const readStateMock = vi.fn();
 const uploadSummaryMock = vi.fn();
 const execFileSyncMock = vi.fn();
 const embedSummaryMock = vi.fn();
@@ -24,6 +25,7 @@ const embedSummaryMock = vi.fn();
 vi.mock("../../src/hooks/summary-state.js", () => ({
   finalizeSummary: (...a: any[]) => finalizeSummaryMock(...a),
   releaseLock: (...a: any[]) => releaseLockMock(...a),
+  readState: (...a: any[]) => readStateMock(...a),
 }));
 vi.mock("../../src/hooks/upload-summary.js", () => ({
   uploadSummary: (...a: any[]) => uploadSummaryMock(...a),
@@ -98,6 +100,7 @@ beforeEach(() => {
   fetchMock.mockReset();
   finalizeSummaryMock.mockReset();
   releaseLockMock.mockReset();
+  readStateMock.mockReset().mockReturnValue(null);
   uploadSummaryMock.mockReset().mockResolvedValue({ path: "insert", summaryLength: 80, descLength: 15, sql: "..." });
   embedSummaryMock.mockReset().mockResolvedValue([0.1, 0.2, 0.3]);
   execFileSyncMock.mockReset();
@@ -137,11 +140,15 @@ describe("codex wiki-worker — happy path", () => {
     { message: JSON.stringify({ type: "user_message", content: "hello codex" }), creation_date: "2026-04-20T00:00:00Z" },
   ];
 
-  const mkFetch = (pathRows = 1, hasSummary = false) => {
+  const mkFetch = (pathRows = 1, hasSummary = false, eventCount = 1) => {
+    const rows = Array.from({ length: eventCount }, (_, i) => [
+      JSON.stringify({ type: "user_message", content: `hello codex ${i}` }),
+      "2026-04-20T00:00:00Z",
+    ]);
     return fetchMock.mockImplementation(async (_url: string, init: any) => {
       const sql = JSON.parse(init.body).query as string;
       if (sql.startsWith("SELECT message, creation_date")) {
-        return jsonResp({ columns: ["message", "creation_date"], rows: eventRow.map(r => [r.message, r.creation_date]) });
+        return jsonResp({ columns: ["message", "creation_date"], rows: eventCount === 1 ? eventRow.map(r => [r.message, r.creation_date]) : rows });
       }
       if (sql.startsWith("SELECT DISTINCT path")) {
         return jsonResp({
@@ -189,15 +196,21 @@ describe("codex wiki-worker — happy path", () => {
     const params = uploadSummaryMock.mock.calls[0][1];
     expect(params.agent).toBe("codex");
     expect(params.sessionId).toBe("sid-codex");
+    // The worker stamps the offset itself — the uploaded summary carries it
+    // even though the fake codex output above never wrote the bookkeeping line.
+    expect(params.text).toContain("**JSONL offset**: 1");
 
     expect(finalizeSummaryMock).toHaveBeenCalledWith("sid-codex", 1);
     expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
   });
 
-  it("parses JSONL offset from an existing summary on resumed session", async () => {
-    mkFetch(1, true);
+  it("parses JSONL offset from an existing summary and feeds only new rows", async () => {
+    // 9 total rows, existing summary offset 7 → only rows 8 and 9 are new.
+    mkFetch(1, true, 9);
+    let capturedJsonl: string | null = null;
     execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
       const prompt = args[2];
+      capturedJsonl = readFileSync(prompt.match(/JSONL=(\S+)/)![1], "utf-8");
       const summaryPath = prompt.match(/SUMMARY=(\S+)/)![1];
       writeFileSync(summaryPath, "# updated\n\n## What Happened\n...\n");
       return Buffer.from("");
@@ -205,8 +218,36 @@ describe("codex wiki-worker — happy path", () => {
     await runWorker();
     const prompt = execFileSyncMock.mock.calls[0][1][2] as string;
     expect(prompt).toContain("OFFSET=7");
+    // Only the rows after the offset reach the JSONL — not the full session.
+    expect(capturedJsonl!.trim().split("\n")).toHaveLength(2);
+    expect(capturedJsonl).toContain("hello codex 7");
+    expect(capturedJsonl).toContain("hello codex 8");
+    expect(capturedJsonl).not.toContain("hello codex 0");
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("existing summary found, offset=7");
+    expect(log).toContain("9 events (2 new since offset 7)");
+  });
+
+  it("caps the codex exec output buffer so a verbose run can't ENOBUFS", async () => {
+    mkFetch();
+    execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
+      writeFileSync(args[2].match(/SUMMARY=(\S+)/)![1], "# s\n\n## What Happened\nx\n");
+      return Buffer.from("");
+    });
+    await runWorker();
+    const execOpts = execFileSyncMock.mock.calls[0][2];
+    expect(execOpts.maxBuffer).toBeGreaterThanOrEqual(64 * 1024 * 1024);
+  });
+
+  it("skips codex exec when the sidecar offset already covers every row", async () => {
+    // 3 rows total, but the sidecar says 3 were already summarized → nothing new.
+    mkFetch(1, false, 3);
+    readStateMock.mockReturnValue({ lastSummaryAt: 0, lastSummaryCount: 3, totalCount: 3 });
+    await runWorker();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("no new events since last summary");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
   });
 
   it("falls back to /sessions/unknown/ when path SELECT empty", async () => {

--- a/tests/codex/codex-wiki-worker.test.ts
+++ b/tests/codex/codex-wiki-worker.test.ts
@@ -238,16 +238,52 @@ describe("codex wiki-worker — happy path", () => {
     expect(execOpts.maxBuffer).toBeGreaterThanOrEqual(64 * 1024 * 1024);
   });
 
-  it("skips codex exec when the sidecar offset already covers every row", async () => {
-    // 3 rows total, but the sidecar says 3 were already summarized → nothing new.
-    mkFetch(1, false, 3);
-    readStateMock.mockReturnValue({ lastSummaryAt: 0, lastSummaryCount: 3, totalCount: 3 });
+  it("skips codex exec when the resumed offset already covers every row", async () => {
+    // Existing summary (offset 7) present + only 3 rows → nothing new to add.
+    mkFetch(1, true, 3);
     await runWorker();
     expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
     expect(log).toContain("no new events since last summary");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
+  });
+
+  it("does NOT advance the offset when codex exec fails after a partial write", async () => {
+    // Resumed session (offset 7, 9 rows → 2 new) where codex writes a PARTIAL
+    // summary and then fails: the changed file must NOT be uploaded/finalized,
+    // or the offset would jump past rows that were never fully summarized.
+    mkFetch(1, true, 9);
+    execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
+      writeFileSync(args[2].match(/SUMMARY=(\S+)/)![1], "# partial\n\n## What Happened\nhalf...\n");
+      throw new Error("timeout");
+    });
+    await runWorker();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    expect(finalizeSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("failed after a partial summary write");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
+  });
+
+  it("ignores a stale sidecar offset when no existing summary was loaded", async () => {
+    // Sidecar says 3 processed, but SELECT summary returns nothing (row gone).
+    // Without a base summary the offset is meaningless — regenerate from scratch
+    // over ALL rows rather than slicing away the first 3.
+    mkFetch(1, false, 3);
+    readStateMock.mockReturnValue({ lastSummaryAt: 0, lastSummaryCount: 3, totalCount: 3 });
+    let capturedJsonl: string | null = null;
+    execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
+      capturedJsonl = readFileSync(args[2].match(/JSONL=(\S+)/)![1], "utf-8");
+      writeFileSync(args[2].match(/SUMMARY=(\S+)/)![1], "# s\n\n## What Happened\nx\n");
+      return Buffer.from("");
+    });
+    await runWorker();
+    expect(execFileSyncMock).toHaveBeenCalledOnce();
+    // All 3 rows fed (offset treated as 0), not sliced down to zero-new → skip.
+    expect(capturedJsonl!.trim().split("\n")).toHaveLength(3);
+    const prompt = execFileSyncMock.mock.calls[0][1][2] as string;
+    expect(prompt).toContain("OFFSET=0");
   });
 
   it("falls back to /sessions/unknown/ when path SELECT empty", async () => {

--- a/tests/cursor/cursor-wiki-worker.test.ts
+++ b/tests/cursor/cursor-wiki-worker.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 
 const finalizeSummaryMock = vi.fn();
 const releaseLockMock = vi.fn();
+const readStateMock = vi.fn();
 const uploadSummaryMock = vi.fn();
 const execFileSyncMock = vi.fn();
 const embedSummaryMock = vi.fn();
@@ -19,6 +20,7 @@ const embedSummaryMock = vi.fn();
 vi.mock("../../src/hooks/summary-state.js", () => ({
   finalizeSummary: (...a: any[]) => finalizeSummaryMock(...a),
   releaseLock: (...a: any[]) => releaseLockMock(...a),
+  readState: (...a: any[]) => readStateMock(...a),
 }));
 vi.mock("../../src/hooks/upload-summary.js", () => ({
   uploadSummary: (...a: any[]) => uploadSummaryMock(...a),
@@ -91,6 +93,7 @@ beforeEach(() => {
   fetchMock.mockReset();
   finalizeSummaryMock.mockReset();
   releaseLockMock.mockReset();
+  readStateMock.mockReset().mockReturnValue(null);
   uploadSummaryMock.mockReset().mockResolvedValue({ path: "insert", summaryLength: 80, descLength: 15, sql: "..." });
   embedSummaryMock.mockReset().mockResolvedValue([0.1, 0.2, 0.3]);
   execFileSyncMock.mockReset();

--- a/tests/hermes/hermes-wiki-worker.test.ts
+++ b/tests/hermes/hermes-wiki-worker.test.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 
 const finalizeSummaryMock = vi.fn();
 const releaseLockMock = vi.fn();
+const readStateMock = vi.fn();
 const uploadSummaryMock = vi.fn();
 const execFileSyncMock = vi.fn();
 const embedSummaryMock = vi.fn();
@@ -20,6 +21,7 @@ const embedSummaryMock = vi.fn();
 vi.mock("../../src/hooks/summary-state.js", () => ({
   finalizeSummary: (...a: any[]) => finalizeSummaryMock(...a),
   releaseLock: (...a: any[]) => releaseLockMock(...a),
+  readState: (...a: any[]) => readStateMock(...a),
 }));
 vi.mock("../../src/hooks/upload-summary.js", () => ({
   uploadSummary: (...a: any[]) => uploadSummaryMock(...a),
@@ -93,6 +95,7 @@ beforeEach(() => {
   fetchMock.mockReset();
   finalizeSummaryMock.mockReset();
   releaseLockMock.mockReset();
+  readStateMock.mockReset().mockReturnValue(null);
   uploadSummaryMock.mockReset().mockResolvedValue({ path: "insert", summaryLength: 80, descLength: 15, sql: "..." });
   embedSummaryMock.mockReset().mockResolvedValue([0.1, 0.2, 0.3]);
   execFileSyncMock.mockReset();

--- a/tests/pi/pi-wiki-worker.test.ts
+++ b/tests/pi/pi-wiki-worker.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 
 const finalizeSummaryMock = vi.fn();
 const releaseLockMock = vi.fn();
+const readStateMock = vi.fn();
 const uploadSummaryMock = vi.fn();
 const execFileSyncMock = vi.fn();
 const embedSummaryMock = vi.fn();
@@ -19,6 +20,7 @@ const embedSummaryMock = vi.fn();
 vi.mock("../../src/hooks/summary-state.js", () => ({
   finalizeSummary: (...a: any[]) => finalizeSummaryMock(...a),
   releaseLock: (...a: any[]) => releaseLockMock(...a),
+  readState: (...a: any[]) => readStateMock(...a),
 }));
 vi.mock("../../src/hooks/upload-summary.js", () => ({
   uploadSummary: (...a: any[]) => uploadSummaryMock(...a),
@@ -92,6 +94,7 @@ beforeEach(() => {
   fetchMock.mockReset();
   finalizeSummaryMock.mockReset();
   releaseLockMock.mockReset();
+  readStateMock.mockReset().mockReturnValue(null);
   uploadSummaryMock.mockReset().mockResolvedValue({ path: "insert", summaryLength: 80, descLength: 15, sql: "..." });
   embedSummaryMock.mockReset().mockResolvedValue([0.1, 0.2, 0.3]);
   execFileSyncMock.mockReset();

--- a/tests/shared/wiki-offset.test.ts
+++ b/tests/shared/wiki-offset.test.ts
@@ -41,14 +41,30 @@ describe("capLinesByBytes", () => {
     expect(dropped).toBe(0);
   });
 
-  it("always keeps at least the last line even when it alone exceeds the budget", () => {
+  it("keeps only the last line but truncates it when it alone exceeds the budget", () => {
     const lines = ["x", "y".repeat(100)];
-    const { kept, dropped } = capLinesByBytes(lines, 10);
-    expect(kept).toEqual([lines[1]]);
+    const { kept, dropped, truncated } = capLinesByBytes(lines, 10);
     expect(dropped).toBe(1);
+    expect(truncated).toBe(true);
+    expect(kept).toHaveLength(1);
+    expect(Buffer.byteLength(kept[0], "utf8")).toBeLessThanOrEqual(10);
   });
 
   it("handles an empty input", () => {
-    expect(capLinesByBytes([], 10)).toEqual({ kept: [], dropped: 0 });
+    expect(capLinesByBytes([], 10)).toEqual({ kept: [], dropped: 0, truncated: false });
+  });
+
+  it("truncates a lone oversized line so the output stays within the budget", () => {
+    const line = "z".repeat(100);
+    const { kept, dropped, truncated } = capLinesByBytes([line], 10);
+    expect(dropped).toBe(0);
+    expect(truncated).toBe(true);
+    expect(kept).toHaveLength(1);
+    expect(Buffer.byteLength(kept[0], "utf8")).toBeLessThanOrEqual(10);
+  });
+
+  it("does not report truncation when the retained line fits", () => {
+    const { truncated } = capLinesByBytes(["ok"], 10);
+    expect(truncated).toBe(false);
   });
 });

--- a/tests/shared/wiki-offset.test.ts
+++ b/tests/shared/wiki-offset.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { stampOffset, parseOffset, capLinesByBytes, WIKI_JSONL_MAX_BYTES } from "../../src/hooks/wiki-offset.js";
+
+describe("stampOffset", () => {
+  it("replaces an existing offset line, preserving the bullet, and round-trips via parseOffset", () => {
+    const summary = "# Session x\n- **Project**: p\n- **JSONL offset**: 7\n\n## What Happened\nstuff";
+    const out = stampOffset(summary, 42);
+    expect(out).toContain("- **JSONL offset**: 42");
+    expect(out).not.toContain("offset**: 7");
+    expect(parseOffset(out)).toBe(42);
+  });
+
+  it("inserts an offset line after the title when none exists", () => {
+    const summary = "# Session x\n\n## What Happened\nstuff";
+    const out = stampOffset(summary, 5);
+    expect(parseOffset(out)).toBe(5);
+    // inserted right after the first line, not appended at the end
+    expect(out.split("\n")[1]).toBe("- **JSONL offset**: 5");
+  });
+
+  it("does not depend on the LLM's exact formatting — a reformatted bullet is still overwritten", () => {
+    // LLM wrote it as a bold line without a bullet; stamping still normalizes it.
+    const summary = "# S\n**JSONL offset**:   999\ntail";
+    expect(parseOffset(stampOffset(summary, 3))).toBe(3);
+  });
+});
+
+describe("capLinesByBytes", () => {
+  it("keeps the NEWEST lines (tail), not the oldest, and reports the drop count", () => {
+    const lines = ["oldest", "mid", "newest"];
+    // budget fits only the last two ("mid\nnewest" = 3+1+6 = 10 bytes)
+    const { kept, dropped } = capLinesByBytes(lines, 10);
+    expect(kept).toEqual(["mid", "newest"]);
+    expect(dropped).toBe(1);
+  });
+
+  it("keeps everything when under budget (no drop)", () => {
+    const lines = ["a", "b", "c"];
+    const { kept, dropped } = capLinesByBytes(lines, WIKI_JSONL_MAX_BYTES);
+    expect(kept).toEqual(lines);
+    expect(dropped).toBe(0);
+  });
+
+  it("always keeps at least the last line even when it alone exceeds the budget", () => {
+    const lines = ["x", "y".repeat(100)];
+    const { kept, dropped } = capLinesByBytes(lines, 10);
+    expect(kept).toEqual([lines[1]]);
+    expect(dropped).toBe(1);
+  });
+
+  it("handles an empty input", () => {
+    expect(capLinesByBytes([], 10)).toEqual({ kept: [], dropped: 0 });
+  });
+});


### PR DESCRIPTION
## Problem

The Stop hook's background wiki-summary worker crashed on long sessions (reported on a ~4480-event Codex session): `ENOBUFS` (the agent's stdout exceeded Node's 1 MB default `execFileSync` buffer) and `ETIMEDOUT` (120s) because the worker re-fed the **entire** session to the summarizer on every run.

Root cause: the offset that should bound each run to only the new rows was never applied — no `rows.slice()` existed, so the full session was always written to the JSONL; and the offset value was parsed by regex from the LLM-generated summary text (fragile) instead of the reliable sidecar counter. When the summary failed, `finalizeSummary` never ran, so the offset stayed at 0 and every run reprocessed everything.

## Fix (all 5 workers: claude-code, codex, cursor, hermes, pi)

- `maxBuffer: 64 MB` on the summarizer `execFileSync` → eliminates ENOBUFS (the summary is written to a file, not read from stdout).
- Read the offset from the **sidecar** (`readState().lastSummaryCount`), with the regex on the stored summary kept only as a cross-machine fallback.
- Actually slice `rows.slice(prevOffset)` → only new rows reach the agent; the run is skipped entirely when nothing is new.
- New shared helper `src/hooks/wiki-offset.ts`:
  - `stampOffset` — the worker writes the offset into the summary itself, removing the dependency on the LLM echoing a bookkeeping line.
  - `capLinesByBytes` — 4 MB tail cap safety net (keeps the newest rows).
- Added the `execSucceeded` guard to cursor/hermes/pi/claude-code (codex already had it) so a failed run on a **resumed** session never advances the offset past rows that were never summarized.

OpenClaw is N/A (pure HTTP/WebSocket gateway — does not run the wiki-worker daemon). MCP/Cowork reuses the base worker.

## Known tradeoff

When a single increment exceeds 4 MB (degenerate case: first summary of an already-huge backlog with offset 0, or a lone giant row) the byte cap keeps the newest rows and permanently skips the oldest ones (logged, not silent). Intentional — documented in the `capLinesByBytes` doc comment. In normal incremental operation increments are tiny and nothing is ever dropped.

## Tests

`tsc` clean; 77 worker/helper tests pass. New coverage: offset slicing feeds only new rows, byte-cap keeps the tail and reports drops, no-new-rows skip, `maxBuffer` presence, and the failure guard that prevents offset advance (data loss) on a failed resumed run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki summarization resumption now uses a persisted per-session progress counter as the authoritative resume point, processing only newly added events.
  * Added stricter per-run JSONL byte limiting with byte-safe truncation and dropped-line tracking.
* **Bug Fixes**
  * Prevents offset advancement, uploads, and finalization when the summarizer run fails or produces unchanged/empty output.
  * Skips summarization when there are no new events to process.
  * Reduces subprocess failures by increasing stdout buffering capacity.
* **Tests**
  * Expanded resume/offset, JSONL capping, buffering, and failure-mode coverage across workers, plus new unit tests for offset stamping and capping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->