### PR TITLE
fix(memory): surface honest notice for bodyless session reads

### DIFF
--- a/src/hooks/virtual-table-query.ts
+++ b/src/hooks/virtual-table-query.ts
@@ -1,6 +1,6 @@
 import type { DeeplakeApi } from "../deeplake-api.js";
 import { sqlLike, sqlStr } from "../utils/sql.js";
-import { normalizeContent } from "../shell/grep-core.js";
+import { normalizeContent, emptySessionBodyNotice } from "../shell/grep-core.js";
 
 type Row = Record<string, unknown>;
 
@@ -165,16 +165,28 @@ export async function readVirtualPathContents(
 
   const memoryHits = new Map<string, string>();
   const sessionHits = new Map<string, string[]>();
+  // Count session rows per path regardless of body content, so a path whose
+  // rows all carry NULL/empty `message` (dropped by the typeof guard below) is
+  // still distinguishable from a path with no rows at all. The former is a
+  // corrupt/bodyless session (size>0 but nothing to read) and must NOT collapse
+  // to a silently-empty file or a misleading "No such file".
+  const sessionRowCounts = new Map<string, number>();
   for (const row of rows) {
     const path = row["path"];
-    const content = row["content"];
     const sourceOrder = Number(row["source_order"] ?? 0);
-    if (typeof path !== "string" || typeof content !== "string") continue;
+    if (typeof path !== "string") continue;
+    if (sourceOrder !== 0) {
+      sessionRowCounts.set(path, (sessionRowCounts.get(path) ?? 0) + 1);
+    }
+    const content = row["content"];
+    if (typeof content !== "string") continue;
     if (sourceOrder === 0) {
       memoryHits.set(path, content);
     } else {
+      const normalized = normalizeSessionPart(path, content);
+      if (!normalized) continue;
       const current = sessionHits.get(path) ?? [];
-      current.push(normalizeSessionPart(path, content));
+      current.push(normalized);
       sessionHits.set(path, current);
     }
   }
@@ -187,6 +199,14 @@ export async function readVirtualPathContents(
     const sessionParts = sessionHits.get(path) ?? [];
     if (sessionParts.length > 0) {
       result.set(path, sessionParts.join("\n"));
+      continue;
+    }
+    // Rows exist for this session but every body was empty/NULL — surface an
+    // honest diagnostic instead of an empty file (silent 0 bytes) or leaving
+    // it null (which the caller renders as "No such file" though `ls` lists it).
+    const rowCount = sessionRowCounts.get(path) ?? 0;
+    if (rowCount > 0) {
+      result.set(path, emptySessionBodyNotice(rowCount));
     }
   }
 

--- a/src/shell/deeplake-fs.ts
+++ b/src/shell/deeplake-fs.ts
@@ -7,7 +7,7 @@ import type {
   IFileSystem, FsStat, MkdirOptions, RmOptions, CpOptions,
   FileContent, BufferEncoding,
 } from "just-bash";
-import { normalizeContent } from "./grep-core.js";
+import { normalizeContent, emptySessionBodyNotice } from "./grep-core.js";
 import { EmbedClient } from "../embeddings/client.js";
 import { embeddingSqlLiteral } from "../embeddings/sql.js";
 import { embeddingsDisabled } from "../embeddings/disable.js";
@@ -58,7 +58,13 @@ export function guessMime(filename: string): string {
 }
 
 function normalizeSessionMessage(path: string, message: unknown): string {
+  // A NULL/undefined message column must coerce to "" — not the JS value
+  // `undefined` (JSON.stringify(undefined) === undefined) which would leak into
+  // the joined output, and not the literal "null" text (JSON.stringify(null)).
+  if (message === null || message === undefined) return "";
   const raw = typeof message === "string" ? message : JSON.stringify(message);
+  // JSON.stringify can still return undefined for non-serializable values.
+  if (typeof raw !== "string") return "";
   return normalizeContent(path, raw);
 }
 
@@ -73,7 +79,13 @@ function resolveEmbedDaemonPath(): string {
 }
 
 function joinSessionMessages(path: string, messages: unknown[]): string {
-  return messages.map((message) => normalizeSessionMessage(path, message)).join("\n");
+  // Drop empty parts so bodyless rows don't turn into phantom blank lines (and
+  // so an all-empty session reconstructs to "" — the caller's cue to emit the
+  // empty-body notice rather than a silently-empty file).
+  return messages
+    .map((message) => normalizeSessionMessage(path, message))
+    .filter((part) => part.length > 0)
+    .join("\n");
 }
 
 function fsErr(code: string, msg: string, path: string): Error {
@@ -680,15 +692,16 @@ export class DeeplakeFs implements IFileSystem {
       const rows = await this.client.query(
         `SELECT path, message, creation_date FROM "${this.sessionsTable}" WHERE path IN (${inList}) ORDER BY path, creation_date ASC`
       );
-      const grouped = new Map<string, string[]>();
+      const grouped = new Map<string, unknown[]>();
       for (const row of rows) {
         const p = row["path"] as string;
         const current = grouped.get(p) ?? [];
-        current.push(normalizeSessionMessage(p, row["message"]));
+        current.push(row["message"]);
         grouped.set(p, current);
       }
-      for (const [p, parts] of grouped) {
-        this.files.set(p, Buffer.from(parts.join("\n"), "utf-8"));
+      for (const [p, messages] of grouped) {
+        const text = joinSessionMessages(p, messages);
+        this.files.set(p, Buffer.from(text || emptySessionBodyNotice(messages.length), "utf-8"));
       }
     }
   }
@@ -715,7 +728,7 @@ export class DeeplakeFs implements IFileSystem {
       );
       if (rows.length === 0) throw fsErr("ENOENT", "no such file or directory", p);
       const text = joinSessionMessages(p, rows.map((row) => row["message"]));
-      const buf = Buffer.from(text, "utf-8");
+      const buf = Buffer.from(text || emptySessionBodyNotice(rows.length), "utf-8");
       this.files.set(p, buf);
       return buf;
     }
@@ -782,7 +795,7 @@ export class DeeplakeFs implements IFileSystem {
         `SELECT message FROM "${this.sessionsTable}" WHERE path = '${esc(p)}' ORDER BY creation_date ASC`
       );
       if (rows.length === 0) throw fsErr("ENOENT", "no such file or directory", p);
-      const text = joinSessionMessages(p, rows.map((row) => row["message"]));
+      const text = joinSessionMessages(p, rows.map((row) => row["message"])) || emptySessionBodyNotice(rows.length);
       const buf = Buffer.from(text, "utf-8");
       this.files.set(p, buf);
       return text;

--- a/src/shell/grep-core.ts
+++ b/src/shell/grep-core.ts
@@ -175,6 +175,26 @@ function formatToolCall(obj: any): string {
   return `[tool:${obj?.tool_name ?? "?"}]\ninput: ${formatToolInput(obj?.tool_input)}\nresponse: ${formatToolResponse(obj?.tool_response, obj?.tool_input, obj?.tool_name)}`;
 }
 
+/**
+ * Diagnostic emitted when a session path resolves to real rows whose message
+ * bodies are all empty/null. A captured event is never legitimately empty
+ * (capture.ts always writes a populated JSON entry), so an empty reconstruction
+ * is always a pathology — the row carries a non-zero `size_bytes` (so `ls`/stat
+ * shows a size) but no readable body. Returning this notice instead of a
+ * silently-empty file is the difference between "the transcript body is gone"
+ * and "this file is genuinely empty" — the exact ambiguity that made the mirror
+ * look populated when it wasn't.
+ */
+export function emptySessionBodyNotice(rowCount: number): string {
+  const plural = rowCount === 1 ? "row" : "rows";
+  return (
+    `[hivemind: this session has ${rowCount} stored ${plural} but the message ` +
+    `body is empty — capture recorded metadata (size only) without content, so ` +
+    `the transcript body is unavailable. This is not an empty file; there is ` +
+    `nothing to read here.]`
+  );
+}
+
 export function normalizeContent(path: string, raw: string): string {
   // Any unknown shape falls through to `raw` below. This function never
   // returns null/empty — if the result would be trivially empty (e.g.

--- a/tests/claude-code/deeplake-fs.test.ts
+++ b/tests/claude-code/deeplake-fs.test.ts
@@ -790,6 +790,73 @@ describe("prefetch", () => {
   });
 });
 
+// ── Session reads: bodyless rows must not read as silent empty files ─────────
+describe("readFile: session bodies", () => {
+  function makeSessionsFs(messages: unknown[]) {
+    const path = "/sessions/alice/a.json";
+    const client = {
+      ensureTable: vi.fn().mockResolvedValue(undefined),
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes("SELECT path, size_bytes, mime_type")) return [];
+        if (sql.includes("SELECT path, MAX(size_bytes) as total_size")) {
+          // size_bytes is populated even when the body is empty — this is the
+          // exact "ls shows a size, cat shows nothing" split being tested.
+          return [{ path, total_size: 30295 }];
+        }
+        if (sql.includes("SELECT message FROM")) {
+          return messages.map((message) => ({ message }));
+        }
+        return [];
+      }),
+    };
+    return { path, client };
+  }
+
+  it("returns an empty-body notice (not 0 bytes) when all message rows are NULL", async () => {
+    const { path, client } = makeSessionsFs([null, null]);
+    const fs = await DeeplakeFs.create(client as never, "memory", "/", "sessions");
+
+    const text = await fs.readFile(path);
+
+    expect(text).not.toBe("");
+    expect(text).toContain("2 stored rows");
+    expect(text).toContain("message body is empty");
+  });
+
+  it("does not leak the literal string 'null' or 'undefined' into content", async () => {
+    const { path, client } = makeSessionsFs([null, undefined]);
+    const fs = await DeeplakeFs.create(client as never, "memory", "/", "sessions");
+
+    const text = await fs.readFile(path);
+
+    expect(text).not.toContain("null");
+    expect(text).not.toContain("undefined");
+  });
+
+  it("readFileBuffer also emits the notice for empty-string bodies", async () => {
+    const { path, client } = makeSessionsFs(["", ""]);
+    const fs = await DeeplakeFs.create(client as never, "memory", "/", "sessions");
+
+    const buf = await fs.readFileBuffer(path);
+
+    expect(Buffer.from(buf).toString("utf-8")).toContain("message body is empty");
+  });
+
+  it("keeps only real turns when a session mixes empty and populated bodies", async () => {
+    const { path, client } = makeSessionsFs([
+      "",
+      "{\"type\":\"user_message\",\"content\":\"hello\"}",
+      null,
+      "{\"type\":\"assistant_message\",\"content\":\"hi\"}",
+    ]);
+    const fs = await DeeplakeFs.create(client as never, "memory", "/", "sessions");
+
+    const text = await fs.readFile(path);
+
+    expect(text).toBe("[user] hello\n[assistant] hi");
+  });
+});
+
 // ── Upsert: id stability & dates ─────────────────────────────────────────────
 describe("flush upsert", () => {
   it("INSERT for new file sets id, creation_date and last_update_date", async () => {

--- a/tests/claude-code/virtual-table-query.test.ts
+++ b/tests/claude-code/virtual-table-query.test.ts
@@ -102,6 +102,50 @@ describe("virtual-table-query", () => {
     expect(content).toBe("[user] hello\n[assistant] hi");
   });
 
+  it("surfaces an empty-body notice when session rows exist but every message is empty", async () => {
+    const api = {
+      query: vi.fn().mockResolvedValueOnce([
+        { path: "/sessions/a.jsonl", content: "", source_order: 1 },
+        { path: "/sessions/a.jsonl", content: "", source_order: 1 },
+      ]),
+    } as any;
+
+    const content = await readVirtualPathContent(api, "memory", "sessions", "/sessions/a.jsonl");
+
+    // Not a silent 0-byte read: the file exists (has rows) but no readable body.
+    expect(content).not.toBe("");
+    expect(content).toContain("2 stored rows");
+    expect(content).toContain("message body is empty");
+  });
+
+  it("surfaces an empty-body notice when session message columns are NULL (dropped by type guard)", async () => {
+    const api = {
+      query: vi.fn().mockResolvedValueOnce([
+        { path: "/sessions/a.jsonl", content: null, source_order: 1 },
+      ]),
+    } as any;
+
+    const content = await readVirtualPathContent(api, "memory", "sessions", "/sessions/a.jsonl");
+
+    // Previously this returned null → caller rendered "No such file" even though
+    // `ls` lists the path. Now it reports the row exists with no readable body.
+    expect(content).toContain("1 stored row");
+    expect(content).toContain("message body is empty");
+  });
+
+  it("keeps only non-empty turns when a session mixes empty and real messages", async () => {
+    const api = {
+      query: vi.fn().mockResolvedValueOnce([
+        { path: "/sessions/a.jsonl", content: "", source_order: 1 },
+        { path: "/sessions/a.jsonl", content: "{\"type\":\"user_message\",\"content\":\"hello\"}", source_order: 1 },
+      ]),
+    } as any;
+
+    const content = await readVirtualPathContent(api, "memory", "sessions", "/sessions/a.jsonl");
+
+    expect(content).toBe("[user] hello");
+  });
+
   it("reads multiple exact paths in a single query and synthesizes /index.md when needed", async () => {
     const api = {
       query: vi.fn()


### PR DESCRIPTION
## Summary

A session `cat` through the memory mirror could return **0 bytes with no signal** while `ls` showed a non-zero size — making the mirror look populated when the transcript body was actually unreadable, and blocking fallback to raw session data for turn-level detail.

Root cause, both plugin-side (backend unchanged):

1. **Silent-empty reconstruction.** A captured event is never legitimately empty (`capture.ts` always writes a populated JSON entry), so a session that reconstructs to `""` is always a pathology — but both readers returned it as an empty file. `ls` size comes from a separate `MAX(size_bytes)` query, so it stayed non-zero → the misleading size-vs-content split.
2. **Fragile null handling.** `normalizeSessionMessage` did `JSON.stringify(message)` unconditionally: a `NULL` column became the literal text `"null"`, and `undefined` leaked into the joined output.

**Fix:**
- **`grep-core.ts`** — shared `emptySessionBodyNotice(rowCount)`: honest diagnostic ("rows exist, body empty, metadata only — not an empty file").
- **`virtual-table-query.ts`** (hook path — what Claude Code's bash `cat` hits) — count session rows even when `message::text` is NULL (previously dropped silently), skip empty normalized parts, emit the notice instead of `""` (silent empty) or `null` (misleading "No such file" though `ls` lists it).
- **`deeplake-fs.ts`** (shell path) — `normalizeSessionMessage` coerces null/undefined/non-serializable → `""`; `joinSessionMessages` filters empty parts; `prefetch`/`readFile`/`readFileBuffer` emit the notice on empty reconstruction.

Scope note: this makes the empty-read case **honest**, not silent — it does not change *why* a body would be empty (a separate capture/storage question, answerable per-row via `length(message::text)` vs `size_bytes`).

## Version Bump

Bug fix → warrants a **patch** bump (`0.7.126` → `0.7.127`). **Not bumped yet** — `package.json` is unchanged, so as-is this merges with no release. Will bump on request to ship it.

## Test plan

- [x] Tests pass locally (`npx vitest run` on affected suites: **376 passed** — deeplake-fs, virtual-table-query, grep-core, pre-tool-use)
- [x] Relevant new tests added (7: NULL / undefined / empty-string bodies, no-`"null"`/`"undefined"`-leak guarantee, mixed empty+real turns across both reader paths)
- [ ] Version bumped in `package.json`, or no release needed for this change — **pending decision** (see Version Bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
