### PR TITLE
feat(docs): persist the docs LLM agent choice (config + onboarding + CLI)

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -47,7 +47,8 @@ import {
   type DocTier,
   type DocAnchor,
 } from "../docs/index.js";
-import { makeHostGenerate, makeHostGenerateDoc, makeHostBatchGenerateDoc, makeHostRunPrompt, makeHostPageRunPrompt } from "../docs/refresh-llm.js";
+import { makeHostGenerate, makeHostGenerateDoc, makeHostBatchGenerateDoc, makeHostRunPrompt, makeHostPageRunPrompt, detectAvailableAgents, knownDocsAgents } from "../docs/refresh-llm.js";
+import { getDocsLlmAgent, setDocsLlmAgent } from "../user-config.js";
 import { generateDocs, selectTargets, type GenScope } from "../docs/generate.js";
 import { generateWikiPages, selectWikiGroups, wikiDocId, wikiGroupEligible, WIKI_DOC_PREFIX } from "../docs/wiki-generate.js";
 import { pullDocs } from "../docs/pull.js";
@@ -92,6 +93,10 @@ Everyday:
   hivemind docs auto on|off [--cwd <dir>]
       Turn automatic per-commit sync on/off for THIS repo on THIS org.
       Enabling with no corpus asks for explicit confirmation (LLM cost).
+  hivemind docs agent [claude|codex|pi|cursor]
+      Show or set which host CLI authors the docs (persisted globally).
+      No arg → show current + installed. Overridable per-run with
+      HIVEMIND_DOCS_LLM_AGENT.
   hivemind docs show <doc-id>
 
 Advanced / plumbing:
@@ -349,6 +354,32 @@ export async function runDocsCommand(args: string[]): Promise<void> {
   const sub = args[0];
   if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
     console.log(USAGE);
+    return;
+  }
+
+  // `agent` is a local-config command — no org creds needed, so handle it
+  // before requireConfig().
+  if (sub === "agent") {
+    const name = args[1];
+    const installed = detectAvailableAgents();
+    if (!name) {
+      const cur = getDocsLlmAgent();
+      console.log(`Docs LLM agent: ${cur ?? `auto (${installed[0] ?? "none installed"})`}`);
+      console.log(`Installed on PATH: ${installed.join(", ") || "none"}`);
+      console.log(`Set with: hivemind docs agent <${knownDocsAgents().join("|")}>  (or HIVEMIND_DOCS_LLM_BIN for any other CLI)`);
+      return;
+    }
+    const lname = name.toLowerCase();
+    if (!knownDocsAgents().includes(lname)) {
+      console.error(`Unknown agent "${name}". Known: ${knownDocsAgents().join(", ")}. For any other CLI use HIVEMIND_DOCS_LLM_BIN.`);
+      process.exit(1);
+      throw new Error("unreachable");
+    }
+    if (!installed.includes(lname)) {
+      console.error(`Warning: "${lname}" is not installed on PATH — doc generation will fail until it is.`);
+    }
+    setDocsLlmAgent(lname);
+    console.log(`Docs LLM agent set to: ${lname}. Change with: hivemind docs agent <name>.`);
     return;
   }
 

--- a/src/docs/onboarding.ts
+++ b/src/docs/onboarding.ts
@@ -20,6 +20,8 @@
 import { createInterface } from "node:readline";
 import { setAuto } from "./auto-registry.js";
 import { selectWikiGroups } from "./wiki-generate.js";
+import { detectAvailableAgents } from "./refresh-llm.js";
+import { getDocsLlmAgent, setDocsLlmAgent } from "../user-config.js";
 import type { GraphSnapshot } from "../graph/types.js";
 
 export interface OnboardingIo {
@@ -58,6 +60,12 @@ export interface OnboardingArgs {
   /** Current snapshot, for the honest page estimate. Null → estimate unknown. */
   snap: GraphSnapshot | null;
   io?: OnboardingIo;
+  /** Installed host agents (injectable for tests). Default: real detection. */
+  detectAgents?: () => string[];
+  /** Read the persisted docs agent (injectable). Default: config.json. */
+  getAgent?: () => string | undefined;
+  /** Persist the chosen docs agent (injectable). Default: config.json. */
+  setAgent?: (agent: string) => void;
 }
 
 export interface OnboardingResult {
@@ -94,6 +102,24 @@ export async function runDocsOnboarding(args: OnboardingArgs): Promise<Onboardin
     io.say("Skipped. Generate later with: hivemind docs wiki");
     io.say(STATUS_HINT);
     return { generate: false, auto: false, asked: true };
+  }
+
+  // Agent choice: only worth asking when more than one host CLI is installed
+  // AND nothing is pinned yet. One agent → no choice; already pinned → respect
+  // it silently. The chosen agent is persisted globally in config.json.
+  const getAgent = args.getAgent ?? getDocsLlmAgent;
+  const setAgent = args.setAgent ?? setDocsLlmAgent;
+  const detectAgents = args.detectAgents ?? detectAvailableAgents;
+  if (!getAgent()) {
+    const available = detectAgents();
+    if (available.length > 1) {
+      const raw = (await io.ask(
+        `Which agent should write the docs? [${available.join("/")}] (default: ${available[0]}) `,
+      )).trim().toLowerCase();
+      const chosen = available.includes(raw) ? raw : available[0];
+      setAgent(chosen);
+      io.say(`Docs will be authored by: ${chosen}. Change with: hivemind docs agent <name>`);
+    }
   }
 
   const autoAnswer = await io.ask(

--- a/src/docs/refresh-llm.ts
+++ b/src/docs/refresh-llm.ts
@@ -20,6 +20,7 @@ import {
   type ClaudeInvocation,
 } from "../hooks/wiki-worker-spawn.js";
 import { resolveCliBin } from "../utils/resolve-cli-bin.js";
+import { getDocsLlmAgent } from "../user-config.js";
 import { buildRefreshPrompt, type GenerateFn } from "./refresh.js";
 import {
   buildGeneratePrompt,
@@ -138,6 +139,21 @@ function tryResolveCliBin(bin: string): string | null {
   }
 }
 
+/** Registry agent names, in detection priority order. */
+export function knownDocsAgents(): string[] {
+  return ["claude", "codex", "pi", "cursor"];
+}
+
+/**
+ * The registry agents whose CLI is actually installed on PATH, in priority
+ * order. `[0]` is what `detectHostAgent()` would pick with no override.
+ */
+export function detectAvailableAgents(
+  resolve: (bin: string) => string | null = tryResolveCliBin,
+): string[] {
+  return knownDocsAgents().filter((name) => resolve(REGISTRY[name]({}).bin) !== null);
+}
+
 /**
  * PAGE-AUTHORING spec: the wiki audit showed final-page writing is where
  * accuracy is won or lost, while note-taking survives the cheap model. So the
@@ -197,9 +213,10 @@ export function resolveDocLlmSpec(env: NodeJS.ProcessEnv = process.env): DocLlmS
       build: (b, p) => (viaStdin ? buildStdinPromptInvocation(b, flags, p) : buildTrailingPromptInvocation(b, flags, p)),
     };
   }
-  // Explicit selection wins; otherwise detect from what is installed —
-  // "on claude code it is claude, on codex it is codex", with no env needed.
-  const agent = (env.HIVEMIND_DOCS_LLM_AGENT ?? detectHostAgent()).toLowerCase();
+  // Precedence: env override wins (one-off), then the persisted config choice
+  // (`hivemind docs agent <name>` / onboarding), then auto-detect from what is
+  // installed — "on claude code it is claude, on codex it is codex".
+  const agent = (env.HIVEMIND_DOCS_LLM_AGENT ?? getDocsLlmAgent() ?? detectHostAgent()).toLowerCase();
   const spec = REGISTRY[agent]?.(env);
   if (!spec) {
     throw new Error(

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -17,6 +17,10 @@ export interface UserConfig {
   embeddings?: {
     enabled?: boolean;
   };
+  docs?: {
+    /** Which host CLI authors the docs (claude | codex | pi | cursor). */
+    llmAgent?: string;
+  };
 }
 
 let _configPath: () => string = () =>
@@ -103,6 +107,20 @@ function migrationValueFromEnv(): boolean {
 
 export function setEmbeddingsEnabled(enabled: boolean): void {
   writeUserConfig({ embeddings: { enabled } });
+}
+
+/**
+ * The persisted host agent for doc generation, or undefined when unset (the
+ * resolver then falls back to auto-detection). No env-var migration: the env
+ * override `HIVEMIND_DOCS_LLM_AGENT` stays a separate, higher-priority knob.
+ */
+export function getDocsLlmAgent(): string | undefined {
+  const v = readUserConfig().docs?.llmAgent;
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export function setDocsLlmAgent(agent: string): void {
+  writeUserConfig({ docs: { llmAgent: agent } });
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/tests/shared/docs-llm-agent.test.ts
+++ b/tests/shared/docs-llm-agent.test.ts
@@ -1,0 +1,203 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveDocLlmSpec,
+  detectAvailableAgents,
+  knownDocsAgents,
+} from "../../src/docs/refresh-llm.js";
+import {
+  getDocsLlmAgent,
+  setDocsLlmAgent,
+  setEmbeddingsEnabled,
+  readUserConfig,
+  _setConfigPathForTesting,
+  _resetUserConfigForTesting,
+} from "../../src/user-config.js";
+import { runDocsOnboarding, type OnboardingIo } from "../../src/docs/onboarding.js";
+
+// ── Resolution precedence: env > config > auto-detect ────────────────────────
+
+describe("resolveDocLlmSpec — config.json slots between env and auto-detect", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "docs-agent-"));
+    _setConfigPathForTesting(() => join(dir, "config.json"));
+  });
+  afterEach(() => {
+    _resetUserConfigForTesting();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("uses the persisted config agent when no env override is set", () => {
+    setDocsLlmAgent("codex");
+    // Empty env → must NOT fall through to auto-detect (which needs a real CLI).
+    const spec = resolveDocLlmSpec({});
+    expect(spec.label).toBe("codex");
+  });
+
+  it("env HIVEMIND_DOCS_LLM_AGENT wins over the config agent", () => {
+    setDocsLlmAgent("codex");
+    const spec = resolveDocLlmSpec({ HIVEMIND_DOCS_LLM_AGENT: "cursor" });
+    expect(spec.label).toBe("cursor");
+  });
+
+  it("HIVEMIND_DOCS_LLM_BIN wins over both env agent and config", () => {
+    setDocsLlmAgent("codex");
+    const spec = resolveDocLlmSpec({
+      HIVEMIND_DOCS_LLM_AGENT: "cursor",
+      HIVEMIND_DOCS_LLM_BIN: "/opt/mytool",
+    });
+    expect(spec.label).toBe("custom:/opt/mytool");
+  });
+});
+
+// ── Persistence ──────────────────────────────────────────────────────────────
+
+describe("getDocsLlmAgent / setDocsLlmAgent persistence", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "docs-agent-"));
+    _setConfigPathForTesting(() => join(dir, "config.json"));
+  });
+  afterEach(() => {
+    _resetUserConfigForTesting();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("round-trips through config.json", () => {
+    expect(getDocsLlmAgent()).toBeUndefined();
+    setDocsLlmAgent("cursor");
+    expect(getDocsLlmAgent()).toBe("cursor");
+  });
+
+  it("does not clobber an existing embeddings setting", () => {
+    setEmbeddingsEnabled(true);
+    setDocsLlmAgent("codex");
+    const cfg = readUserConfig();
+    expect(cfg.embeddings?.enabled).toBe(true);
+    expect(cfg.docs?.llmAgent).toBe("codex");
+  });
+
+  it("treats blank/whitespace as unset", () => {
+    setDocsLlmAgent("   ");
+    expect(getDocsLlmAgent()).toBeUndefined();
+  });
+});
+
+// ── Detection helpers ────────────────────────────────────────────────────────
+
+describe("detectAvailableAgents / knownDocsAgents", () => {
+  it("knownDocsAgents lists the registry in priority order", () => {
+    expect(knownDocsAgents()).toEqual(["claude", "codex", "pi", "cursor"]);
+  });
+
+  it("returns only installed agents, in priority order", () => {
+    // Simulate: codex + cursor installed, claude + pi absent.
+    const installed = new Set(["codex", "cursor-agent"]);
+    const got = detectAvailableAgents((bin) => (installed.has(bin) ? `/usr/bin/${bin}` : null));
+    expect(got).toEqual(["codex", "cursor"]);
+  });
+
+  it("returns [] when nothing is installed", () => {
+    expect(detectAvailableAgents(() => null)).toEqual([]);
+  });
+});
+
+// ── Onboarding: ask the agent question only when it makes sense ──────────────
+
+function scriptedIo(answers: string[]): { io: OnboardingIo; asked: string[] } {
+  const asked: string[] = [];
+  const queue = [...answers];
+  const io: OnboardingIo = {
+    interactive: true,
+    say: () => {},
+    ask: async (q: string) => {
+      asked.push(q);
+      return queue.shift() ?? "";
+    },
+  };
+  return { io, asked };
+}
+
+const baseArgs = {
+  root: "/repo",
+  isGitRepo: true,
+  orgId: "org",
+  orgName: "org",
+  project: "proj",
+  snap: null,
+};
+
+describe("runDocsOnboarding — agent question gate", () => {
+  it("asks which agent when >1 installed and none pinned, then persists the choice", async () => {
+    const setAgent = vi.fn();
+    const { io, asked } = scriptedIo(["y", "codex", "n"]); // generate, agent, auto
+    const res = await runDocsOnboarding({
+      ...baseArgs,
+      io,
+      detectAgents: () => ["claude", "codex"],
+      getAgent: () => undefined,
+      setAgent,
+    });
+    expect(res.generate).toBe(true);
+    expect(asked.some((q) => /Which agent should write the docs/.test(q))).toBe(true);
+    expect(setAgent).toHaveBeenCalledWith("codex");
+  });
+
+  it("falls back to the default (first available) on a blank answer", async () => {
+    const setAgent = vi.fn();
+    const { io } = scriptedIo(["y", "", "n"]);
+    await runDocsOnboarding({
+      ...baseArgs,
+      io,
+      detectAgents: () => ["claude", "codex"],
+      getAgent: () => undefined,
+      setAgent,
+    });
+    expect(setAgent).toHaveBeenCalledWith("claude");
+  });
+
+  it("does NOT ask when only one agent is installed", async () => {
+    const setAgent = vi.fn();
+    const { io, asked } = scriptedIo(["y", "n"]); // generate, auto — no agent Q
+    await runDocsOnboarding({
+      ...baseArgs,
+      io,
+      detectAgents: () => ["claude"],
+      getAgent: () => undefined,
+      setAgent,
+    });
+    expect(asked.some((q) => /Which agent/.test(q))).toBe(false);
+    expect(setAgent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT ask when an agent is already pinned", async () => {
+    const setAgent = vi.fn();
+    const { io, asked } = scriptedIo(["y", "n"]);
+    await runDocsOnboarding({
+      ...baseArgs,
+      io,
+      detectAgents: () => ["claude", "codex"],
+      getAgent: () => "claude",
+      setAgent,
+    });
+    expect(asked.some((q) => /Which agent/.test(q))).toBe(false);
+    expect(setAgent).not.toHaveBeenCalled();
+  });
+
+  it("never asks the agent question when the user declines generation", async () => {
+    const setAgent = vi.fn();
+    const { io, asked } = scriptedIo(["n"]); // decline generate → stop
+    await runDocsOnboarding({
+      ...baseArgs,
+      io,
+      detectAgents: () => ["claude", "codex"],
+      getAgent: () => undefined,
+      setAgent,
+    });
+    expect(asked.some((q) => /Which agent/.test(q))).toBe(false);
+    expect(setAgent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/shared/docs-llm-agent.test.ts
+++ b/tests/shared/docs-llm-agent.test.ts
@@ -16,6 +16,7 @@ import {
   _resetUserConfigForTesting,
 } from "../../src/user-config.js";
 import { runDocsOnboarding, type OnboardingIo } from "../../src/docs/onboarding.js";
+import { runDocsCommand } from "../../src/commands/docs.js";
 
 // ── Resolution precedence: env > config > auto-detect ────────────────────────
 
@@ -199,5 +200,57 @@ describe("runDocsOnboarding — agent question gate", () => {
     });
     expect(asked.some((q) => /Which agent/.test(q))).toBe(false);
     expect(setAgent).not.toHaveBeenCalled();
+  });
+});
+
+// ── `hivemind docs agent` command (runs before requireConfig — no creds) ─────
+
+describe("runDocsCommand agent — show / set / validate", () => {
+  let dir: string;
+  let logs: string[];
+  let errs: string[];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "docs-agent-cmd-"));
+    _setConfigPathForTesting(() => join(dir, "config.json"));
+    logs = [];
+    errs = [];
+    logSpy = vi.spyOn(console, "log").mockImplementation((m?: unknown) => { logs.push(String(m)); });
+    errSpy = vi.spyOn(console, "error").mockImplementation((m?: unknown) => { errs.push(String(m)); });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => { throw new Error("process.exit"); }) as never);
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    _resetUserConfigForTesting();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("no arg → shows current (auto when unset) + installed + how to set", async () => {
+    await runDocsCommand(["agent"]);
+    expect(logs.join("\n")).toMatch(/Docs LLM agent:/);
+    expect(logs.join("\n")).toMatch(/Set with: hivemind docs agent/);
+  });
+
+  it("no arg after a pin → shows the pinned agent", async () => {
+    setDocsLlmAgent("codex");
+    await runDocsCommand(["agent"]);
+    expect(logs.join("\n")).toContain("Docs LLM agent: codex");
+  });
+
+  it("set a known agent → persists it", async () => {
+    await runDocsCommand(["agent", "Codex"]); // case-insensitive
+    expect(getDocsLlmAgent()).toBe("codex");
+    expect(logs.join("\n")).toContain("Docs LLM agent set to: codex");
+  });
+
+  it("unknown agent → error + non-zero exit, nothing persisted", async () => {
+    await expect(runDocsCommand(["agent", "bogus"])).rejects.toThrow("process.exit");
+    expect(errs.join("\n")).toMatch(/Unknown agent/);
+    expect(getDocsLlmAgent()).toBeUndefined();
   });
 });

--- a/tests/shared/docs-onboarding.test.ts
+++ b/tests/shared/docs-onboarding.test.ts
@@ -31,7 +31,11 @@ describe("runDocsOnboarding (the one consent moment — fail-closed everywhere)"
   });
   afterEach(() => { delete process.env.HIVEMIND_DOCS_AUTO_FILE; rmSync(dir, { recursive: true, force: true }); });
 
-  const base = { root: "/work/repo", isGitRepo: true, orgId: "org-a", orgName: "acme", project: "proj-1", snap: SNAP };
+  // detectAgents: () => [] opts these tests out of the (separate) "which agent
+  // writes the docs?" question — that gate is covered in docs-llm-agent.test.ts.
+  // Without this, a test host with >1 agent CLI installed would see the extra
+  // question consume an answer meant for the auto prompt.
+  const base = { root: "/work/repo", isGitRepo: true, orgId: "org-a", orgName: "acme", project: "proj-1", snap: SNAP, detectAgents: () => [] };
 
   it("yes + yes: real page estimate shown, registry entry written for (org, project)", async () => {
     const t = io(["y", "yes"]);


### PR DESCRIPTION
## What & why

Make the docs-generation host agent a **persistent** choice instead of an env var that vanishes when you close the shell. You asked: "why does it default to claude, and where do I change it so it survives a restart?"

## Behaviour

- **New config field** `docs.llmAgent` in `~/.deeplake/config.json` (survives restarts, machines, sessions).
- **Resolution precedence** in `resolveDocLlmSpec`:
  `HIVEMIND_DOCS_LLM_BIN` > `HIVEMIND_DOCS_LLM_AGENT` (env, one-off) > **config `docs.llmAgent`** > auto-detect (`claude → codex → pi → cursor`).
- **Asked during onboarding** (`runDocsOnboarding`) — but only when **>1 host CLI is installed AND none is pinned yet**. One agent, or an existing pin → no question (zero nag). The choice persists.
- **New command** `hivemind docs agent [name]` — show current + installed, or set (validated; warns if not on PATH; no org creds needed).

Out of scope (explicitly deferred): a persistent per-tier **model** override, and giving `cursor`/`pi` the fast/slow split. Sonnet stays the slow-tier default.

## Verification
- `tsc` clean; **20 unit tests** (precedence env>config>auto, config persistence + no-clobber of `embeddings`, install detection, onboarding gate across all cases: >1/1/already-pinned/declined).
- **Real end-to-end** (sandbox HOME): two separate processes — process A `docs agent cursor`, process B (fresh) `docs agent` reads `cursor` back from disk → survives restart. Unknown agent → exit 1.
- Full suite completes with no regressions (the one unrelated red is the pre-existing `tree-sitter absent` bundle test, an env artifact on Node 24 that passes in CI).

## Files
- `src/user-config.ts` — `docs.llmAgent` field + `get/setDocsLlmAgent`
- `src/docs/refresh-llm.ts` — precedence + `detectAvailableAgents`/`knownDocsAgents`
- `src/commands/docs.ts` — `docs agent` command + USAGE
- `src/docs/onboarding.ts` — the gated agent question (injectable deps)
- `tests/shared/docs-llm-agent.test.ts` (new), `tests/shared/docs-onboarding.test.ts` (opt out of the new gate)

## Session Context
[Session transcript](https://gist.github.com/efenocchi/1e496865aedebf168c17493e8eb94f0e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting which installed agent generates documentation.
  - Added `hivemind docs agent` to view the currently configured agent (or available options) and to set it for future runs.
  - Onboarding now includes an agent-choice step when multiple agents are available and none is already selected.
  - Documentation agent selection is persisted for reuse, with support for environment-based overrides.
- **Bug Fixes**
  - Preserved existing configuration settings (e.g., embedding options) when saving documentation agent preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->