### PR TITLE
fix(docs): scope generation existence checks to the project

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -835,7 +835,7 @@ export async function runDocsCommand(args: string[]): Promise<void> {
 
     let existingDocs: DocRow[] = [];
     try {
-      existingDocs = await listDocs(query, tableName, { status: "all", limit: 1000000 });
+      existingDocs = await listDocs(query, tableName, { status: "all", projectOrLegacy: project, limit: 1000000 });
     } catch (err) {
       if (!isMissingTableError((err as Error).message)) throw err;
     }
@@ -913,7 +913,7 @@ export async function runDocsCommand(args: string[]): Promise<void> {
     }
     let existingDocs: DocRow[] = [];
     try {
-      existingDocs = await listDocs(query, tableName, { status: "all", limit: 1000000 });
+      existingDocs = await listDocs(query, tableName, { status: "all", projectOrLegacy: project, limit: 1000000 });
     } catch (err) {
       if (!isMissingTableError((err as Error).message)) throw err;
     }

--- a/tests/claude-code/cli-docs.test.ts
+++ b/tests/claude-code/cli-docs.test.ts
@@ -598,7 +598,7 @@ describe("hivemind docs — subcommand surface coverage", () => {
     const project = deriveProjectKey(dir).key;
     queryMock.mockResolvedValue([docRow({ doc_id: "wiki/x", project, content: "# x\nbody" })]);
     await run(["pull", "--cwd", dir]);
-    expect(logged.join()).toMatch(/Pulled|up to date/);
+    expect(logged.join()).toMatch(/Pulled \d+ doc\(s\)/); // a row was mocked → a write, not a no-op
   });
 
   // --- reindex backfills embeddings ---
@@ -887,7 +887,7 @@ describe("hivemind docs — subcommand surface coverage", () => {
     const project = deriveProjectKey(dir).key;
     queryMock.mockResolvedValue([docRow({ doc_id: "wiki/x", project, content: "# x\nbody" })]);
     await run(["pull", "--force", "--cwd", dir]);
-    expect(logged.join()).toMatch(/Pulled|up to date/);
+    expect(logged.join()).toMatch(/Pulled \d+ doc\(s\)/); // a row was mocked → a write, not a no-op
   });
   it("sync --force passes force through to the wiki cycle", async () => {
     setAuto({ orgId: "org", orgName: "OrgName", project: deriveProjectKey(dir).key, path: dir, auto: true });

--- a/tests/claude-code/cli-docs.test.ts
+++ b/tests/claude-code/cli-docs.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../src/docs/embed.js", () => ({
 }));
 
 import { runDocsCommand } from "../../src/commands/docs.js";
+import { deriveProjectKey } from "../../src/utils/repo-identity.js";
 import { loadConfig } from "../../src/config.js";
 const loadConfigMock = loadConfig as unknown as ReturnType<typeof vi.fn>;
 
@@ -322,5 +323,89 @@ describe("hivemind docs — anchored authoring + refresh over real files", () =>
     // even if the gate leaked a write; check both statement kinds.
     const writes = queryMock.mock.calls.map((c) => c[0] as string).filter((s) => /INSERT|UPDATE/.test(s));
     expect(writes).toHaveLength(0);
+  });
+});
+
+describe("hivemind docs — cross-project existence scoping", () => {
+  // Regression (bugs/fix-cross-project-existence-suppression.md): the wiki and
+  // generate existence reads were GLOBAL (`listDocs` with no project filter),
+  // so a same-named doc_id owned by ANOTHER repo in the shared org table
+  // silently suppressed generation for THIS repo. The reads are now scoped
+  // `projectOrLegacy: project`, so only this project's rows — plus legacy ''
+  // rows written before project stamping — count as "already exists".
+  //
+  // Note: `listDocs` applies the project filter CLIENT-side (it reads the full
+  // union then drops non-matching rows in JS — see src/docs/read.ts), so these
+  // tests assert the observable skip decision rather than a WHERE clause in the
+  // captured SQL. The behavioral discrimination in the last test is the real
+  // guarantee: a global read could never suppress exactly the same-project row.
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cli-docs-scope-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  // One documentable file under tests/ → wiki group key "tests" → doc_id wiki/tests.
+  const wikiSnap = {
+    nodes: [{
+      id: "tests/foo.ts:foo:function", label: "foo", kind: "function",
+      source_file: "tests/foo.ts", source_location: "L1-L2",
+      language: "typescript", exported: true,
+    }],
+    links: [],
+  };
+  // One documentable file → per-file generate target with doc_id src/reader.ts.
+  const genSnap = {
+    nodes: [{
+      id: "src/reader.ts:read:function", label: "read", kind: "function",
+      source_file: "src/reader.ts", source_location: "L1-L2",
+      language: "typescript", exported: true,
+    }],
+    links: [],
+  };
+
+  it("wiki --dry-run: another project's wiki/tests does NOT suppress this repo's", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(wikiSnap);
+    // The single existence read returns only a FOREIGN-project collision.
+    queryMock.mockResolvedValueOnce([docRow({ doc_id: "wiki/tests", project: "other-project" })]);
+    await run(["wiki", "--dry-run", "--cwd", dir]);
+    const out = logged.join("\n");
+    expect(out).toMatch(/1 wiki page\(s\) would be generated/);
+    expect(out).toMatch(/wiki\/tests/);
+  });
+
+  it("generate --dry-run: another project's colliding per-file doc_id does NOT suppress", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(genSnap);
+    queryMock.mockResolvedValueOnce([docRow({ doc_id: "src/reader.ts", project: "other-project" })]);
+    await run(["generate", "--dry-run", "--cwd", dir]);
+    const out = logged.join("\n");
+    expect(out).toMatch(/1 target\(s\) would be documented/);
+    expect(out).toMatch(/src\/reader\.ts/);
+  });
+
+  it("legacy '' rows still suppress (pre-scoping corpora keep working)", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(wikiSnap);
+    // A legacy unstamped row with the same doc_id must STILL count as existing.
+    queryMock.mockResolvedValueOnce([docRow({ doc_id: "wiki/tests", project: "" })]);
+    await run(["wiki", "--dry-run", "--cwd", dir]);
+    const out = logged.join("\n");
+    expect(out).toMatch(/0 wiki page\(s\) would be generated/);
+    expect(out).not.toMatch(/wiki\/tests/);
+  });
+
+  it("existence read is project-scoped, not global: same-project row suppresses, foreign is ignored", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(wikiSnap);
+    const project = deriveProjectKey(dir).key;
+    // Table holds BOTH a foreign collision (must be ignored) and this repo's own
+    // row (must suppress). A global read would count both or neither — only a
+    // project-scoped read suppresses exactly the same-project doc.
+    queryMock.mockResolvedValueOnce([
+      docRow({ doc_id: "wiki/tests", project: "other-project" }),
+      docRow({ doc_id: "wiki/tests", project }),
+    ]);
+    await run(["wiki", "--dry-run", "--cwd", dir]);
+    const out = logged.join("\n");
+    expect(out).toMatch(/0 wiki page\(s\) would be generated/);
+    expect(out).not.toMatch(/wiki\/tests/);
   });
 });

--- a/tests/claude-code/cli-docs.test.ts
+++ b/tests/claude-code/cli-docs.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 
 /**
  * CLI handler tests for `hivemind docs`. The handler is thin (argparse +
@@ -36,15 +37,36 @@ vi.mock("../../src/docs/refresh-llm.js", () => ({
   makeHostGenerate: () => async () => "stub",
   makeHostGenerateDoc: () => async () => "stub",
   makeHostBatchGenerateDoc: () => async () => new Map<string, string>(),
+  // Wiki + wiki-refresh reach these; stub so no test ever spawns a real LLM.
+  // The narrative must carry a markdown heading to pass validateWikiNarrative.
+  makeHostRunPrompt: () => async () => "## Overview\n\nStub wiki narrative.",
+  makeHostPageRunPrompt: () => async () => "## Overview\n\nStub wiki narrative.",
 }));
 // Hermetic: no embed daemon round-trips in unit tests.
 vi.mock("../../src/docs/embed.js", () => ({
   makeDocEmbedder: () => async () => null,
   makeQueryEmbedder: () => async () => null,
 }));
+// The wiki-refresh cycle is a lease/meta/network orchestration (and its local
+// variant patches working-tree files). Stub both so the `wiki-refresh` and
+// `sync` handler branches are exercised without a live backend or real LLM.
+const runWikiRefreshCycleMock = vi.fn();
+const runLocalWikiRefreshMock = vi.fn();
+vi.mock("../../src/docs/wiki-refresh.js", () => ({
+  runWikiRefreshCycle: (...a: unknown[]) => runWikiRefreshCycleMock(...a),
+  runLocalWikiRefresh: (...a: unknown[]) => runLocalWikiRefreshMock(...a),
+}));
+// Onboarding IO is TTY-driven; drive it explicitly so the interactive
+// consent branches of `sync` and `auto on` are reachable without a terminal.
+const io = vi.hoisted(() => ({ interactive: false, answer: "n", generate: false }));
+vi.mock("../../src/docs/onboarding.js", () => ({
+  defaultIo: () => ({ interactive: io.interactive, ask: async () => io.answer }),
+  runDocsOnboarding: async () => ({ generate: io.generate, auto: false, asked: true }),
+}));
 
 import { runDocsCommand } from "../../src/commands/docs.js";
 import { deriveProjectKey } from "../../src/utils/repo-identity.js";
+import { setAuto } from "../../src/docs/auto-registry.js";
 import { loadConfig } from "../../src/config.js";
 const loadConfigMock = loadConfig as unknown as ReturnType<typeof vi.fn>;
 
@@ -88,6 +110,9 @@ beforeEach(() => {
   ensureDocsTableMock.mockReset().mockResolvedValue(undefined);
   queryMock.mockReset().mockResolvedValue([]);
   loadCurrentSnapshotMock.mockReset().mockReturnValue({ nodes: [], links: [] });
+  runWikiRefreshCycleMock.mockReset().mockResolvedValue({ status: "generated", head: "abcdef1234567", outcomes: [{ action: "created", doc_id: "wiki/x" }] });
+  runLocalWikiRefreshMock.mockReset().mockResolvedValue({ outcomes: [{ action: "patched", file: "a.hivemind.md", reasons: ["drift"] }] });
+  io.interactive = false; io.answer = "n"; io.generate = false;
   loadConfigMock.mockReset().mockReturnValue(VALID_CONFIG);
   logSpy = vi.spyOn(console, "log").mockImplementation((...a: any[]) => { logged.push(a.join(" ")); });
   errSpy = vi.spyOn(console, "error").mockImplementation((...a: any[]) => { erred.push(a.join(" ")); });
@@ -407,5 +432,557 @@ describe("hivemind docs — cross-project existence scoping", () => {
     const out = logged.join("\n");
     expect(out).toMatch(/0 wiki page\(s\) would be generated/);
     expect(out).not.toMatch(/wiki\/tests/);
+  });
+});
+
+// Broad surface coverage for the CLI dispatcher: every subcommand handler is
+// driven through runDocsCommand against the query spy + real store, so a
+// refactor that drops a branch (or an escaping/order regression) is caught.
+// The registry-touching subcommands are isolated to a per-test temp file via
+// HIVEMIND_DOCS_AUTO_FILE so they never read/write the developer's real state.
+describe("hivemind docs — subcommand surface coverage", () => {
+  let dir: string;
+  let regFile: string;
+  let prevReg: string | undefined;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cli-docs-surf-"));
+    regFile = join(dir, "docs-auto.json");
+    prevReg = process.env.HIVEMIND_DOCS_AUTO_FILE;
+    process.env.HIVEMIND_DOCS_AUTO_FILE = regFile;
+  });
+  afterEach(() => {
+    if (prevReg === undefined) delete process.env.HIVEMIND_DOCS_AUTO_FILE;
+    else process.env.HIVEMIND_DOCS_AUTO_FILE = prevReg;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const fooNode = {
+    id: "f.ts:foo:function", label: "foo", kind: "function",
+    source_file: "f.ts", source_location: "L1-L3", language: "typescript",
+    exported: true, signature: "function foo(): number", source: "export function foo() {\n  return 1;\n}\n",
+  };
+
+  // --- flag parsing guards ---
+  it("set rejects an invalid --tier", async () => {
+    expect(await run(["set", "a.ts", "body", "--tier", "bogus"])).toBe(1);
+    expect(erred.join()).toMatch(/Invalid --tier/);
+  });
+  it("list rejects a non-integer --limit", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    expect(await run(["list", "--limit", "abc", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/Invalid --limit/);
+  });
+  it("set reads the body from --file", async () => {
+    const f = join(dir, "body.md");
+    writeFileSync(f, "body from a file");
+    await run(["set", "a.ts", "--file", f, "--project", "p"]);
+    const insert = queryMock.mock.calls.map((c) => c[0] as string).find((s) => /INSERT INTO "hivemind_docs"/.test(s));
+    expect(insert).toBeDefined();
+    expect(insert!).toContain("body from a file");
+  });
+
+  // --- index ---
+  it("index prints a browsable directory listing", async () => {
+    queryMock.mockResolvedValueOnce([docRow({ doc_id: "a.ts" })]); // listDocMeta
+    queryMock.mockResolvedValueOnce([docRow({ doc_id: "a.ts", content: "# A\nfirst line" })]); // listDocsByIds
+    await run(["index"]);
+    expect(logged.join("\n")).toMatch(/a\.ts/);
+  });
+
+  // --- list: registry + project views ---
+  it("list --repos with no registry entries prints the enable hint", async () => {
+    await run(["list", "--repos"]);
+    expect(logged.join()).toMatch(/no repos registered/);
+  });
+  it("list --repos lists registered repos", async () => {
+    setAuto({ orgId: "org", orgName: "OrgName", project: "projkey", path: "/some/repo", auto: true });
+    await run(["list", "--repos"]);
+    expect(logged.join("\n")).toMatch(/AUTO.*\/some\/repo/);
+  });
+  it("list --project resolves an explicit project and scopes the read", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]);
+    await run(["list", "--project", "projkey", "--cwd", dir]);
+    // No throw + a per-repo (not org grouped) view means the scoped path ran.
+    expect(logged.join()).toMatch(/no docs with status=active/);
+  });
+
+  // --- archive failure ---
+  it("archive reports failure when the doc does not exist", async () => {
+    queryMock.mockResolvedValue([]); // getDocLatest → none → editDoc throws
+    expect(await run(["archive", "missing.ts"])).toBe(1);
+    expect(erred.join()).toMatch(/Archive failed/);
+  });
+
+  // --- refresh: dry-run with an impacted doc (full-scan branch, no git) ---
+  it("refresh --dry-run lists impacted docs (full scan when no git diff)", async () => {
+    writeFileSync(join(dir, "f.ts"), "export function foo() {\n  return 1;\n}\n");
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [fooNode], links: [] });
+    const stale = JSON.stringify([{ symbol_id: "f.ts:foo:function", content_hash: "stale000" }]);
+    queryMock.mockResolvedValue([docRow({ doc_id: "f.ts", anchors: stale })]);
+    await run(["refresh", "--dry-run", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/1 doc\(s\) would be refreshed/);
+    expect(logged.join("\n")).toMatch(/f\.ts/);
+  });
+
+  // --- wiki-refresh --local (working-tree preview, no table writes) ---
+  it("wiki-refresh --local runs a working-tree preview", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    await run(["wiki-refresh", "--local", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/Local wiki preview: 1 page\(s\) considered/);
+    expect(logged.join("\n")).toMatch(/patched a\.hivemind\.md/);
+  });
+  it("wiki-refresh --local reports when the working tree touches nothing", async () => {
+    runLocalWikiRefreshMock.mockResolvedValue({ outcomes: [] });
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    await run(["wiki-refresh", "--local", "--cwd", dir]);
+    expect(logged.join()).toMatch(/nothing touched by the working tree/);
+  });
+  it("wiki-refresh (real cycle) prints the cycle status and outcomes", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    await run(["wiki-refresh", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/Wiki refresh: generated @ abcdef12/);
+    expect(logged.join("\n")).toMatch(/created wiki\/x/);
+  });
+  it("wiki-refresh errors without a local graph", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(null);
+    expect(await run(["wiki-refresh", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/No local graph/);
+  });
+
+  // --- sync: non-interactive + auto disabled short-circuits at zero LLM cost ---
+  it("sync does nothing when auto is not enabled (non-interactive)", async () => {
+    await run(["sync", "--cwd", dir]);
+    expect(logged.join()).toMatch(/auto not enabled/);
+  });
+
+  // --- auto on/off ---
+  it("auto rejects a bad mode", async () => {
+    expect(await run(["auto", "bogus", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/Usage: hivemind docs auto/);
+  });
+  it("auto off records the opt-out", async () => {
+    await run(["auto", "off", "--cwd", dir]);
+    expect(logged.join()).toMatch(/Auto sync OFF/);
+  });
+  it("auto on refuses an empty corpus non-interactively", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]); // no wiki pages yet
+    expect(await run(["auto", "on", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/enabling auto would generate/);
+  });
+  it("auto on (interactive) leaves off when the user declines the prompt", async () => {
+    io.interactive = true; io.answer = "n";
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]); // empty corpus → prompt
+    await run(["auto", "on", "--cwd", dir]);
+    expect(logged.join()).toMatch(/Left OFF/);
+  });
+  it("auto on (interactive) enables when the user accepts the prompt", async () => {
+    io.interactive = true; io.answer = "y";
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]); // empty corpus → prompt → yes
+    await run(["auto", "on", "--cwd", dir]);
+    expect(logged.join()).toMatch(/Auto sync ON/);
+  });
+  it("auto on enables when a wiki corpus already exists", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    const project = deriveProjectKey(dir).key;
+    queryMock.mockResolvedValue([docRow({ doc_id: "wiki/x", project })]);
+    await run(["auto", "on", "--cwd", dir]);
+    expect(logged.join()).toMatch(/Auto sync ON/);
+  });
+
+  // --- pull writes docs to the working tree ---
+  it("pull writes the project's docs locally", async () => {
+    const project = deriveProjectKey(dir).key;
+    queryMock.mockResolvedValue([docRow({ doc_id: "wiki/x", project, content: "# x\nbody" })]);
+    await run(["pull", "--cwd", dir]);
+    expect(logged.join()).toMatch(/Pulled|up to date/);
+  });
+
+  // --- reindex backfills embeddings ---
+  it("reindex reports how many docs were embedded", async () => {
+    queryMock.mockResolvedValue([]); // no docs missing a vector
+    await run(["reindex"]);
+    expect(logged.join()).toMatch(/Reindexed/);
+  });
+
+  // --- wiki real run: below the min-group gate → skipped, no LLM ---
+  it("wiki (real run) reports outcomes and skips a below-threshold group", async () => {
+    writeFileSync(join(dir, "solo.ts"), "export const x = 1;\n");
+    loadCurrentSnapshotMock.mockReturnValue({
+      nodes: [{ id: "solo.ts:x:function", label: "x", kind: "function", source_file: "solo.ts", source_location: "L1", language: "typescript", exported: true, source: "export const x = 1;\n" }],
+      links: [],
+    });
+    queryMock.mockResolvedValue([]);
+    await run(["wiki", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/Wiki: created \d+, skipped \d+/);
+  });
+
+  // --- generate real run: single-batch stub generator creates one doc ---
+  it("generate (real run, --batch 1) creates a doc via the stub generator", async () => {
+    mkdirSync(join(dir, "src"));
+    writeFileSync(join(dir, "src", "reader.ts"), "export function read() {\n  return 1;\n}\n");
+    loadCurrentSnapshotMock.mockReturnValue({
+      nodes: [{ id: "src/reader.ts:read:function", label: "read", kind: "function", source_file: "src/reader.ts", source_location: "L1-L3", language: "typescript", exported: true }],
+      links: [],
+    });
+    queryMock.mockResolvedValue([]);
+    await run(["generate", "--batch", "1", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/Generated \d+, skipped \d+/);
+    const insert = queryMock.mock.calls.map((c) => c[0] as string).find((s) => /INSERT INTO "hivemind_docs"/.test(s));
+    expect(insert).toBeDefined();
+  });
+  it("generate rejects an invalid --scope", async () => {
+    expect(await run(["generate", "--scope", "bogus", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/Invalid --scope/);
+  });
+  it("generate errors without a local graph", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(null);
+    expect(await run(["generate", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/No local graph/);
+  });
+  it("wiki errors without a local graph", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(null);
+    expect(await run(["wiki", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/No local graph/);
+  });
+
+  // --- list header: sync freshness derived from refresh meta ---
+  it("list header reports sync freshness from refresh meta", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    // readRefreshMeta reads the _meta row; its content carries last_refresh_sha.
+    queryMock.mockResolvedValueOnce([{ content: JSON.stringify({ last_refresh_sha: "abc12345def" }), updated_at: "t" }]);
+    queryMock.mockResolvedValue([]); // the row listing
+    await run(["list", "--cwd", dir]);
+    // Temp dir has no git → gitHeadOf null → "no git" freshness branch.
+    expect(logged.join("\n")).toMatch(/sync: no git/);
+  });
+
+  it("list header shows in-sync and behind-HEAD freshness in a git repo", async () => {
+    const g = (a: string[]) => execFileSync("git", ["-C", dir, ...a], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    g(["init", "-q"]); g(["config", "user.email", "t@t"]); g(["config", "user.name", "t"]);
+    writeFileSync(join(dir, "f.ts"), "x\n"); g(["add", "."]); g(["commit", "-q", "-m", "init"]);
+    const head = g(["rev-parse", "HEAD"]).trim();
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValueOnce([{ content: JSON.stringify({ last_refresh_sha: head }), updated_at: "t" }]);
+    queryMock.mockResolvedValue([]);
+    await run(["list", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/sync: in sync \(HEAD\)/);
+    logged.length = 0;
+    queryMock.mockResolvedValueOnce([{ content: JSON.stringify({ last_refresh_sha: "deadbeef0000" }), updated_at: "t" }]);
+    queryMock.mockResolvedValue([]);
+    await run(["list", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/sync: behind HEAD \(last: deadbeef\)/);
+  });
+
+  it("wiki (real run) creates a page for a group above the min gate", async () => {
+    mkdirSync(join(dir, "pkg"));
+    const nodes: any[] = [];
+    for (const n of ["a", "b", "c"]) {
+      writeFileSync(join(dir, "pkg", `${n}.ts`), "export const v = 1;\n".repeat(300));
+      nodes.push({ id: `pkg/${n}.ts:${n}:function`, label: n, kind: "function", source_file: `pkg/${n}.ts`, source_location: "L1-L2", language: "typescript", exported: true });
+    }
+    loadCurrentSnapshotMock.mockReturnValue({ nodes, links: [] });
+    queryMock.mockResolvedValue([]);
+    await run(["wiki", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/created wiki\/pkg/);
+  });
+
+  it("generate (real run) prints a skipped outcome when a symbol can't be anchored", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({
+      nodes: [{ id: "ghost.ts:g:function", label: "g", kind: "function", source_file: "ghost.ts", source_location: "L1-L3", language: "typescript", exported: true }],
+      links: [],
+    });
+    queryMock.mockResolvedValue([]);
+    await run(["generate", "--batch", "1", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/skipped ghost\.ts/);
+  });
+
+  it("index tolerates a missing table on the per-file content read", async () => {
+    queryMock.mockResolvedValueOnce([docRow({ doc_id: "a.ts" })]); // listDocMeta
+    queryMock.mockRejectedValue(new Error('relation "hivemind_docs" does not exist')); // listDocsByIds
+    await run(["index"]);
+    expect(logged.join("\n")).toMatch(/a\.ts/);
+  });
+
+  it("list --all with an empty table prints the empty marker", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]);
+    await run(["list", "--all", "--cwd", dir]);
+    expect(logged.join()).toMatch(/no docs with status=active/);
+  });
+
+  it("list --all groups rows under their registered repo name", async () => {
+    setAuto({ orgId: "org", orgName: "OrgName", project: "bigproj", path: "/x/bigrepo", auto: true });
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValueOnce([]); // header meta read
+    queryMock.mockResolvedValueOnce([docRow({ doc_id: "wiki/p", project: "bigproj" })]);
+    await run(["list", "--all", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/\/x\/bigrepo/);
+  });
+
+  it("list --project resolves a repo basename and a key prefix", async () => {
+    setAuto({ orgId: "org", orgName: "OrgName", project: "projABC123", path: "/x/openrepl", auto: true });
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]);
+    await run(["list", "--project", "openrepl", "--cwd", dir]); // byPath
+    await run(["list", "--project", "projABC", "--cwd", dir]);  // byPrefix
+    // Both resolve without throwing and hit the scoped per-repo view.
+    expect(logged.join()).toMatch(/no docs with status=active/);
+  });
+
+  // --- set --anchor error branches ---
+  it("set --anchor errors when no graph is built", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(null);
+    expect(await run(["set", "a.ts", "body", "--anchor", "a.ts:foo:function", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/--anchor needs a built graph/);
+  });
+  it("set --anchor errors when the source cannot be read", async () => {
+    // Symbol is in the graph but its file is absent on disk → buildAnchor null.
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [fooNode], links: [] });
+    expect(await run(["set", "f.ts", "body", "--anchor", "f.ts:foo:function", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/could not read source/);
+  });
+  it("set fails cleanly when --file points at a missing path", async () => {
+    expect(await run(["set", "a.ts", "--file", join(dir, "nope.md"), "--project", "p"])).toBe(1);
+    expect(erred.join()).toMatch(/Set failed/);
+  });
+
+  // --- reindex swallows a missing table ---
+  it("reindex tolerates a missing docs table", async () => {
+    queryMock.mockRejectedValue(new Error('relation "hivemind_docs" does not exist'));
+    await run(["reindex"]);
+    expect(logged.join()).toMatch(/no docs table yet/);
+  });
+
+  // --- missing-table tolerance across the read subcommands (the
+  //     isMissingTableError TRUE arm of each catch) ---
+  const MISSING = () => new Error('relation "hivemind_docs" does not exist');
+  it("index tolerates a missing table", async () => {
+    queryMock.mockRejectedValue(MISSING());
+    await run(["index"]);
+    expect(logged.length).toBeGreaterThan(0); // buildDocsIndex still printed
+  });
+  it("show tolerates a missing table", async () => {
+    queryMock.mockRejectedValue(MISSING());
+    await run(["show", "a.ts"]);
+    expect(logged.join()).toMatch(/no doc for a\.ts/);
+  });
+  it("list tolerates a missing table", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockRejectedValue(MISSING());
+    await run(["list", "--cwd", dir]);
+    expect(logged.join()).toMatch(/no docs with status=active/);
+  });
+  it("refresh --dry-run tolerates a missing table", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockRejectedValue(MISSING());
+    await run(["refresh", "--dry-run", "--cwd", dir]);
+    expect(logged.join()).toMatch(/no docs need refreshing/);
+  });
+  it("wiki --dry-run tolerates a missing table", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockRejectedValue(MISSING());
+    await run(["wiki", "--dry-run", "--cwd", dir]);
+    expect(logged.join()).toMatch(/wiki page\(s\) would be generated/);
+  });
+  it("generate --dry-run tolerates a missing table", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockRejectedValue(MISSING());
+    await run(["generate", "--dry-run", "--cwd", dir]);
+    expect(logged.join()).toMatch(/target\(s\) would be documented/);
+  });
+  it("pull tolerates a missing table", async () => {
+    queryMock.mockRejectedValue(MISSING());
+    await run(["pull", "--cwd", dir]);
+    expect(logged.join()).toMatch(/no docs table yet/);
+  });
+
+  it("list formats archived rows with a singular anchor label", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValueOnce([]); // header meta read
+    queryMock.mockResolvedValueOnce([docRow({ doc_id: "a.ts", status: "archived", anchors: JSON.stringify([{ symbol_id: "a.ts:x:function", content_hash: "h" }]) })]);
+    await run(["list", "--status", "all", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/\[archived\] a\.ts.*1 anchor\b/);
+  });
+
+  it("list --repos marks an auto-off repo", async () => {
+    setAuto({ orgId: "org", orgName: "OrgName", project: "p1", path: "/x/offrepo", auto: false });
+    await run(["list", "--repos"]);
+    expect(logged.join("\n")).toMatch(/off  \/x\/offrepo/);
+  });
+
+  it("set accepts the --flag=value form", async () => {
+    await run(["set", "a.ts", "body", "--project=pv", "--tier=slow"]);
+    const insert = queryMock.mock.calls.map((c) => c[0] as string).find((s) => /INSERT INTO "hivemind_docs"/.test(s));
+    expect(insert).toBeDefined();
+    expect(insert!).toMatch(/'slow'/);
+  });
+
+  it("wiki --dry-run honors --force and --limit", async () => {
+    mkdirSync(join(dir, "one")); mkdirSync(join(dir, "two"));
+    writeFileSync(join(dir, "one", "a.ts"), "x\n"); writeFileSync(join(dir, "two", "b.ts"), "y\n");
+    loadCurrentSnapshotMock.mockReturnValue({
+      nodes: [
+        { id: "one/a.ts:a:function", label: "a", kind: "function", source_file: "one/a.ts", source_location: "L1", language: "typescript", exported: true },
+        { id: "two/b.ts:b:function", label: "b", kind: "function", source_file: "two/b.ts", source_location: "L1", language: "typescript", exported: true },
+      ],
+      links: [],
+    });
+    // Both pages already exist; --force re-plans them, --limit caps to 1.
+    queryMock.mockResolvedValue([docRow({ doc_id: "wiki/one" }), docRow({ doc_id: "wiki/two" })]);
+    await run(["wiki", "--dry-run", "--force", "--limit", "1", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/1 wiki page\(s\) would be generated/);
+  });
+
+  it("generate --dry-run honors --force and --limit", async () => {
+    mkdirSync(join(dir, "src"));
+    writeFileSync(join(dir, "src", "a.ts"), "x\n"); writeFileSync(join(dir, "src", "b.ts"), "y\n");
+    loadCurrentSnapshotMock.mockReturnValue({
+      nodes: [
+        { id: "src/a.ts:a:function", label: "a", kind: "function", source_file: "src/a.ts", source_location: "L1", language: "typescript", exported: true },
+        { id: "src/b.ts:b:function", label: "b", kind: "function", source_file: "src/b.ts", source_location: "L1", language: "typescript", exported: true },
+      ],
+      links: [],
+    });
+    queryMock.mockResolvedValue([docRow({ doc_id: "src/a.ts" }), docRow({ doc_id: "src/b.ts" })]);
+    await run(["generate", "--dry-run", "--force", "--limit", "1", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/1 target\(s\) would be documented/);
+  });
+
+  it("generate --scope symbol documents individual symbols", async () => {
+    mkdirSync(join(dir, "src"));
+    writeFileSync(join(dir, "src", "reader.ts"), "export function read() {\n  return 1;\n}\n");
+    loadCurrentSnapshotMock.mockReturnValue({
+      nodes: [{ id: "src/reader.ts:read:function", label: "read", kind: "function", source_file: "src/reader.ts", source_location: "L1-L3", language: "typescript", exported: true }],
+      links: [],
+    });
+    queryMock.mockResolvedValue([]);
+    await run(["generate", "--scope", "symbol", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/Generated \d+/);
+  });
+
+  it("generate (default batching) falls back to single when the batch is empty", async () => {
+    // Default batchSize (5) uses batchGenerate, mocked to return an empty Map →
+    // every file falls back to the single-file generator (stub) and is created.
+    mkdirSync(join(dir, "src"));
+    writeFileSync(join(dir, "src", "reader.ts"), "export function read() {\n  return 1;\n}\n");
+    loadCurrentSnapshotMock.mockReturnValue({
+      nodes: [{ id: "src/reader.ts:read:function", label: "read", kind: "function", source_file: "src/reader.ts", source_location: "L1-L3", language: "typescript", exported: true }],
+      links: [],
+    });
+    queryMock.mockResolvedValue([]);
+    await run(["generate", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/Generated \d+/);
+  });
+
+  it("list rejects a non-positive --limit", async () => {
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    expect(await run(["list", "--limit", "0", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/Invalid --limit/);
+  });
+  it("pull --force overwrites local docs", async () => {
+    const project = deriveProjectKey(dir).key;
+    queryMock.mockResolvedValue([docRow({ doc_id: "wiki/x", project, content: "# x\nbody" })]);
+    await run(["pull", "--force", "--cwd", dir]);
+    expect(logged.join()).toMatch(/Pulled|up to date/);
+  });
+  it("sync --force passes force through to the wiki cycle", async () => {
+    setAuto({ orgId: "org", orgName: "OrgName", project: deriveProjectKey(dir).key, path: dir, auto: true });
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]);
+    await run(["sync", "--force", "--cwd", dir]);
+    expect(runWikiRefreshCycleMock).toHaveBeenCalledTimes(1);
+    expect(runWikiRefreshCycleMock.mock.calls[0][0]).toMatchObject({ force: true });
+  });
+  it("auto on describes the full corpus when no graph is present (non-interactive)", async () => {
+    loadCurrentSnapshotMock.mockReturnValue(null);
+    queryMock.mockResolvedValue([]);
+    expect(await run(["auto", "on", "--cwd", dir])).toBe(1);
+    expect(erred.join()).toMatch(/the full corpus/);
+  });
+
+  // A NON-missing-table error must propagate (the FALSE arm — `throw err`).
+  it("show rethrows a non-missing-table error", async () => {
+    queryMock.mockRejectedValue(new Error("boom: connection reset"));
+    await expect(run(["show", "a.ts"])).rejects.toThrow(/boom/);
+  });
+
+  // --- sync --local recurses into the working-tree wiki preview ---
+  it("sync --local runs the local preview when auto is enabled", async () => {
+    setAuto({ orgId: "org", orgName: "OrgName", project: deriveProjectKey(dir).key, path: dir, auto: true });
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]);
+    await run(["sync", "--local", "--cwd", dir]);
+    expect(logged.join()).toMatch(/Local wiki preview/);
+  });
+  it("sync (interactive, empty corpus) stops when onboarding declines", async () => {
+    io.interactive = true; io.generate = false;
+    setAuto({ orgId: "org", orgName: "OrgName", project: deriveProjectKey(dir).key, path: dir, auto: true });
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]); // 0 wiki pages → onboarding runs
+    await run(["sync", "--cwd", dir]);
+    // Declined → no wiki cycle spend.
+    expect(runWikiRefreshCycleMock).not.toHaveBeenCalled();
+  });
+  it("sync (interactive, empty corpus) proceeds when onboarding consents", async () => {
+    io.interactive = true; io.generate = true;
+    setAuto({ orgId: "org", orgName: "OrgName", project: deriveProjectKey(dir).key, path: dir, auto: true });
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]);
+    await run(["sync", "--cwd", dir]);
+    expect(runWikiRefreshCycleMock).toHaveBeenCalledTimes(1);
+  });
+  it("sync (full) runs the wiki cycle then the per-file refresh", async () => {
+    setAuto({ orgId: "org", orgName: "OrgName", project: deriveProjectKey(dir).key, path: dir, auto: true });
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    queryMock.mockResolvedValue([]);
+    await run(["sync", "--cwd", dir]);
+    // Recurses into wiki-refresh (mocked cycle) + refresh --full (real, empty).
+    expect(runWikiRefreshCycleMock).toHaveBeenCalledTimes(1);
+    expect(logged.join("\n")).toMatch(/Wiki refresh: generated/);
+  });
+
+  // --- pull with an empty corpus reports "up to date" ---
+  it("pull reports up-to-date when nothing changes", async () => {
+    queryMock.mockResolvedValue([]);
+    await run(["pull", "--cwd", dir]);
+    expect(logged.join()).toMatch(/up to date/);
+  });
+
+  // --- refresh over a real git diff: refresh changed + generate added ---
+  it("refresh over a git diff refreshes a changed doc and generates an added one", async () => {
+    const g = (a: string[]) => execFileSync("git", ["-C", dir, ...a], { stdio: ["ignore", "pipe", "ignore"] });
+    g(["init", "-q"]);
+    g(["config", "user.email", "t@t"]);
+    g(["config", "user.name", "t"]);
+    writeFileSync(join(dir, "f.ts"), "export function foo() {\n  return 1;\n}\n");
+    g(["add", "."]);
+    g(["commit", "-q", "-m", "init"]);
+    // f.ts modified (shows in `git diff HEAD`); g.ts brand-new (untracked).
+    writeFileSync(join(dir, "f.ts"), "export function foo() {\n  return 2;\n}\n");
+    writeFileSync(join(dir, "g.ts"), "export function bar() {\n  return 3;\n}\n");
+    const barNode = { id: "g.ts:bar:function", label: "bar", kind: "function", source_file: "g.ts", source_location: "L1-L3", language: "typescript", exported: true };
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [fooNode, barNode], links: [] });
+    const stale = JSON.stringify([{ symbol_id: "f.ts:foo:function", content_hash: "stale000" }]);
+    queryMock.mockResolvedValue([docRow({ doc_id: "f.ts", anchors: stale })]);
+    await run(["refresh", "--cwd", dir]);
+    const out = logged.join("\n");
+    expect(out).toMatch(/Refreshed \d+/);
+    // Self-complete: the added file with no doc gets one generated.
+    expect(out).toMatch(/Generated \d+ new doc\(s\) for added files|created g\.ts/);
+  });
+
+  // --- refresh real run: a doc whose anchored symbol vanished is archived ---
+  it("refresh archives a doc whose anchored symbol is gone", async () => {
+    writeFileSync(join(dir, "f.ts"), "export function foo() {\n  return 1;\n}\n");
+    // Graph no longer contains f.ts:foo:function → the anchored doc is orphaned.
+    loadCurrentSnapshotMock.mockReturnValue({ nodes: [], links: [] });
+    const anchors = JSON.stringify([{ symbol_id: "f.ts:foo:function", content_hash: "abc" }]);
+    queryMock.mockResolvedValue([docRow({ doc_id: "f.ts", anchors })]);
+    await run(["refresh", "--cwd", dir]);
+    expect(logged.join("\n")).toMatch(/archived|Refreshed \d+, archived \d+/);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -300,6 +300,22 @@ export default defineConfig({
           functions: 80,
           lines: 90,
         },
+        // fix/docs-scope-existence-checks — the `docs` CLI dispatcher gained a
+        // full subcommand-surface suite in tests/claude-code/cli-docs.test.ts
+        // (set/index/show/list/archive/refresh/wiki-refresh/sync/auto/pull/
+        // reindex/wiki/generate), driven through the real store against the
+        // query spy. Actuals: statements 95, branches 87, functions 91, lines 98.
+        // Branches + functions pinned at 85 (not 90): the residual gaps are the
+        // interactive graph-build recursion (dynamic-imports native tree-sitter)
+        // and the closures handed to runWikiRefreshCycle (git runner /
+        // snapshot loader), which are dead once that cycle is stubbed — neither
+        // is deterministically reachable from a unit test.
+        "src/commands/docs.ts": {
+          statements: 90,
+          branches: 85,
+          functions: 85,
+          lines: 90,
+        },
         "src/deeplake-api.ts": {
           // ensureCodebaseTable (create + heal + ensureLookupIndex branches)
           // covered directly in tests/shared/deeplake-api-codebase-table.test.ts.


### PR DESCRIPTION
## Problem

`hivemind docs wiki` and `hivemind docs generate` decided which docs already
exist (to skip them for idempotence) with a **global** existence read —
`listDocs(...)` with no project filter. On the shared org table that returns
every repo's rows, and the skip decision compared by `doc_id` alone. A doc's
real identity is `(project, doc_id)`, so a same-named doc owned by another repo
silently suppressed generation for the current one.

Observed live on `mempalace` (org `june16`): another repo's `wiki/tests` row
made mempalace's own `wiki/tests` skip — it planned 7 wiki groups but generated
only 6. Severity is higher for `generate`, whose per-file doc_ids are file
paths (`src/index.ts`, `README.md`, ...) that collide across repos by default.

## Fix

Scope both existence reads to the run's project with the same semantics every
other reader uses (current project OR legacy `''` rows):

```ts
existingDocs = await listDocs(query, tableName, { status: "all", projectOrLegacy: project, limit: 1000000 });
```

`project` was already in scope in both subcommands; `listDocs` already supports
`projectOrLegacy`. No new plumbing. Audited every other `listDocs` caller —
only the `docs list --all` display view is intentionally unscoped; all
decision-path callers are already project-scoped.

## Tests

Four new cases in `tests/claude-code/cli-docs.test.ts`:

1. `wiki --dry-run` — another project's `wiki/tests` no longer suppresses this repo's.
2. `generate --dry-run` — a colliding per-file doc_id from another project no longer suppresses.
3. Legacy `''`-project rows still suppress (pre-scoping corpora keep working).
4. The existence read discriminates by project: a same-project row suppresses while a foreign row is ignored.

## Verification

- `npm run build` clean (tsc + esbuild).
- Full vitest with `HOME=/tmp/clean-home`: 5178 passed; the only failure is the
  known local-only `cli-bundle-runtime.test.ts` tree-sitter guard (passes in CI).
- End-to-end on the real `hivemind_docs` table (org `june16`, mempalace):
  `docs wiki --dry-run` now reports `1 wiki page(s) would be generated` with
  `wiki/tests` in the todo — previously suppressed by another repo's row.

## Session Context
[Session transcript](https://gist.github.com/efenocchi/08c038b1223b79873e96e7c6be676fbd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `docs` subcommand dry-run checks for `wiki` and `generate` so “already exists” detection is scoped to the active project, preventing cross-project results from blocking actions.
  * Preserved legacy behavior where unscoped (empty-project) documentation entries still count as existing.

* **Tests**
  * Added regression coverage for cross-project vs same-project vs legacy existence scoping.
  * Enhanced CLI test harness determinism and extended docs subcommand scenario coverage.
  * Increased/adjusted coverage thresholds for the `docs` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->