### PR TITLE
feat(auth): tag CLI device login with X-Deeplake-Signup-Flow: hivemind

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -101,6 +101,14 @@ export function hivemindReferrerHeader(ref?: string): Record<string, string> {
   return { "X-Hivemind-Referrer": code };
 }
 
+// Tags the signup with the product entry point. The backend reads
+// X-Deeplake-Signup-Flow at user creation (first-write-wins) and persists it on
+// users.signup_flow, driving per-flow onboarding (the CLI signup plan step) and
+// attribution. Always "hivemind" for this CLI.
+export function signupFlowHeader(): Record<string, string> {
+  return { "X-Deeplake-Signup-Flow": "hivemind" };
+}
+
 export async function requestDeviceCode(apiUrl = DEFAULT_API_URL, ref?: string): Promise<DeviceCodeResponse> {
   const resp = await fetch(`${apiUrl}/auth/device/code`, {
     method: "POST",
@@ -109,6 +117,7 @@ export async function requestDeviceCode(apiUrl = DEFAULT_API_URL, ref?: string):
       ...deeplakeClientHeader(),
       ...hivemindInstallIDHeader(),
       ...hivemindReferrerHeader(ref),
+      ...signupFlowHeader(),
     },
   });
   if (!resp.ok) throw new Error(`Device flow unavailable: HTTP ${resp.status}`);
@@ -122,6 +131,10 @@ export async function pollForToken(deviceCode: string, apiUrl = DEFAULT_API_URL)
       "Content-Type": "application/json",
       ...deeplakeClientHeader(),
       ...hivemindInstallIDHeader(),
+      // The backend resolves/creates the user on this poll (trackDeviceFlowAuth),
+      // so the flow header must ride along here too — the /auth/device/code
+      // request alone no longer parks it (signup_flow_pending was dropped).
+      ...signupFlowHeader(),
     },
     body: JSON.stringify({ device_code: deviceCode }),
   });

--- a/tests/cli/signup-flow.test.ts
+++ b/tests/cli/signup-flow.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { signupFlowHeader, requestDeviceCode, pollForToken } from "../../src/commands/auth.js";
+
+// The signup flow (X-Deeplake-Signup-Flow: hivemind) tags which product entry
+// point a user signed up through. The backend reads it at user creation, which
+// happens on the /auth/device/token poll (trackDeviceFlowAuth), so the header
+// must ride on BOTH the device-code request and the token poll — the
+// signup_flow_pending parking bridge was removed. These tests pin the pure
+// header and that both requests actually put it on the wire.
+
+describe("signupFlowHeader", () => {
+  it("always emits the hivemind flow header", () => {
+    expect(signupFlowHeader()).toEqual({ "X-Deeplake-Signup-Flow": "hivemind" });
+  });
+});
+
+describe("device flow sends the signup-flow header", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let prevHome: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    // Sandbox HOME so the install-id helper writes to throwaway state.
+    prevHome = process.env.HOME;
+    tmpHome = mkdtempSync(join(tmpdir(), "hivemind-flow-home-"));
+    process.env.HOME = tmpHome;
+
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function sentHeaders(): Record<string, string> {
+    return mockFetch.mock.calls[0][1].headers as Record<string, string>;
+  }
+
+  it("sends the header on /auth/device/code", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        device_code: "dc", user_code: "uc",
+        verification_uri: "https://v", verification_uri_complete: "https://v?c=uc",
+        expires_in: 600, interval: 5,
+      }),
+    });
+
+    await requestDeviceCode("https://api.example.com");
+    expect(sentHeaders()["X-Deeplake-Signup-Flow"]).toBe("hivemind");
+  });
+
+  it("sends the header on /auth/device/token", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "at", token_type: "Bearer", expires_in: 3600 }),
+    });
+
+    await pollForToken("dc", "https://api.example.com");
+    expect(sentHeaders()["X-Deeplake-Signup-Flow"]).toBe("hivemind");
+  });
+});


### PR DESCRIPTION
## What
Sends `X-Deeplake-Signup-Flow: hivemind` on the device-flow login requests so the backend persists `users.signup_flow='hivemind'` at user creation (first-write-wins). This tags which product entry point a user signed up through — driving per-flow onboarding (the CLI signup plan step) and attribution.

## Changes
- `signupFlowHeader()` helper (mirrors `hivemindReferrerHeader`).
- Sent on **both** `/auth/device/code` and `/auth/device/token` — the user is resolved/created on the token poll (`trackDeviceFlowAuth`) and the `signup_flow_pending` parking bridge was removed backend-side, so the header must ride on the poll.
- `tests/cli/signup-flow.test.ts` pins the header on both requests.

## Notes
Part of the hivemind CLI signup → plan-selection flow (deeplake-ui #332, deeplake-api #308). This CLI change is independent and backward-compatible on its own. Handing back for maintainer review/merge (public repo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signup-flow identification to device authorization requests and token polling, supporting a smoother authentication experience.

* **Bug Fixes**
  * Ensured signup-flow information is consistently included throughout the device login process.

* **Tests**
  * Added coverage verifying the required signup-flow header is sent during authorization and token requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->