### PR TITLE
fix(graph): stop graph-on-stop hook crashing when tree-sitter is absent

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,10 +1,78 @@
 import { build } from "esbuild";
-import { chmodSync, writeFileSync, readFileSync } from "node:fs";
+import { chmodSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 
 const esmPackageJson = '{"type":"module"}\n';
 const hivemindVersion = JSON.parse(readFileSync("package.json", "utf-8")).version;
 const openclawVersion = JSON.parse(readFileSync("harnesses/openclaw/package.json", "utf-8")).version;
 const openclawSkillBody = readFileSync("harnesses/openclaw/skills/SKILL.md", "utf-8");
+
+// tree-sitter + language grammars ship native .node prebuilds esbuild can't
+// bundle; they're always external and resolved from node_modules at runtime.
+const treeSitterExternals = [
+  "tree-sitter",
+  "tree-sitter-typescript",
+  "tree-sitter-javascript",
+  "tree-sitter-python",
+  "tree-sitter-go",
+  "tree-sitter-rust",
+  "tree-sitter-java",
+  "tree-sitter-ruby",
+  "tree-sitter-c",
+  "tree-sitter-cpp",
+];
+
+/**
+ * Build the graph-on-stop Stop/SessionEnd hook as its OWN code-split bundle.
+ *
+ * Why a dedicated `splitting` build instead of adding graph-on-stop to each
+ * harness's shared build list: the hook's build path (runBuildCommand →
+ * extract/index → `import Parser from "tree-sitter"`) is a chain of static
+ * ESM imports. If that chain were part of graph-on-stop's own bundle, esbuild
+ * would hoist the external `import ... from "tree-sitter"` to the TOP of the
+ * file, so Node resolves tree-sitter at MODULE LOAD — before main() runs. On
+ * an install where the tree-sitter optionalDependency is absent (e.g. codex /
+ * cursor with no embed-deps grammars), that load fails with
+ * ERR_MODULE_NOT_FOUND and the Stop hook exits 1 — the exact error we're
+ * fixing. main()'s catch never gets a chance to swallow it.
+ *
+ * With `splitting: true`, graph-on-stop.ts's `await import("../commands/graph.js")`
+ * stays a real runtime import into a separate chunk; the tree-sitter statics
+ * live only in that chunk, loaded lazily behind the gate. A missing grammar
+ * then rejects the dynamic import, which main()'s try/catch turns into a
+ * logged skip + exit 0. The entry filename stays graph-on-stop.js so the hook
+ * registrations are unchanged; the chunk lands under graph-chunks/.
+ */
+async function buildGraphOnStop(outdir) {
+  // Clear stale chunks first: chunk filenames are content-hashed, so a code
+  // change leaves the previous graph-*.js behind. esbuild won't remove it and
+  // it would ship (dir is copied recursively) as dead weight. Scoped to
+  // graph-chunks/ so the shared bundle outputs are untouched (emptyOutdir
+  // would wipe them).
+  rmSync(`${outdir}/graph-chunks`, { recursive: true, force: true });
+  await build({
+    entryPoints: { "graph-on-stop": "dist/src/hooks/graph-on-stop.js" },
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outdir,
+    splitting: true,
+    chunkNames: "graph-chunks/[name]-[hash]",
+    external: [
+      "node:*",
+      "node-liblzma",
+      "@mongodb-js/zstd",
+      "@huggingface/transformers",
+      "onnxruntime-node",
+      "onnxruntime-common",
+      "sharp",
+      ...treeSitterExternals,
+    ],
+    define: {
+      __HIVEMIND_VERSION__: JSON.stringify(hivemindVersion),
+    },
+  });
+  chmodSync(`${outdir}/graph-on-stop.js`, 0o755);
+}
 
 // Claude Code plugin
 const ccHooks = [
@@ -24,10 +92,9 @@ const ccHooks = [
   { entry: "dist/src/skillify/skillopt-worker.js", out: "skillopt-worker" },
   // codebase-graph Phase 1.5: auto-build the graph at SessionEnd, gated
   // on (a) 10-min rate limit, (b) HEAD changed since last build, (c) ≥1
-  // source file diff. See src/hooks/graph-on-stop.ts.
-  // Filename keeps the "on-stop" suffix for backward-compat with prior
-  // builds; the hook itself is registered under SessionEnd, not Stop.
-  { entry: "dist/src/hooks/graph-on-stop.js", out: "graph-on-stop" },
+  // source file diff. See src/hooks/graph-on-stop.ts. Built separately via
+  // buildGraphOnStop() (code-split so tree-sitter loads lazily) — NOT in
+  // this shared list.
   // codebase-graph Phase 3 v1.1: async auto-pull on SessionStart.
   // Spawned detached via nohup from each agent's SessionStart hook;
   // pulls the freshest cloud snapshot for HEAD if newer than local.
@@ -100,7 +167,7 @@ const codexHooks = [
   { entry: "dist/src/skillify/skillopt-worker.js", out: "skillopt-worker" },
   { entry: "dist/src/hooks/graph-pull-worker.js", out: "graph-pull-worker" },
   // G3: code-graph auto-build parity for Codex (same shared hook as CC/Cursor).
-  { entry: "dist/src/hooks/graph-on-stop.js", out: "graph-on-stop" },
+  // graph-on-stop is built separately via buildGraphOnStop() (code-split).
 ];
 
 const codexShell = [
@@ -164,8 +231,8 @@ const cursorHooks = [
   { entry: "dist/src/hooks/graph-pull-worker.js", out: "graph-pull-worker" },
   // A1 (graph Cursor parity): same auto-build hook as Claude Code, wired
   // to Cursor's stop + sessionEnd events in install-cursor.ts. Reuses the
-  // shared src/hooks/graph-on-stop.ts entry (no per-agent logic).
-  { entry: "dist/src/hooks/graph-on-stop.js", out: "graph-on-stop" },
+  // shared src/hooks/graph-on-stop.ts entry (no per-agent logic). Built
+  // separately via buildGraphOnStop() (code-split).
 ];
 
 // Hermes Agent shell-hook bundles (matches Claude Code's wire protocol; see
@@ -182,7 +249,7 @@ const hermesHooks = [
   { entry: "dist/src/skillify/skillopt-worker.js", out: "skillopt-worker" },
   { entry: "dist/src/hooks/graph-pull-worker.js", out: "graph-pull-worker" },
   // G3: code-graph auto-build parity for Hermes (registered on on_session_end).
-  { entry: "dist/src/hooks/graph-on-stop.js", out: "graph-on-stop" },
+  // graph-on-stop is built separately via buildGraphOnStop() (code-split).
 ];
 
 const cursorShell = [
@@ -325,6 +392,20 @@ for (const h of piWorker) {
 }
 writeFileSync("harnesses/pi/bundle/package.json", esmPackageJson);
 writeFileSync("harnesses/hermes/bundle/package.json", esmPackageJson);
+
+// Code-split graph-on-stop bundles for every harness that registers the hook.
+// Kept out of the shared build lists above so its tree-sitter dependency
+// loads lazily (see buildGraphOnStop for the full rationale). Each harness's
+// bundle/package.json ({"type":"module"}) has already been written, so the
+// emitted graph-chunks/ resolve as ESM.
+for (const outdir of [
+  "harnesses/claude-code/bundle",
+  "harnesses/codex/bundle",
+  "harnesses/cursor/bundle",
+  "harnesses/hermes/bundle",
+]) {
+  await buildGraphOnStop(outdir);
+}
 
 // OpenClaw plugin bundle. The shared CC/Codex source modules reference a
 // handful of HIVEMIND_* env vars for dev-only overrides. Those env paths are
@@ -571,4 +652,6 @@ chmodSync("embeddings/embed-daemon.js", 0o755);
 // don't get script log noise mixed into their data pipe — see PR #185
 // where `scripts/pack-check.mjs` (which runs `prepack` via npm pack)
 // failed JSON parse because this line and sync-versions printed to stdout.
-console.error(`Built: ${ccAll.length} CC + ${codexAll.length} Codex + ${cursorAll.length} Cursor + ${hermesAll.length} Hermes + 1 OpenClaw + 1 MCP + 1 CLI + 1 standalone-daemon bundle`);
+// +1 per harness for the code-split graph-on-stop bundle built separately via
+// buildGraphOnStop() (not counted in the shared *All list lengths).
+console.error(`Built: ${ccAll.length + 1} CC + ${codexAll.length + 1} Codex + ${cursorAll.length + 1} Cursor + ${hermesAll.length + 1} Hermes + 1 OpenClaw + 1 MCP + 1 CLI + 1 standalone-daemon bundle`);

--- a/src/hooks/graph-on-stop.ts
+++ b/src/hooks/graph-on-stop.ts
@@ -49,7 +49,6 @@ import { createHash } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
-import { runBuildCommand } from "../commands/graph.js";
 import { acquireBuildLock, releaseBuildLock } from "../graph/build-lock.js";
 import { readLastBuild } from "../graph/last-build.js";
 import { repoDir } from "../graph/snapshot.js";
@@ -208,7 +207,6 @@ export interface MainDeps {
  * crashes the user's session.
  */
 export async function main(deps: MainDeps = {}): Promise<void> {
-  const runBuildFn = deps.runBuildCommand ?? runBuildCommand;
   const acquireFn = deps.acquireBuildLock ?? acquireBuildLock;
   const releaseFn = deps.releaseBuildLock ?? releaseBuildLock;
   const gateFn = deps.decideGate ?? decideGate;
@@ -255,6 +253,19 @@ export async function main(deps: MainDeps = {}): Promise<void> {
   // not "which underlying event"; both feed the same gate + lock so the
   // distinction is invisible to consumers.
   try {
+    // Lazy-load runBuildCommand so this hook's MODULE LOAD never depends on
+    // the tree-sitter native extractors. runBuildCommand → extract/index →
+    // `import Parser from "tree-sitter"` is a chain of static ESM imports;
+    // pulling it at the top of this file would make Node resolve tree-sitter
+    // at load time. tree-sitter is an optionalDependency (may be absent on a
+    // codex/cursor install with no embed-deps), so an unresolved package
+    // would abort module load with ERR_MODULE_NOT_FOUND and exit the Stop
+    // hook with code 1 — BEFORE main()'s catch can swallow it. Deferring the
+    // import to here (behind the gate, inside this try) means a missing
+    // extractor degrades to a logged skip + exit 0, per this hook's contract
+    // that "a buggy hook must never break the user's session".
+    const runBuildFn =
+      deps.runBuildCommand ?? (await import("../commands/graph.js")).runBuildCommand;
     await runBuildFn(["--trigger", "session-end"]);
   } catch (err) {
     logToFile(ctx.cwd, `build threw: ${err instanceof Error ? err.message : String(err)}`);

--- a/tests/shared/graph/graph-on-stop-bundle.test.ts
+++ b/tests/shared/graph/graph-on-stop-bundle.test.ts
@@ -31,10 +31,12 @@ describe("graph-on-stop shipped bundle (tree-sitter isolation)", () => {
     chunkDir: join(REPO_ROOT, "harnesses", h, "bundle", "graph-chunks"),
   })).filter((b) => existsSync(b.entry));
 
-  it("has at least one built harness bundle to check", () => {
-    // Guards against the glob silently matching nothing (e.g. path drift) and
-    // the suite reporting green without asserting anything.
-    expect(built.length).toBeGreaterThan(0);
+  it("has every harness bundle built (none silently missing)", () => {
+    // Require ALL four harnesses, not just one: a filtered subset would let a
+    // per-harness packaging regression (or a build that skipped a harness)
+    // pass unnoticed. Asserting the exact set also guards against the glob
+    // matching nothing after a path drift.
+    expect(built.map((b) => b.harness)).toEqual(HARNESSES);
   });
 
   for (const b of built) {

--- a/tests/shared/graph/graph-on-stop-bundle.test.ts
+++ b/tests/shared/graph/graph-on-stop-bundle.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Bundle-level guard for the graph-on-stop tree-sitter regression.
+ *
+ * The bug: graph-on-stop's build path statically imports `tree-sitter` (a
+ * native optionalDependency). When esbuild bundles that chain into the entry,
+ * it hoists `import ... from "tree-sitter"` to the TOP of the entry file, so
+ * Node resolves it at MODULE LOAD — before main()'s try/catch runs. On an
+ * install without the grammar, the Stop hook exits 1 (ERR_MODULE_NOT_FOUND).
+ *
+ * The fix builds graph-on-stop as its own `splitting: true` bundle so the
+ * `await import("../commands/graph.js")` stays a runtime chunk load and the
+ * tree-sitter statics live only in graph-chunks/. These assertions FAIL if
+ * splitting is dropped or the tree-sitter chain leaks back into the entry —
+ * the exact regression the unit test (which injects runBuildCommand) can't see.
+ *
+ * Scans the SHIPPED artifacts, so it also catches a stale build that didn't
+ * regenerate. Skips a harness whose bundle isn't built (bundles are untracked;
+ * run `npm run build` first — the harness with no bundle just isn't asserted).
+ */
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+const HARNESSES = ["claude-code", "codex", "cursor", "hermes"];
+
+describe("graph-on-stop shipped bundle (tree-sitter isolation)", () => {
+  const built = HARNESSES.map((h) => ({
+    harness: h,
+    entry: join(REPO_ROOT, "harnesses", h, "bundle", "graph-on-stop.js"),
+    chunkDir: join(REPO_ROOT, "harnesses", h, "bundle", "graph-chunks"),
+  })).filter((b) => existsSync(b.entry));
+
+  it("has at least one built harness bundle to check", () => {
+    // Guards against the glob silently matching nothing (e.g. path drift) and
+    // the suite reporting green without asserting anything.
+    expect(built.length).toBeGreaterThan(0);
+  });
+
+  for (const b of built) {
+    describe(b.harness, () => {
+      const entrySrc = readFileSync(b.entry, "utf8");
+
+      it("entry does NOT statically import tree-sitter", () => {
+        // Any `from "tree-sitter..."` in the entry means the native import was
+        // hoisted to module top → the exact load-time crash we fixed.
+        expect(entrySrc).not.toMatch(/from\s*["']tree-sitter/);
+      });
+
+      it("entry loads the build path via a lazy graph-chunks/ import", () => {
+        expect(entrySrc).toMatch(/import\(\s*["']\.\/graph-chunks\/graph-[^"']+\.js["']\s*\)/);
+      });
+
+      it("tree-sitter lives only in the lazy graph chunk", () => {
+        expect(existsSync(b.chunkDir)).toBe(true);
+        const chunks = readdirSync(b.chunkDir).filter((f) => f.endsWith(".js"));
+        const withTreeSitter = chunks.filter((f) =>
+          /from\s*["']tree-sitter/.test(readFileSync(join(b.chunkDir, f), "utf8")),
+        );
+        // At least one chunk must carry the grammar imports (proves they were
+        // split out, not dropped), and the entry proved they're not inline.
+        expect(withTreeSitter.length).toBeGreaterThan(0);
+      });
+    });
+  }
+});

--- a/tests/shared/graph/graph-on-stop-main.test.ts
+++ b/tests/shared/graph/graph-on-stop-main.test.ts
@@ -134,10 +134,14 @@ describe("graph-on-stop main()", () => {
       }),
     ).resolves.toBeUndefined();
     expect(release).toHaveBeenCalledTimes(1);
+    // Logging is part of this regression's contract (the operator's only trace
+    // that the build was skipped), so assert it unconditionally with the
+    // specific message rather than guarding on the file's existence.
     const log = join(baseDir, ".graph-on-stop.log");
-    if (existsSync(log)) {
-      expect(readFileSync(log, "utf8")).toContain("build threw");
-    }
+    expect(existsSync(log)).toBe(true);
+    expect(readFileSync(log, "utf8")).toContain(
+      "build threw: Cannot find package 'tree-sitter'",
+    );
   });
 
   it("decideGate throws → early return, no lock attempt, error logged", async () => {

--- a/tests/shared/graph/graph-on-stop-main.test.ts
+++ b/tests/shared/graph/graph-on-stop-main.test.ts
@@ -113,6 +113,33 @@ describe("graph-on-stop main()", () => {
     }
   });
 
+  it("injected runBuildCommand that rejects with ERR_MODULE_NOT_FOUND (tree-sitter missing) → lock released, error logged, main() resolves", async () => {
+    // Simulates the codex/cursor case where the tree-sitter native extractor
+    // is not installed: the lazy `import("../commands/graph.js")` rejects.
+    // main() must swallow it (log + release lock + resolve) so the Stop hook
+    // exits 0 instead of crashing with a non-zero code.
+    const acquire = vi.fn(() => ({ acquired: true, reason: "acquired" }));
+    const release = vi.fn();
+    const run = vi.fn(async () => {
+      const err = new Error("Cannot find package 'tree-sitter'");
+      (err as NodeJS.ErrnoException).code = "ERR_MODULE_NOT_FOUND";
+      throw err;
+    });
+    await expect(
+      main({
+        decideGate: () => ({ fire: true, reason: "test-fire" }),
+        acquireBuildLock: acquire,
+        releaseBuildLock: release,
+        runBuildCommand: run,
+      }),
+    ).resolves.toBeUndefined();
+    expect(release).toHaveBeenCalledTimes(1);
+    const log = join(baseDir, ".graph-on-stop.log");
+    if (existsSync(log)) {
+      expect(readFileSync(log, "utf8")).toContain("build threw");
+    }
+  });
+
   it("decideGate throws → early return, no lock attempt, error logged", async () => {
     const acquire = vi.fn();
     const release = vi.fn();


### PR DESCRIPTION
## Problem

The `graph-on-stop` Stop/SessionEnd hook crashed with exit code 1 on installs where the optional `tree-sitter` native grammar is absent (e.g. codex / cursor with no `embed-deps`):

```
Stop hook (failed) — hook exited with code 1
ERR_MODULE_NOT_FOUND: Cannot find package 'tree-sitter'
```

Root cause: the hook's build path is a chain of **static ESM imports** — `runBuildCommand` → `extract/index` → `import Parser from "tree-sitter"`. esbuild hoisted the external `tree-sitter` import to the **top of the bundle**, so Node resolved it at **module load** — before `main()`'s `try/catch` runs. `main().catch(() => process.exit(0))` never fired, so the process exited 1 instead of degrading. `tree-sitter` is an `optionalDependency`, so it is allowed to be absent.

## Fix

- **`src/hooks/graph-on-stop.ts`** — defer the build path behind the gate via a lazy `await import("../commands/graph.js")` inside the existing `try/catch`. A missing extractor now degrades to a logged skip + exit 0.
- **`esbuild.config.mjs`** — a source-level lazy import alone isn't enough (esbuild inlines it and re-hoists the external), so `graph-on-stop` is now built in its own `splitting: true` bundle via `buildGraphOnStop()`. The dynamic import stays a real runtime chunk load and the `tree-sitter` statics live only in `graph-chunks/`. Also clears stale hashed chunks before each build and removes `graph-on-stop` from the four shared harness build lists (claude-code, codex, cursor, hermes).
- **tests** — a unit seam for the reject path, plus a **bundle-level guard** (`graph-on-stop-bundle.test.ts`) asserting the shipped entry has no static `tree-sitter` import and loads it only via `graph-chunks/`. The guard fails if `splitting` is ever dropped — the exact regression.

## Verification

Reproduced before / after on the real bundle, same scenario (git repo, gate fires, `tree-sitter` unresolvable):

| | pre-fix bundle | fixed bundle |
| --- | --- | --- |
| tree-sitter absent | **exit 1** — `ERR_MODULE_NOT_FOUND: Cannot find package 'tree-sitter'` | **exit 0** — logs `build threw: Cannot find package 'tree-sitter'`, session unbroken |
| tree-sitter present | builds graph | **builds graph** (parses source, writes snapshot) — no regression |

- Full suite: 4679 passed. The single failure (`codex-hooks.test.ts` → `plugin.json` arrays) is pre-existing and unrelated (a WIP `plugin.json` change on `main`), not touched here.
- Codex review of the diff: "functionally sound; no BLOCKER/HIGH correctness issues." Its three non-blocking notes (bundle-level test, stale-chunk cleanup, summary count) are all addressed.

## Session Context
[Session transcript](https://gist.github.com/efenocchi/bc831cb9a34e5ec4478324867bb5a891)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph-on-stop builds so missing optional native components no longer interrupt user sessions.
  * Graph build errors are now swallowed, logged, and build locks are released correctly.
* **Reliability**
  * Graph-on-stop is packaged as dedicated per-harness bundles, preventing load-time dependency failures.
* **Tests**
  * Added regression tests ensuring tree-sitter is deferred into lazy graph chunks and that missing-module build errors are handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->