### PR TITLE
fix(recall): semantic-only proactive recall, drop ILIKE full-scan fallback

### DIFF
--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -102,9 +102,10 @@ function emit(additionalContext: string): void {
 }
 
 /**
- * Find the top hit: semantic when embeddings yield a vector, else lexical.
- * Also falls back to lexical when semantic finds nothing (e.g. summaries not
- * embedded yet). Bounded by withDeadline in main.
+ * Find the top hit: SEMANTIC-ONLY. Embeds the prompt and takes the top cosine
+ * hit that clears the threshold. If embeddings are unavailable, the prompt
+ * yields no vector, or nothing clears the bar, recall is skipped — there is
+ * deliberately no lexical (ILIKE) fallback. Bounded by withDeadline in main.
  */
 async function findHit(
   input: RecallInput,
@@ -142,9 +143,9 @@ async function findHit(
       // `node_modules` symlink that `hivemind embeddings install` created.
       // capture.js repairs this too, but recall and capture are independent
       // async UserPromptSubmit hooks — recall can run first, so without this
-      // the first prompt after an upgrade would silently lose semantic recall
-      // (falling back to lexical/null) even though embeddings are installed.
-      // Best-effort: a failure here just means we degrade to lexical.
+      // the first prompt after an upgrade would silently skip recall entirely
+      // (there is no lexical fallback) even though embeddings are installed.
+      // Best-effort: a failure here just means we skip semantic recall.
       try { ensurePluginNodeModulesLink({ bundleDir: __bundleDir }); } catch { /* best-effort */ }
       // Warm the daemon (spawn + wait for socket, bounded) THEN embed with one
       // retry, so a cold first prompt doesn't lose semantic recall to the

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -10,9 +10,10 @@
  * `~/.deeplake/recall-events.jsonl` sink (independent of HIVEMIND_DEBUG) so
  * usage / hit-rate is directly measurable.
  *
- * Search mode: SEMANTIC (cosine) when embeddings are available, else falls back
- * to LEXICAL (ILIKE keyword overlap) — so recall works WITHOUT the embeddings
- * model installed. Each mode has its own precision gate.
+ * Search mode: SEMANTIC (cosine) ONLY. When embeddings are unavailable (or the
+ * query yields no vector), recall is SKIPPED — there is deliberately no lexical
+ * (ILIKE) fallback, which forced unindexed full-table scans on the backend
+ * (seconds-long per prompt) for little precision. Better to return nothing.
  *
  * Design guarantees:
  *   - Precision-biased: skip aggressively; never inject below the bar.
@@ -40,13 +41,11 @@ import { dirname, join } from "node:path";
 import {
   shouldRecall,
   passesThreshold,
-  extractKeywords,
   proactiveRecallDisabled,
   parsePositive,
   RECALL_THRESHOLD,
-  MIN_LEXICAL_OVERLAP,
 } from "./shared/recall-gate.js";
-import { recallTopHit, recallTopHitLexical } from "./shared/recall-query.js";
+import { recallTopHit } from "./shared/recall-query.js";
 import { entrypointPassesOnlyCliGate } from "./shared/capture-gate.js";
 import { formatRecallContext, type RecallHit } from "./shared/recall-format.js";
 import { withDeadline } from "./shared/with-deadline.js";
@@ -132,10 +131,10 @@ async function findHit(
   // Failure-isolated: catch our own I/O errors and report `error` so the caller
   // (and telemetry) never mislabels a backend failure as a deadline timeout.
   try {
-    // Hybrid: prefer a semantic hit that clears the threshold; otherwise fall
-    // through to lexical (exact keyword/identifier match), the same way the grep
-    // path blends both. A below-threshold semantic hit must NOT suppress a good
-    // lexical match (stack traces / exact error names).
+    // SEMANTIC-ONLY: take the top cosine hit that clears the threshold. There is
+    // deliberately NO lexical (ILIKE) fallback — an unindexed keyword scan over
+    // summary+message is a full-table scan on the backend (seconds per prompt),
+    // so if semantic is unavailable or misses we skip rather than fall back.
     let semanticHit: RecallHit | null = null;
     if (SEMANTIC_ENABLED) {
       // Self-heal the shared-deps symlink BEFORE building the EmbedClient.
@@ -164,13 +163,7 @@ async function findHit(
       }
     }
 
-    const keywords = extractKeywords(prompt);
-    if (keywords.length >= 2) {
-      const lex = await recallTopHitLexical(q, config.tableName, keywords, opts);
-      if (lex && lex.score >= MIN_LEXICAL_OVERLAP) return { kind: "hit", hit: lex };
-    }
-
-    // Nothing cleared a bar. Surface the below-threshold semantic hit (so
+    // Nothing cleared the bar. Surface the below-threshold semantic hit (so
     // telemetry records 'below') if we had one; otherwise nothing matched.
     return semanticHit ? { kind: "hit", hit: semanticHit } : { kind: "none" };
   } catch (e) {
@@ -182,11 +175,9 @@ async function findHit(
   }
 }
 
-/** Mode-aware relevance gate: cosine threshold for semantic, overlap for lexical. */
+/** Relevance gate: cosine threshold for the (semantic-only) hit. */
 function hitPasses(hit: RecallHit): boolean {
-  return hit.mode === "semantic"
-    ? passesThreshold(hit.score)
-    : hit.score >= MIN_LEXICAL_OVERLAP;
+  return passesThreshold(hit.score);
 }
 
 async function main(): Promise<void> {
@@ -237,7 +228,7 @@ async function main(): Promise<void> {
 
   const hit = res.hit;
   const teammate = hit.author !== config.userName;
-  const bar = hit.mode === "semantic" ? `thr=${RECALL_THRESHOLD}` : `min=${MIN_LEXICAL_OVERLAP}`;
+  const bar = `thr=${RECALL_THRESHOLD}`;
   if (!hitPasses(hit)) {
     log(`searched mode=${hit.mode} hit=below score=${hit.score} ${bar} author=${hit.author}`);
     recordRecallEvent({ event: "below", gate: reason, mode: hit.mode, score: hit.score, author: hit.author, teammate, project: hit.project, session });

--- a/src/hooks/shared/recall-format.ts
+++ b/src/hooks/shared/recall-format.ts
@@ -50,9 +50,9 @@ export interface RecallHit {
   summary?: string;
   description: string;
   lastUpdate: string; // ISO-ish date string from last_update_date
-  /** semantic: cosine 0..1; lexical: count of distinct keywords matched. */
+  /** semantic cosine similarity, 0..1 (higher = closer). */
   score: number;
-  mode: "semantic" | "lexical";
+  mode: "semantic";
 }
 
 /**

--- a/src/hooks/shared/recall-query.ts
+++ b/src/hooks/shared/recall-query.ts
@@ -10,7 +10,7 @@
  */
 
 import { serializeFloat4Array } from "../../shell/grep-core.js";
-import { sqlStr, sqlLike } from "../../utils/sql.js";
+import { sqlStr } from "../../utils/sql.js";
 import type { RecallHit } from "./recall-format.js";
 
 // `summary` is selected alongside `description` so recall can inject a
@@ -67,40 +67,7 @@ export async function recallTopHit(
   return mapTopRow(await query(sql), "semantic");
 }
 
-/**
- * Lexical fallback (no embeddings): rank summaries by how many of the prompt's
- * salient keywords they contain (ILIKE on summary+description). Mirrors the
- * codebase's ILIKE search path (BM25 indexing is currently disabled backend-
- * side — see deeplake-api.ts). `score` is the distinct-keyword overlap count;
- * the caller gates on MIN_LEXICAL_OVERLAP.
- */
-export async function recallTopHitLexical(
-  query: QueryFn,
-  memoryTable: string,
-  keywords: string[],
-  opts: RecallQueryOptions = {},
-): Promise<RecallHit | null> {
-  if (keywords.length < 2) return null;
-  const field = `(COALESCE(summary, '') || ' ' || COALESCE(description, ''))`;
-  const overlap = keywords
-    .map((k) => `(CASE WHEN ${field} ILIKE '%${sqlLike(k)}%' THEN 1 ELSE 0 END)`)
-    .join(" + ");
-  const anyMatch = keywords.map((k) => `${field} ILIKE '%${sqlLike(k)}%'`).join(" OR ");
-
-  // Summaries only (the memory table also holds notes/goals/files).
-  const filters = [`path LIKE '/summaries/%'`, `(${anyMatch})`];
-  if (opts.project) filters.push(`project = '${sqlStr(opts.project)}'`);
-  if (opts.excludePath) filters.push(`path <> '${sqlStr(opts.excludePath)}'`);
-
-  const sql =
-    `SELECT ${SELECT_COLS}, (${overlap}) AS score ` +
-    `FROM "${memoryTable}" WHERE ${filters.join(" AND ")} ` +
-    `ORDER BY score DESC, ${TIE_BREAK} LIMIT ${Math.max(1, opts.limit ?? 3)}`;
-
-  return mapTopRow(await query(sql), "lexical");
-}
-
-function mapTopRow(rows: Array<Record<string, unknown>>, mode: "semantic" | "lexical"): RecallHit | null {
+function mapTopRow(rows: Array<Record<string, unknown>>, mode: "semantic"): RecallHit | null {
   if (!rows.length) return null;
   const r = rows[0];
   const score = Number(r["score"]);

--- a/tests/claude-code/recall-hook.test.ts
+++ b/tests/claude-code/recall-hook.test.ts
@@ -4,9 +4,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
  * Orchestration tests for src/hooks/recall.ts — the UserPromptSubmit proactive-
  * recall hook. Drives main() end-to-end with mocked boundaries (stdin, config,
  * embeddings, DeeplakeApi, plugin-state, debug log) and asserts the emit/skip
- * decision, semantic↔lexical fallback, mode-aware gating, latency budget, and
- * failure isolation. The pure helpers (gate/format/query/deadline) run for
- * real — only the I/O boundary is mocked.
+ * decision, semantic-only search (no lexical/ILIKE fallback), the cosine gate,
+ * latency budget, and failure isolation. The pure helpers
+ * (gate/format/query/deadline) run for real — only the I/O boundary is mocked.
  *
  * SEMANTIC_ENABLED and RECALL_BUDGET_MS are read at module-eval time, so each
  * case sets env + mocks BEFORE the per-test dynamic import (vi.resetModules).
@@ -78,7 +78,7 @@ beforeEach(() => {
   stdinMock.mockReset().mockResolvedValue({ prompt: "how did we fix the parser typeerror crash bug", session_id: "sid", cwd: "/repo" });
   loadConfigMock.mockReset().mockReturnValue(CONFIG);
   pluginEnabledMock.mockReset().mockReturnValue(true);
-  embeddingsDisabledMock.mockReset().mockReturnValue(true); // default: lexical
+  embeddingsDisabledMock.mockReset().mockReturnValue(false); // default: semantic on (only search mode)
   embedMock.mockReset().mockResolvedValue([0.1, 0.2, 0.3]);
   queryMock.mockReset().mockResolvedValue([]);
   debugLogMock.mockReset();
@@ -146,55 +146,34 @@ describe("recall hook — guards (no search, no emit)", () => {
   });
 });
 
-describe("recall hook — lexical path (no embeddings)", () => {
-  it("injects an attributed block on a lexical hit above the overlap floor", async () => {
+describe("recall hook — no embeddings (semantic-only: skip, never lexical)", () => {
+  it("skips the search entirely when embeddings are disabled — NO ILIKE fallback", async () => {
+    // The lexical (ILIKE) fallback was removed: it forced unindexed full-table
+    // scans on the backend. With embeddings off there is no search mode, so
+    // recall must return nothing WITHOUT ever querying.
+    embeddingsDisabledMock.mockReturnValue(true);
     queryMock.mockResolvedValue([row({ score: 4, author: "levon" })]);
-    const out = await runHook(); // embeddingsDisabled=true → lexical
-    const parsed = parse(out);
-    expect(parsed.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
-    expect(parsed.hookSpecificOutput.additionalContext).toContain("HIVEMIND RECALL");
-    expect(parsed.hookSpecificOutput.additionalContext).toContain("levon");
-    // It used the lexical ILIKE query, not the semantic one.
-    expect(queryMock.mock.calls[0][0]).toContain("ILIKE");
-    expect(queryMock.mock.calls[0][0]).not.toContain("<#>");
-    expect(embedMock).not.toHaveBeenCalled();
-    expect(debugLogMock).toHaveBeenCalledWith(expect.stringContaining("injected mode=lexical"));
-    // Always-on telemetry records the injection.
-    expect(recordEventMock).toHaveBeenCalledWith(expect.objectContaining({ event: "injected", mode: "lexical", teammate: true }));
-  });
-
-  it("does NOT inject when the lexical overlap is below the floor (records 'none')", async () => {
-    // A too-weak lexical match (overlap 1 < MIN 2) is treated as nothing
-    // relevant — recorded as 'none', not 'below' (which is for scored-but-low
-    // semantic hits).
-    queryMock.mockResolvedValue([row({ score: 1 })]);
     const out = await runHook();
     expect(out).toBeNull();
+    expect(queryMock).not.toHaveBeenCalled(); // no lexical query
+    expect(embedMock).not.toHaveBeenCalled(); // no embedding either
     expect(recordEventMock).toHaveBeenCalledWith(expect.objectContaining({ event: "none" }));
   });
 
-  it("does not search when the prompt passes the gate but yields fewer than 2 keywords", async () => {
-    // "TypeError?" passes shouldRecall (signal) but extractKeywords → 1 token,
-    // so the lexical path must bail BEFORE querying (exercises keywords<2, not
-    // the gate's too-short branch).
-    stdinMock.mockResolvedValue({ prompt: "TypeError?", session_id: "sid", cwd: "/repo" });
-    const out = await runHook();
-    expect(out).toBeNull();
-    expect(queryMock).not.toHaveBeenCalled();
-  });
-
-  it("excludes the current session's own summary from results", async () => {
-    queryMock.mockResolvedValue([row({ score: 3 })]);
+  it("excludes the current session's own summary from the (semantic) results", async () => {
+    queryMock.mockResolvedValue([row({ score: 0.8 })]);
     await runHook();
     expect(queryMock.mock.calls[0][0]).toContain("path <> '/summaries/sasun/sid.md'");
   });
 
   it("restricts the search to summary rows and does NOT project-scope by cwd basename", async () => {
-    queryMock.mockResolvedValue([row({ score: 3 })]);
+    queryMock.mockResolvedValue([row({ score: 0.8 })]);
     await runHook(); // default fixture cwd = "/repo"
     const sql = queryMock.mock.calls[0][0];
     expect(sql).toContain("path LIKE '/summaries/%'"); // summaries only
     expect(sql).not.toContain("project ="); // no fragile basename scoping
+    expect(sql).toContain("<#>"); // cosine (semantic) query, not ILIKE
+    expect(sql).not.toContain("ILIKE");
   });
 });
 
@@ -229,44 +208,35 @@ describe("recall hook — semantic path (embeddings on)", () => {
     expect(embedMock).toHaveBeenCalled(); // proceeded to embed despite repair failure
   });
 
-  it("records 'below' (no inject) when semantic is below threshold AND lexical also misses", async () => {
+  it("records 'below' (no inject) when the semantic hit is below the cosine threshold", async () => {
     embeddingsDisabledMock.mockReturnValue(false);
-    queryMock.mockResolvedValue([row({ score: 0.2 })]); // semantic below; lexical overlap 0.2 < 2
+    queryMock.mockResolvedValue([row({ score: 0.2 })]); // semantic below threshold
     const out = await runHook();
     expect(out).toBeNull();
     expect(debugLogMock).toHaveBeenCalledWith(expect.stringContaining("mode=semantic hit=below"));
+    // No lexical retry: only the one semantic query ran.
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][0]).not.toContain("ILIKE");
   });
 
-  it("HYBRID: a below-threshold semantic hit does not suppress a passing lexical match", async () => {
+  it("skips (no inject) when semantic finds no embedded rows — NO lexical fallback", async () => {
     embeddingsDisabledMock.mockReturnValue(false);
-    queryMock
-      .mockResolvedValueOnce([row({ score: 0.2 })])              // semantic: below threshold
-      .mockResolvedValueOnce([row({ score: 3, author: "levon" })]); // lexical: clears overlap
+    queryMock.mockResolvedValue([]); // semantic: no embedded rows
     const out = await runHook();
-    expect(parse(out).hookSpecificOutput.additionalContext).toContain("levon");
-    expect(queryMock.mock.calls[0][0]).toContain("<#>");   // semantic tried first
-    expect(queryMock.mock.calls[1][0]).toContain("ILIKE"); // then lexical wins
-    expect(debugLogMock).toHaveBeenCalledWith(expect.stringContaining("injected mode=lexical"));
+    expect(out).toBeNull();
+    expect(queryMock).toHaveBeenCalledTimes(1); // only the semantic query, no ILIKE retry
+    expect(queryMock.mock.calls[0][0]).toContain("<#>");
+    expect(recordEventMock).toHaveBeenCalledWith(expect.objectContaining({ event: "none" }));
   });
 
-  it("falls back to lexical when semantic finds no embedded rows", async () => {
+  it("skips (no query at all) when the embed daemon is unavailable — NO lexical fallback", async () => {
     embeddingsDisabledMock.mockReturnValue(false);
-    queryMock
-      .mockResolvedValueOnce([])                       // semantic: no embedded rows
-      .mockResolvedValueOnce([row({ score: 3 })]);     // lexical: keyword hit
-    const out = await runHook();
-    expect(parse(out).hookSpecificOutput.additionalContext).toContain("HIVEMIND RECALL");
-    expect(queryMock.mock.calls[0][0]).toContain("<#>");   // 1st = semantic
-    expect(queryMock.mock.calls[1][0]).toContain("ILIKE"); // 2nd = lexical
-  });
-
-  it("falls back to lexical when the embed daemon is unavailable", async () => {
-    embeddingsDisabledMock.mockReturnValue(false);
-    embedMock.mockResolvedValue(null); // daemon down
+    embedMock.mockResolvedValue(null); // daemon down → no query vector
     queryMock.mockResolvedValue([row({ score: 3 })]);
     const out = await runHook();
-    expect(parse(out).hookSpecificOutput.additionalContext).toContain("HIVEMIND RECALL");
-    expect(queryMock.mock.calls[0][0]).toContain("ILIKE");
+    expect(out).toBeNull();
+    expect(queryMock).not.toHaveBeenCalled(); // no vector → never query
+    expect(recordEventMock).toHaveBeenCalledWith(expect.objectContaining({ event: "none" }));
   });
 });
 

--- a/tests/shared/recall.test.ts
+++ b/tests/shared/recall.test.ts
@@ -15,7 +15,7 @@ import {
   extractSection,
   type RecallHit,
 } from "../../src/hooks/shared/recall-format.js";
-import { recallTopHit, recallTopHitLexical } from "../../src/hooks/shared/recall-query.js";
+import { recallTopHit } from "../../src/hooks/shared/recall-query.js";
 import { withDeadline } from "../../src/hooks/shared/with-deadline.js";
 import { recordRecallEvent } from "../../src/hooks/shared/recall-events.js";
 import { setFakeHome, clearFakeHome } from "./fake-home.js";
@@ -508,42 +508,6 @@ describe("extractKeywords — lexical fallback keyword extraction", () => {
   });
   it("returns few/no keywords for terse input (can't meet the lexical bar)", () => {
     expect(extractKeywords("ok go").length).toBeLessThan(2);
-  });
-});
-
-describe("recallTopHitLexical — ILIKE keyword-overlap fallback", () => {
-  const kw = ["parser", "typeerror"];
-
-  it("builds an overlap-ranked ILIKE query and tags the hit lexical", async () => {
-    let captured = "";
-    const query = async (sql: string) => {
-      captured = sql;
-      return [{ path: "/summaries/levon/s.md", author: "levon", project: "indra", description: "d", last_update_date: "2026-06-18", score: 2 }];
-    };
-    const hit = await recallTopHitLexical(query, "org_memory", kw, { excludePath: "/summaries/me/x.md" });
-    expect(captured).toContain("path LIKE '/summaries/%'"); // summaries only
-    expect(captured).toContain("ILIKE '%parser%'");
-    expect(captured).toContain("ILIKE '%typeerror%'");
-    expect(captured).toContain("CASE WHEN"); // overlap count
-    expect(captured).toContain('FROM "org_memory"');
-    expect(captured).toContain("path <> '/summaries/me/x.md'");
-    // overlap ties are common (small ints) → break deterministically by recency
-    expect(captured).toContain("ORDER BY score DESC, last_update_date DESC, path ASC");
-    expect(hit).toMatchObject({ author: "levon", score: 2, mode: "lexical" });
-  });
-
-  it("returns null when fewer than 2 keywords (precision floor)", async () => {
-    let called = false;
-    const hit = await recallTopHitLexical(async () => { called = true; return []; }, "t", ["only"], {});
-    expect(hit).toBeNull();
-    expect(called).toBe(false);
-  });
-
-  it("applies the project filter when provided", async () => {
-    let captured = "";
-    await recallTopHitLexical(async (sql) => { captured = sql; return []; }, "t", kw, { project: "indra", limit: 5 });
-    expect(captured).toContain("project = 'indra'");
-    expect(captured).toContain("LIMIT 5"); // explicit limit honored (vs default 3)
   });
 });
 


### PR DESCRIPTION
## Problem

Proactive recall (`UserPromptSubmit` hook) fell back to a **lexical ILIKE** search when semantic embeddings were unavailable or missed the threshold. That fallback (`recallTopHitLexical`) issued:

```sql
... WHERE path LIKE '/summaries/%' AND (summary||description) ILIKE '%kw%' OR ...
```

A leading-`%` `ILIKE` can't use any index, so pg-deeplake runs it as a **full-table scan over the summary/message text columns** — measured at **~37s** on a large org (`coding.sessions` ≈ 923k rows). Worse, the recall client abandons the query at the 1500ms budget, but the backend keeps executing to completion, so **the server pays the full multi-second cost even though the result is thrown away**.

## Fix

Remove the lexical fallback entirely. Recall is now **semantic (cosine) only**:

- If embeddings are unavailable, yield no vector, or the top hit misses the threshold → **skip** (emit nothing).
- No ILIKE query is ever issued from the proactive path, so it can't trigger the backend full-scan.

The semantic path, the 1500ms recall budget, and failure-isolation are unchanged.

## Changes
- `recall.ts` — `findHit()` semantic-only; drop `extractKeywords`/`MIN_LEXICAL_OVERLAP`/`recallTopHitLexical` usage; simplify `hitPasses` + log bar
- `recall-query.ts` — delete `recallTopHitLexical` + now-unused `sqlLike` import
- `recall-format.ts` — narrow `RecallHit.mode` to `"semantic"`
- `tests/shared/recall.test.ts` — drop the lexical-path suite

Net **−78 lines**. `tsc --noEmit` clean; all **61** recall tests pass.

## Notes
- `extractKeywords` / `MIN_LEXICAL_OVERLAP` in `recall-gate.ts` are now unused in `src` (kept to keep this focused; can delete in a follow-up).
- The **reactive** grep path (`virtual-table-query.ts`, the memory+sessions UNION ILIKE) is the other source of the same full-scan and is **not** touched here — separate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Proactive recall now uses semantic matching exclusively (no keyword/lexical fallback).
  * Recall results now consistently report semantic similarity scoring and semantic-only mode.
* **Bug Fixes**
  * Prevented unavailable or below-threshold semantic searches from triggering broad keyword scans.
* **Tests**
  * Updated recall test coverage to validate semantic-only behavior, including scenarios where embeddings are disabled or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->