### PR TITLE
fix(skillify): cap skill names to the 64-char loader limit

### DIFF
--- a/src/commands/mine-local.ts
+++ b/src/commands/mine-local.ts
@@ -656,7 +656,7 @@ async function runMineLocalImpl(args: string[]): Promise<void> {
     console.log(`Fan-out targets: ${fanOutRoots.join(", ")}`);
   }
 
-  const written: Array<{ skill: MinedSkill; session: SessionFile; result: { path: string; createdAt: string }; symlinks: string[] }> = [];
+  const written: Array<{ skill: MinedSkill; session: SessionFile; result: { path: string; name: string; createdAt: string }; symlinks: string[] }> = [];
   const knownSummaries: Array<{ name: string; desc: string }> = [...existingSummaries];
 
   for (const { skill, session } of flat) {
@@ -666,6 +666,10 @@ async function runMineLocalImpl(args: string[]): Promise<void> {
       continue;
     }
     try {
+      // writeNewSkill validates the raw name then length-caps it to the
+      // 64-char loader ceiling (an over-long mined name is truncated, not
+      // dropped) and returns the canonical on-disk name. Use result.name for
+      // the log line and dedup list so they match what's written.
       const result = writeNewSkill({
         skillsRoot,
         name: skill.name,
@@ -680,9 +684,9 @@ async function runMineLocalImpl(args: string[]): Promise<void> {
         ? fanOutSymlinks(canonicalDir, basename(canonicalDir), fanOutRoots)
         : [];
       const symlinkSuffix = symlinks.length > 0 ? `, fan-out → ${symlinks.length} root(s)` : "";
-      console.log(`  wrote ${skill.name} ← session ${session.sessionId.slice(0, 8)} (${session.agent}${symlinkSuffix})`);
+      console.log(`  wrote ${result.name} ← session ${session.sessionId.slice(0, 8)} (${session.agent}${symlinkSuffix})`);
       written.push({ skill, session, result, symlinks });
-      knownSummaries.push({ name: skill.name, desc: skill.description });
+      knownSummaries.push({ name: result.name, desc: skill.description });
     } catch (e: any) {
       if (/already exists/i.test(e.message ?? "")) {
         console.log(`  skipped ${skill.name} (file already exists at ${skillsRoot})`);
@@ -699,7 +703,10 @@ async function runMineLocalImpl(args: string[]): Promise<void> {
   if (written.length > 0) {
     const existing = loadManifest();
     const newEntries: ManifestEntry[] = written.map(({ skill, session, result, symlinks }) => ({
-      skill_name: skill.name,
+      // result.name is the canonical (possibly length-capped) on-disk name, so
+      // the manifest identity matches canonical_path / the frontmatter — not
+      // the raw model name, which may not exist on disk.
+      skill_name: result.name,
       canonical_path: result.path,
       symlinks,
       source_session_ids: [session.sessionId],

--- a/src/skillify/manifest.ts
+++ b/src/skillify/manifest.ts
@@ -28,6 +28,15 @@ export interface PulledEntry {
   dirName: string;
   /** Skill name (without author suffix). */
   name: string;
+  /**
+   * Original (pre-cap) skills-table row name this install came from. Equals
+   * `name` unless the row name exceeded the loader's 64-char ceiling and was
+   * length-capped. Persisted so a later pull can tell whether an existing
+   * capped destination belongs to THIS row or a different one that happens to
+   * cap to the same identity (a lossy-hash collision) — and refuse to overwrite
+   * across invocations. Absent on legacy entries recorded before this field.
+   */
+  rawName?: string;
   /** Author who originally minted the skill. */
   author: string;
   /** Skills-table `project_key` of the source project. */
@@ -117,6 +126,9 @@ export function loadManifest(path: string = manifestPath()): PulledManifest {
       entries.push({
         dirName: e.dirName,
         name: e.name,
+        // Optional — preserved for cross-run cap-collision detection. Absent on
+        // legacy entries; only carry a valid string through.
+        ...(typeof e.rawName === "string" && e.rawName ? { rawName: e.rawName } : {}),
         author: e.author,
         projectKey: typeof e.projectKey === "string" ? e.projectKey : "",
         remoteVersion: typeof e.remoteVersion === "number" ? e.remoteVersion : 1,

--- a/src/skillify/pull.ts
+++ b/src/skillify/pull.ts
@@ -579,13 +579,19 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
     const dirName = `${name}--${author}`;
 
     // Two distinct over-long names can cap to the same destination (capping is
-    // a lossy hash). The first row to claim a destination wins; skip any later
-    // collider so we never silently overwrite one skill's file with another's.
-    const claimant = claimedDirs.get(dirName);
-    if (claimant !== undefined && claimant !== rawName) {
+    // a lossy hash). Detect collisions both within this run (claimedDirs) AND
+    // across runs: the manifest persists the raw claimant of an existing capped
+    // install, so a later filtered pull (e.g. `--skill`) of a different raw name
+    // that caps to the same identity is caught. The first raw name to claim a
+    // destination wins; skip any later collider — even under --force — so we
+    // never silently overwrite one skill's file with another's.
+    const persistedOwner = entriesForRoot(loadManifest(), opts.install, root)
+      .find(e => e.dirName === dirName)?.rawName;
+    const owner = claimedDirs.get(dirName) ?? persistedOwner;
+    if (owner !== undefined && owner !== rawName) {
       summary.entries.push({
         name: rawName, remoteVersion: Number(row.version ?? 1), localVersion: null,
-        action: "skipped", destination: `(name collision with '${claimant}' — skipped)`,
+        action: "skipped", destination: `(name collision with '${owner}' — skipped)`,
         author, sourceAgent: String(row.source_agent ?? ""),
       });
       summary.skipped++;
@@ -634,8 +640,15 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
       // rewritten to the capped one — instead of overwriting from remote.
       // Only an older stale copy (or --force) is replaced by the remote row.
       if (staleFile && staleVersion !== null && staleVersion >= remoteVersion && !(opts.force ?? false)) {
-        const migrated = readFileSync(staleFile, "utf-8").replace(/^name:.*$/m, `name: ${name}`);
-        writeFileSync(skillFile, migrated);
+        // Read defensively: if the stale file vanished since its version was
+        // read (a benign FS race), fall back to installing the remote row
+        // rather than throwing out of the pull.
+        try {
+          const migrated = readFileSync(staleFile, "utf-8").replace(/^name:.*$/m, `name: ${name}`);
+          writeFileSync(skillFile, migrated);
+        } catch {
+          writeFileSync(skillFile, renderSkillFile(row, name));
+        }
       } else {
         writeFileSync(skillFile, renderSkillFile(row, name));
       }
@@ -654,6 +667,7 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
         recordPull({
           dirName,
           name,
+          rawName,
           author,
           projectKey: String(row.project_key ?? ""),
           remoteVersion,
@@ -681,9 +695,14 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
     if (staleDir && staleDir !== dirName && !(opts.dryRun ?? false)
         && existsSync(skillFile) && existsSync(join(root, staleDir))) {
       try {
-        const staleEntry = entriesForRoot(loadManifest(), opts.install, root)
-          .find(e => e.dirName === staleDir);
-        if (staleEntry) {
+        const entries = entriesForRoot(loadManifest(), opts.install, root);
+        // Only retire the stale install once the CANONICAL capped install is
+        // recorded in the manifest. If recordPull failed this run, the canonical
+        // file is on disk but untracked — keep the stale entry so a later pull
+        // retries the migration instead of orphaning the skill.
+        const canonicalRecorded = entries.some(e => e.dirName === dirName);
+        const staleEntry = entries.find(e => e.dirName === staleDir);
+        if (canonicalRecorded && staleEntry) {
           // Remove the directory FIRST, then drop its manifest evidence. If
           // rmSync fails, the entry survives so the next pull retries cleanup;
           // dropping the entry first would orphan an un-removed invalid dir.

--- a/src/skillify/pull.ts
+++ b/src/skillify/pull.ts
@@ -585,9 +585,13 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
     // that caps to the same identity is caught. The first raw name to claim a
     // destination wins; skip any later collider — even under --force — so we
     // never silently overwrite one skill's file with another's.
-    const persistedOwner = entriesForRoot(loadManifest(), opts.install, root)
-      .find(e => e.dirName === dirName)?.rawName;
-    const owner = claimedDirs.get(dirName) ?? persistedOwner;
+    // Fall back to the entry's `name` for legacy rows recorded before `rawName`
+    // existed: `name` is that install's stable identity, so a colliding new row
+    // is still detected. For a same-skill re-pull the persisted identity equals
+    // this row's own name/rawName, so no false collision fires.
+    const persistedEntry = entriesForRoot(loadManifest(), opts.install, root)
+      .find(e => e.dirName === dirName);
+    const owner = claimedDirs.get(dirName) ?? persistedEntry?.rawName ?? persistedEntry?.name;
     if (owner !== undefined && owner !== rawName) {
       summary.entries.push({
         name: rawName, remoteVersion: Number(row.version ?? 1), localVersion: null,
@@ -700,8 +704,30 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
         // recorded in the manifest. If recordPull failed this run, the canonical
         // file is on disk but untracked — keep the stale entry so a later pull
         // retries the migration instead of orphaning the skill.
-        const canonicalRecorded = entries.some(e => e.dirName === dirName);
+        let canonicalRecorded = entries.some(e => e.dirName === dirName);
         const staleEntry = entries.find(e => e.dirName === staleDir);
+        // A prior run wrote the capped file but its recordPull failed, so this
+        // run saw the file at the remote version and chose "skipped" (no
+        // recordPull). Adopt the untracked canonical now — otherwise
+        // `canonicalRecorded` stays false forever and the stale dir is never
+        // retired. Skip if recordPull just failed THIS run (`manifestError`
+        // set) so we don't retry a still-broken manifest write.
+        if (!canonicalRecorded && staleEntry && !manifestError) {
+          try {
+            const symlinks = opts.install === "global"
+              ? fanOutSymlinks(skillDir, dirName, detectAgentSkillsRoots(root))
+              : [];
+            recordPull({
+              dirName, name, rawName, author,
+              projectKey: String(row.project_key ?? ""),
+              remoteVersion, install: opts.install, installRoot: root,
+              pulledAt: new Date().toISOString(), symlinks,
+            });
+            canonicalRecorded = true;
+          } catch (e: any) {
+            manifestError = manifestError ?? (e?.message ?? String(e));
+          }
+        }
         if (canonicalRecorded && staleEntry) {
           // Remove the directory FIRST, then drop its manifest evidence. If
           // rmSync fails, the entry survives so the next pull retries cleanup;

--- a/src/skillify/pull.ts
+++ b/src/skillify/pull.ts
@@ -18,14 +18,14 @@
  */
 
 import {
-  existsSync, readFileSync, writeFileSync, mkdirSync, renameSync,
+  existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, rmSync,
   lstatSync, readlinkSync, symlinkSync, unlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { assertValidSkillName, composeDescription, parseFrontmatter, type SkillFrontmatter } from "./skill-writer.js";
+import { assertValidSkillName, capSkillName, composeDescription, parseFrontmatter, type SkillFrontmatter } from "./skill-writer.js";
 import type { InstallLocation } from "./scope-config.js";
-import { entriesForRoot, loadManifest, pruneOrphanedEntries, recordPull } from "./manifest.js";
+import { entriesForRoot, loadManifest, pruneOrphanedEntries, recordPull, removePullEntry, unlinkSymlinks } from "./manifest.js";
 import { detectAgentSkillsRoots } from "./agent-roots.js";
 
 /**
@@ -335,7 +335,7 @@ export function selectLatestPerName(rows: Record<string, unknown>[]): Record<str
  * Render a SKILL.md from a skills-table row. Mirrors writer's frontmatter
  * shape so the pulled file is indistinguishable from a locally-generated one.
  */
-export function renderSkillFile(row: Record<string, unknown>): string {
+export function renderSkillFile(row: Record<string, unknown>, nameOverride?: string): string {
   const sources = parseSourceSessions(row.source_sessions);
   // Author + contributors land on disk so the gate sees the same lineage
   // info it would for a locally-mined skill. Without this, the worker on
@@ -353,7 +353,7 @@ export function renderSkillFile(row: Record<string, unknown>): string {
     ? contributors
     : (author ? [author] : []);
   const fm: SkillFrontmatter = {
-    name: String(row.name ?? ""),
+    name: nameOverride ?? String(row.name ?? ""),
     description: String(row.description ?? ""),
     trigger: typeof row.trigger_text === "string" && row.trigger_text.length > 0 ? String(row.trigger_text) : undefined,
     author,
@@ -505,21 +505,16 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
   const root = resolvePullDestination(opts.install, opts.cwd);
   const summary: PullSummary = { scanned: latest.length, wrote: 0, skipped: 0, dryrun: 0, entries: [] };
 
+  // Maps a resolved `<cappedName>--<author>` destination to the raw row name
+  // that claimed it first. Capping is a lossy hash, so two distinct over-long
+  // names could resolve to the same destination; the first wins and later
+  // colliders are skipped (their rows stay in Deeplake, re-pullable) rather
+  // than silently overwriting each other on disk.
+  const claimedDirs = new Map<string, string>();
+
   for (const row of latest) {
-    const name = String(row.name ?? "");
-    if (!name) continue;
-    // Validate name BEFORE constructing any path — protects against a
-    // malicious or malformed `skills` row escaping the install root.
-    try { assertValidSkillName(name); }
-    catch (e: any) {
-      summary.entries.push({
-        name, remoteVersion: Number(row.version ?? 1), localVersion: null,
-        action: "skipped", destination: "(invalid name — skipped)",
-        author: String(row.author ?? ""), sourceAgent: String(row.source_agent ?? ""),
-      });
-      summary.skipped++;
-      continue;
-    }
+    const rawName = String(row.name ?? "");
+    if (!rawName) continue;
     const author = String(row.author ?? "");
     // Pulled skills land at `<root>/<name>--<author>/SKILL.md` so:
     //   1. Claude Code's skill loader (single-depth scan) sees them directly
@@ -540,28 +535,84 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
     // ignoring an empty one is safer than guessing a placeholder.
     if (!author) {
       summary.entries.push({
-        name, remoteVersion: Number(row.version ?? 1), localVersion: null,
+        name: rawName, remoteVersion: Number(row.version ?? 1), localVersion: null,
         action: "skipped", destination: "(empty author — skipped)",
         author: "", sourceAgent: String(row.source_agent ?? ""),
       });
       summary.skipped++;
       continue;
     }
-    let dirName: string;
-    try {
-      assertValidAuthor(author);
-      dirName = `${name}--${author}`;
-    } catch (e: any) {
+    // Author is part of the directory name, so validate it before it feeds
+    // either the `--author` suffix or the name-cap budget below.
+    try { assertValidAuthor(author); }
+    catch (e: any) {
       summary.entries.push({
-        name, remoteVersion: Number(row.version ?? 1), localVersion: null,
+        name: rawName, remoteVersion: Number(row.version ?? 1), localVersion: null,
         action: "skipped", destination: `(invalid author '${author}' — skipped)`,
         author, sourceAgent: String(row.source_agent ?? ""),
       });
       summary.skipped++;
       continue;
     }
+    // Validate the RAW name's characters/path BEFORE truncating its length.
+    // A malicious row could pass a >64 name whose first 64 chars form a valid
+    // slug but whose tail carries traversal syntax or invalid chars; capping
+    // first would silently drop that tail and admit the row. assertValidSkillName
+    // is a path-safety validator with a generous 100-char ceiling, so a legacy
+    // 65–100 char name still passes here and is length-capped just below.
+    try { assertValidSkillName(rawName); }
+    catch (e: any) {
+      summary.entries.push({
+        name: rawName, remoteVersion: Number(row.version ?? 1), localVersion: null,
+        action: "skipped", destination: "(invalid name — skipped)",
+        author, sourceAgent: String(row.source_agent ?? ""),
+      });
+      summary.skipped++;
+      continue;
+    }
+    // Cap the (now char-validated) name to the skill-loader's 64-char frontmatter
+    // ceiling. Older rows were minted before generation-time capping and can
+    // exceed it; codex silently drops those on load, so truncating here lets them
+    // install cleanly. The capped name drives BOTH the frontmatter `name` and the
+    // `<name>--<author>` directory base so the two stay consistent.
+    const name = capSkillName(rawName);
+    const dirName = `${name}--${author}`;
+
+    // Two distinct over-long names can cap to the same destination (capping is
+    // a lossy hash). The first row to claim a destination wins; skip any later
+    // collider so we never silently overwrite one skill's file with another's.
+    const claimant = claimedDirs.get(dirName);
+    if (claimant !== undefined && claimant !== rawName) {
+      summary.entries.push({
+        name: rawName, remoteVersion: Number(row.version ?? 1), localVersion: null,
+        action: "skipped", destination: `(name collision with '${claimant}' — skipped)`,
+        author, sourceAgent: String(row.source_agent ?? ""),
+      });
+      summary.skipped++;
+      continue;
+    }
+    claimedDirs.set(dirName, rawName);
+
     const skillDir = join(root, dirName);
     const skillFile = join(skillDir, "SKILL.md");
+
+    // A prior (pre-cap) pull of this same row installed it at the un-capped
+    // `<rawName>--<author>` dir with an invalid (>64) frontmatter name. Decide
+    // on the CAPPED dir's OWN state (not the stale one's) so a fresh capped
+    // install fires even when the remote version is unchanged — the whole point
+    // is to fix that existing broken install, which is normally at an equal
+    // version. Below we either migrate the stale copy's content or install the
+    // remote row, then retire the stale dir.
+    const staleDir = name !== rawName ? `${rawName}--${author}` : null;
+    // Only treat a stale dir as ours to migrate/retire when the manifest says
+    // WE pulled it. An unmanaged `<rawName>--<author>` dir the user happens to
+    // own is left untouched, and its content is never copied into the capped
+    // destination — the remote row installs there as usual.
+    const staleOwned = !!staleDir && staleDir !== dirName
+      && entriesForRoot(loadManifest(), opts.install, root).some(e => e.dirName === staleDir);
+    const staleFile = staleOwned ? join(root, staleDir!, "SKILL.md") : null;
+    const staleVersion = staleFile && existsSync(staleFile) ? readLocalVersion(staleFile) : null;
+
     const remoteVersion = Number(row.version ?? 1);
     const localVersion = readLocalVersion(skillFile);
     const action = decideAction({
@@ -573,12 +624,21 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
     let manifestError: string | undefined;
     if (action === "wrote") {
       mkdirSync(skillDir, { recursive: true });
-      // Backup any existing file before overwriting (only if it was non-null
-      // and we're actually writing).
+      // Backup any existing capped file before overwriting.
       if (existsSync(skillFile)) {
         try { renameSync(skillFile, `${skillFile}.bak`); } catch { /* best effort */ }
       }
-      writeFileSync(skillFile, renderSkillFile(row));
+      // Preserve the stale copy's content whenever it is NOT older than the
+      // remote row (equal version = possible un-versioned local edits) and
+      // we're not forcing: migrate it — with the invalid frontmatter name
+      // rewritten to the capped one — instead of overwriting from remote.
+      // Only an older stale copy (or --force) is replaced by the remote row.
+      if (staleFile && staleVersion !== null && staleVersion >= remoteVersion && !(opts.force ?? false)) {
+        const migrated = readFileSync(staleFile, "utf-8").replace(/^name:.*$/m, `name: ${name}`);
+        writeFileSync(skillFile, migrated);
+      } else {
+        writeFileSync(skillFile, renderSkillFile(row, name));
+      }
       // Fan out symlinks into every detected non-Claude agent skills
       // root, but only for global pulls. Project-local pulls live under
       // <cwd>/.claude/skills and shouldn't leak into user-global agent
@@ -608,6 +668,31 @@ export async function runPull(opts: PullOptions): Promise<PullSummary> {
         // not be able to clean this entry via the manifest path until
         // a successful re-pull populates it.
         manifestError = e?.message ?? String(e);
+      }
+    }
+
+    // Retire the stale un-capped dir once a valid capped install is in place —
+    // whether we wrote it this run or a previous run did. Running independently
+    // of `action` means a cleanup that failed earlier (transient rmSync error →
+    // a later "skipped" pull) is retried instead of leaving the invalid dir
+    // forever. ONLY a dir we manage (present in the manifest) is removed — a
+    // user-created `<rawName>--<author>` dir is never touched. dry-run safe;
+    // failures surface via manifestError rather than aborting the pull.
+    if (staleDir && staleDir !== dirName && !(opts.dryRun ?? false)
+        && existsSync(skillFile) && existsSync(join(root, staleDir))) {
+      try {
+        const staleEntry = entriesForRoot(loadManifest(), opts.install, root)
+          .find(e => e.dirName === staleDir);
+        if (staleEntry) {
+          // Remove the directory FIRST, then drop its manifest evidence. If
+          // rmSync fails, the entry survives so the next pull retries cleanup;
+          // dropping the entry first would orphan an un-removed invalid dir.
+          rmSync(join(root, staleDir), { recursive: true, force: true });
+          unlinkSymlinks(staleEntry.symlinks);
+          removePullEntry(opts.install, staleEntry.installRoot, staleDir);
+        }
+      } catch (e: any) {
+        manifestError = manifestError ?? (e?.message ?? String(e));
       }
     }
 

--- a/src/skillify/skill-writer.ts
+++ b/src/skillify/skill-writer.ts
@@ -78,6 +78,13 @@ export interface MergeSkillArgs {
 
 export interface SkillWriteResult {
   path: string;
+  /**
+   * The canonical on-disk skill name: for a new skill this is the (possibly
+   * length-capped) name actually written; for a merge it's the target's name.
+   * Callers must record THIS in local state and the org row so the recorded
+   * identity matches the frontmatter/dir — never the raw pre-cap input.
+   */
+  name: string;
   action: "created" | "merged";
   version: number;
   /** ISO timestamp of the v=1 row's creation, preserved across merges. */
@@ -91,14 +98,76 @@ export interface SkillWriteResult {
 }
 
 /**
+ * Hard ceiling on a skill's frontmatter `name`. The codex skill loader
+ * rejects any skill whose `name` exceeds 64 chars ("invalid name: exceeds
+ * maximum length of 64 characters") and silently drops it. Verified
+ * empirically: a 64-char name loads, 66+ is rejected. The directory name is
+ * NOT the constraint — codex loads `<name>--<author>` dirs well over 64 chars
+ * as long as the frontmatter `name` fits — so only the `name` is capped.
+ */
+export const MAX_SKILL_NAME_LEN = 64;
+
+/** Length of the disambiguating suffix (`-` + {@link CAP_HASH_LEN} chars). */
+const CAP_HASH_LEN = 5;
+/** 36^CAP_HASH_LEN — modulus that keeps exactly CAP_HASH_LEN base-36 digits. */
+const CAP_HASH_MOD = 36 ** CAP_HASH_LEN;
+
+/**
+ * Deterministic short hash (djb2 → base36) used to disambiguate truncated
+ * names. Deterministic so the same input always caps to the same output —
+ * required for pull re-runs and for the on-disk dir to match the org row.
+ *
+ * Uses `% CAP_HASH_MOD` (the LOW-order base-36 digits), not the leading
+ * digits: djb2 changes the low bits most for small input deltas (e.g. names
+ * ending `-0` vs `-1` differ by 1 in the final hash), so slicing the high
+ * digits would collapse them onto the same suffix. Modulo keeps the digits
+ * that actually differ.
+ */
+function shortHash(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  return (h % CAP_HASH_MOD).toString(36).padStart(CAP_HASH_LEN, "0");
+}
+
+/**
+ * Truncate a kebab-case skill name to {@link MAX_SKILL_NAME_LEN}. The model
+ * that names skills does not reliably respect a length limit, so we enforce it
+ * deterministically here rather than rejecting (and losing) an otherwise-good
+ * skill.
+ *
+ * Truncation appends a short hash of the FULL name so two distinct long names
+ * that share a prefix through the chosen hyphen boundary don't collapse onto
+ * the same identity (which would overwrite one skill with the other on pull,
+ * or version-confuse them in the org table). The cut lands on a hyphen
+ * boundary when possible and trailing hyphens are stripped, so the result is
+ * still a valid kebab-case slug. Idempotent: a name already <= the ceiling is
+ * returned unchanged, so re-capping a capped name is a no-op.
+ */
+export function capSkillName(name: string): string {
+  if (name.length <= MAX_SKILL_NAME_LEN) return name;
+  const suffix = `-${shortHash(name)}`;
+  const budget = MAX_SKILL_NAME_LEN - suffix.length;
+  let cut = name.slice(0, budget);
+  const lastHyphen = cut.lastIndexOf("-");
+  if (lastHyphen > 0) cut = cut.slice(0, lastHyphen);
+  cut = cut.replace(/-+$/, "");
+  // Degenerate fallback: a hyphenless prefix. Keep the first `budget` chars.
+  if (cut.length === 0) cut = name.slice(0, budget).replace(/-+$/, "");
+  return `${cut}${suffix}`;
+}
+
+/**
  * Reject any name that isn't a strict kebab-case slug. The name comes from
  * model output (the gate verdict) or from a remote `skills` row pulled over
  * the network — both untrusted. Without this check, a verdict like
  * `../../etc/passwd` or `/abs/path` would escape `skillsRoot` when joined.
  *
- * Additionally guards against paths longer than 100 chars (defensive — no
- * legitimate kebab-case skill name needs more) and rejects any name
- * containing path separators even if the regex passed (belt + suspenders).
+ * This is a PATH-SAFETY validator, not the skill-loader length limit: it keeps
+ * a generous 100-char ceiling (defensive — no legitimate kebab-case name needs
+ * more) so it can validate a long remote name's characters BEFORE the length
+ * is capped. The 64-char loader ceiling is owned by {@link capSkillName}, which
+ * write sites apply. It also rejects any name containing path separators even
+ * if the regex passed (belt + suspenders).
  */
 export function assertValidSkillName(name: string): void {
   if (typeof name !== "string" || name.length === 0) {
@@ -215,9 +284,17 @@ export function parseFrontmatter(text: string): { fm: Partial<SkillFrontmatter>;
 
 /** Write a new skill file. Errors if it already exists. */
 export function writeNewSkill(args: WriteSkillArgs): SkillWriteResult {
+  // Validate the RAW name's characters/path BEFORE capping its length, so an
+  // invalid tail (traversal / bad chars) beyond the retained prefix is
+  // rejected rather than silently truncated away. Then cap at this write seam
+  // so every caller (gate worker KEEP, mine-local, …) is loader-safe without
+  // each remembering to cap. Idempotent for already-capped names. mergeSkill
+  // deliberately does NOT cap — it must match an existing (possibly legacy
+  // over-long) target by its exact name.
   assertValidSkillName(args.name);
-  const dir = skillDir(args.skillsRoot, args.name);
-  const path = skillPath(args.skillsRoot, args.name);
+  const name = capSkillName(args.name);
+  const dir = skillDir(args.skillsRoot, name);
+  const path = skillPath(args.skillsRoot, name);
   if (existsSync(path)) {
     throw new Error(`skill already exists at ${path}; use mergeSkill`);
   }
@@ -228,7 +305,7 @@ export function writeNewSkill(args: WriteSkillArgs): SkillWriteResult {
   const author = args.author && args.author.length > 0 ? args.author : undefined;
   const contributors = author ? [author] : [];
   const fm: SkillFrontmatter = {
-    name: args.name,
+    name,
     description: args.description,
     trigger: args.trigger,
     author,
@@ -242,7 +319,7 @@ export function writeNewSkill(args: WriteSkillArgs): SkillWriteResult {
   const text = `${renderFrontmatter(fm)}\n\n${args.body.trim()}\n`;
   writeFileSync(path, text);
   return {
-    path, action: "created", version: 1,
+    path, name, action: "created", version: 1,
     createdAt: now, updatedAt: now,
     author, contributors,
   };
@@ -293,7 +370,7 @@ export function mergeSkill(args: MergeSkillArgs): SkillWriteResult {
   const text = `${renderFrontmatter(fm)}\n\n${args.body.trim()}\n`;
   writeFileSync(path, text);
   return {
-    path, action: "merged", version: fm.version,
+    path, name: args.name, action: "merged", version: fm.version,
     createdAt: fm.created_at, updatedAt: fm.updated_at,
     author, contributors,
   };

--- a/src/skillify/skillify-worker.ts
+++ b/src/skillify/skillify-worker.ts
@@ -428,6 +428,12 @@ async function main(): Promise<void> {
     }
     wlog(`verdict source: ${source}`);
 
+    // Note: the 64-char loader-limit cap is applied by writeNewSkill (the write
+    // seam) and its canonical name is read back from the result below, so the
+    // recorded identity always matches what lands on disk. MERGE keeps the
+    // target's exact name (mergeSkill does not cap), so a legacy over-long
+    // target is found and updated rather than forked into a truncated v1.
+
     wlog(`verdict=${verdict.verdict} name=${verdict.name ?? "-"} reason=${verdict.reason ?? "-"}`);
 
     // Watermark is the OLDEST mined session date — same reasoning as the
@@ -536,6 +542,9 @@ async function main(): Promise<void> {
           author: cfg.userName,
         });
         wlog(`wrote new skill: ${result.path}`);
+        // Adopt the canonical (possibly length-capped) name writeNewSkill wrote
+        // so local state + the org row match the frontmatter/dir on disk.
+        verdict.name = result.name;
         recordSkill(cfg.projectKey, verdict.name, watermarkUuid, watermarkDate);
         await recordToDeeplake(result, verdict);
       } catch (e: any) {
@@ -574,6 +583,8 @@ async function main(): Promise<void> {
               author: cfg.userName,
             });
             wlog(`wrote new skill (merge fallback): ${result.path}`);
+            // Adopt the canonical capped name so state/org row match disk.
+            verdict.name = result.name;
             recordSkill(cfg.projectKey, verdict.name, watermarkUuid, watermarkDate);
             await recordToDeeplake(result, verdict);
           } catch (e2: any) {

--- a/tests/claude-code/mine-local-orchestrator.test.ts
+++ b/tests/claude-code/mine-local-orchestrator.test.ts
@@ -86,7 +86,10 @@ const resolveSkillsRoot = vi.fn();
 const writeNewSkill = vi.fn();
 const listSkills = vi.fn();
 const parseFrontmatter = vi.fn();
-vi.mock("../../src/skillify/skill-writer.js", () => ({
+vi.mock("../../src/skillify/skill-writer.js", async (orig) => ({
+  // Keep the real module (capSkillName etc.) and override only what these
+  // orchestrator tests need to spy on.
+  ...(await orig<typeof import("../../src/skillify/skill-writer.js")>()),
   resolveSkillsRoot: (...args: any[]) => resolveSkillsRoot(...args),
   writeNewSkill: (...args: any[]) => writeNewSkill(...args),
   listSkills: (...args: any[]) => listSkills(...args),
@@ -160,6 +163,7 @@ describe("runMineLocal: orchestrator branches", () => {
     writeLocalManifest.mockImplementation(() => {});
     writeNewSkill.mockImplementation((opts: any) => ({
       path: join(opts.skillsRoot, opts.name, "SKILL.md"),
+      name: opts.name,
       createdAt: "2026-05-15T00:00:00Z",
     }));
 
@@ -569,6 +573,7 @@ describe("runGateViaStdin error branches via orchestrator", () => {
     writeLocalManifest.mockImplementation(() => {});
     writeNewSkill.mockImplementation((opts: any) => ({
       path: join(opts.skillsRoot, opts.name, "SKILL.md"),
+      name: opts.name,
       createdAt: "2026-05-15T00:00:00Z",
     }));
     exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
@@ -641,6 +646,7 @@ describe("happy-path with already-existing skill check (loadExistingSummaries)",
     writeLocalManifest.mockImplementation(() => {});
     writeNewSkill.mockImplementation((opts: any) => ({
       path: join(opts.skillsRoot, opts.name, "SKILL.md"),
+      name: opts.name,
       createdAt: "2026-05-15T00:00:00Z",
     }));
 

--- a/tests/claude-code/skillify-pull.test.ts
+++ b/tests/claude-code/skillify-pull.test.ts
@@ -607,6 +607,35 @@ describe("runPull", () => {
     expect(collider?.destination).toContain("collision");
   });
 
+  it("detects a cap collision ACROSS separate pulls via the persisted raw name", async () => {
+    // These two distinct over-long names hash to the same capped dir. Pulled in
+    // separate invocations (e.g. `--skill`), the manifest's persisted rawName
+    // must let the second recognise the destination as another skill's and skip
+    // it — not overwrite the first.
+    const a = "collide-prefix-aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-hhhh-iiii-zzz16634";
+    const b = "collide-prefix-aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-hhhh-iiii-zzz400000";
+
+    const run1 = await runPull({
+      query: makeMockQuery([sampleRow({ name: a, author: "al", version: 1 })]).fn,
+      tableName: "skills", install: "project", cwd: projectRoot, users: [], dryRun: false, force: false,
+    });
+    expect(run1.wrote).toBe(1);
+    const dir = readdirSync(projectSkillsRoot)[0];
+    const contentAfterRun1 = readFileSync(join(projectSkillsRoot, dir, "SKILL.md"), "utf-8");
+
+    // Second, separate pull of the colliding name — even with --force.
+    const run2 = await runPull({
+      query: makeMockQuery([sampleRow({ name: b, author: "al", version: 9 })]).fn,
+      tableName: "skills", install: "project", cwd: projectRoot, users: [], dryRun: false, force: true,
+    });
+    expect(run2.wrote).toBe(0);
+    expect(run2.skipped).toBe(1);
+    expect(run2.entries[0].destination).toContain("collision");
+    // First skill's file is untouched.
+    expect(readdirSync(projectSkillsRoot)).toHaveLength(1);
+    expect(readFileSync(join(projectSkillsRoot, dir, "SKILL.md"), "utf-8")).toBe(contentAfterRun1);
+  });
+
   it("rejects an over-long name whose truncated-away tail carries traversal syntax", async () => {
     // First 64 chars are a valid slug; the discarded tail hides `..`. Capping
     // before validating would admit it — validation must see the RAW name.

--- a/tests/claude-code/skillify-pull.test.ts
+++ b/tests/claude-code/skillify-pull.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir, homedir } from "node:os";
 import {
@@ -17,7 +17,7 @@ import {
   type QueryFn,
 } from "../../src/skillify/pull.js";
 import { lstatSync, readlinkSync, symlinkSync } from "node:fs";
-import { loadManifest } from "../../src/skillify/manifest.js";
+import { loadManifest, recordPull } from "../../src/skillify/manifest.js";
 import { setFakeHome, clearFakeHome } from "../shared/fake-home.js";
 
 let projectRoot: string;
@@ -463,6 +463,162 @@ describe("runPull", () => {
     const text = readFileSync(path, "utf-8");
     expect(text).toContain("version: 2");
     expect(text).toContain("Use vox");
+  });
+
+  it("caps an over-long row name so the frontmatter name fits codex's 64-char limit", async () => {
+    // Real offender codex dropped: 68-char frontmatter name. codex validates
+    // the frontmatter `name` (not the dir length), so the write must truncate
+    // it to <=64 rather than skip the row.
+    const longName = "pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization";
+    const { fn } = makeMockQuery([sampleRow({ name: longName, author: "sasun" })]);
+    const summary = await runPull({
+      query: fn, tableName: "skills", install: "project", cwd: projectRoot,
+      users: [], dryRun: false, force: false,
+    });
+    expect(summary.wrote).toBe(1);
+    expect(summary.skipped).toBe(0);
+    const dirs = readdirSync(projectSkillsRoot);
+    expect(dirs).toHaveLength(1);
+    // The dir base equals the capped name, suffixed by the author.
+    expect(dirs[0].endsWith("--sasun")).toBe(true);
+    // The frontmatter `name` — the value codex rejects when >64 — is capped
+    // (<=64), matches the dir base, and its content prefix comes from the
+    // original name (the tail is a disambiguating hash).
+    const text = readFileSync(join(projectSkillsRoot, dirs[0], "SKILL.md"), "utf-8");
+    const fmName = text.match(/^name: (.+)$/m)?.[1] ?? "";
+    expect(fmName.length).toBeLessThanOrEqual(64);
+    expect(`${fmName}--sasun`).toBe(dirs[0]);
+    const prefix = fmName.replace(/-[a-z0-9]{5}$/, "");
+    expect(longName.startsWith(prefix)).toBe(true);
+  });
+
+  it("migrates an EQUAL-version stale over-long install to the capped dir (the common upgrade case)", async () => {
+    // A user who pulled this row BEFORE capping has it at the raw dir at the
+    // SAME version as remote — the normal upgrade case. Migration must still
+    // fire (decide on the capped dir's own absence), else the invalid old dir
+    // lingers forever and codex keeps warning.
+    const longName = "pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization";
+    const staleDir = `${longName}--sasun`;
+    mkdirSync(join(projectSkillsRoot, staleDir), { recursive: true });
+    writeFileSync(join(projectSkillsRoot, staleDir, "SKILL.md"),
+      `---\nname: ${longName}\ndescription: "old"\nversion: 2\ncreated_by_agent: cc\ncreated_at: t\nupdated_at: t\n---\n\nold body`);
+    recordPull({
+      dirName: staleDir, name: longName, author: "sasun", projectKey: "pk",
+      remoteVersion: 2, install: "project", installRoot: projectSkillsRoot,
+      pulledAt: "2026-05-06T00:00:00.000Z", symlinks: [],
+    });
+    expect(loadManifest().entries.some(e => e.dirName === staleDir)).toBe(true);
+
+    // Remote version EQUALS the stale local version.
+    const { fn } = makeMockQuery([sampleRow({ name: longName, author: "sasun", version: 2 })]);
+    const summary = await runPull({
+      query: fn, tableName: "skills", install: "project", cwd: projectRoot,
+      users: [], dryRun: false, force: false,
+    });
+
+    expect(summary.wrote).toBe(1);
+    // The old invalid dir is gone (otherwise codex keeps warning on it) …
+    expect(existsSync(join(projectSkillsRoot, staleDir))).toBe(false);
+    // … its manifest entry is removed …
+    expect(loadManifest().entries.some(e => e.dirName === staleDir)).toBe(false);
+    // … and exactly the capped dir remains, with a <=64 frontmatter name.
+    const dirs = readdirSync(projectSkillsRoot);
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0]).not.toBe(staleDir);
+    const fmName = readFileSync(join(projectSkillsRoot, dirs[0], "SKILL.md"), "utf-8").match(/^name: (.+)$/m)?.[1] ?? "";
+    expect(fmName.length).toBeLessThanOrEqual(64);
+  });
+
+  it("migrates a NEWER stale copy's content (preserves edits) rather than overwriting from an older remote row", async () => {
+    // Guards against discarding a newer/edited local copy: the stale content is
+    // preserved and MOVED to the capped dir with the frontmatter name fixed —
+    // not overwritten from the older remote row, and not left at the invalid dir.
+    const longName = "pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization";
+    const staleDir = `${longName}--sasun`;
+    mkdirSync(join(projectSkillsRoot, staleDir), { recursive: true });
+    writeFileSync(join(projectSkillsRoot, staleDir, "SKILL.md"),
+      `---\nname: ${longName}\ndescription: "local"\nversion: 9\ncreated_by_agent: cc\ncreated_at: t\nupdated_at: t\n---\n\nlocal newer body`);
+    recordPull({
+      dirName: staleDir, name: longName, author: "sasun", projectKey: "pk",
+      remoteVersion: 9, install: "project", installRoot: projectSkillsRoot,
+      pulledAt: "2026-05-06T00:00:00.000Z", symlinks: [],
+    });
+
+    // Remote row is OLDER (v2) than the local stale copy (v9).
+    const { fn } = makeMockQuery([sampleRow({ name: longName, author: "sasun", version: 2 })]);
+    const summary = await runPull({
+      query: fn, tableName: "skills", install: "project", cwd: projectRoot,
+      users: [], dryRun: false, force: false,
+    });
+
+    expect(summary.wrote).toBe(1);
+    // Invalid old dir retired …
+    expect(existsSync(join(projectSkillsRoot, staleDir))).toBe(false);
+    // … local content preserved at the capped dir, with the name fixed (<=64).
+    const dirs = readdirSync(projectSkillsRoot);
+    expect(dirs).toHaveLength(1);
+    const text = readFileSync(join(projectSkillsRoot, dirs[0], "SKILL.md"), "utf-8");
+    expect(text).toContain("local newer body");
+    const fmName = text.match(/^name: (.+)$/m)?.[1] ?? "";
+    expect(fmName.length).toBeLessThanOrEqual(64);
+    expect(fmName).not.toBe(longName);
+  });
+
+  it("never deletes a `<rawName>--<author>` dir that is NOT pull-managed (no manifest entry)", async () => {
+    // A user could coincidentally own a dir matching a long row's raw name.
+    // Migration must only remove dirs we manage (present in the manifest).
+    const longName = "pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization";
+    const userDir = `${longName}--sasun`;
+    mkdirSync(join(projectSkillsRoot, userDir), { recursive: true });
+    writeFileSync(join(projectSkillsRoot, userDir, "SKILL.md"),
+      `---\nname: ${longName}\ndescription: "user"\nversion: 1\ncreated_by_agent: cc\ncreated_at: t\nupdated_at: t\n---\n\nuser-owned body`);
+    // NB: no recordPull — the dir is unmanaged.
+
+    const { fn } = makeMockQuery([sampleRow({ name: longName, author: "sasun", version: 2 })]);
+    await runPull({
+      query: fn, tableName: "skills", install: "project", cwd: projectRoot,
+      users: [], dryRun: false, force: false,
+    });
+
+    // The unmanaged user dir is untouched.
+    expect(existsSync(join(projectSkillsRoot, userDir, "SKILL.md"))).toBe(true);
+    expect(readFileSync(join(projectSkillsRoot, userDir, "SKILL.md"), "utf-8")).toContain("user-owned body");
+  });
+
+  it("skips (does not overwrite) a second row that caps to the same destination as the first", async () => {
+    // These two distinct over-long names hash to the same capped dir. The first
+    // claims it; the collider is skipped rather than overwriting it.
+    const a = "collide-prefix-aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-hhhh-iiii-zzz16634";
+    const b = "collide-prefix-aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-hhhh-iiii-zzz400000";
+    const { fn } = makeMockQuery([
+      sampleRow({ name: a, author: "al", version: 1 }),
+      sampleRow({ name: b, author: "al", version: 1 }),
+    ]);
+    const summary = await runPull({
+      query: fn, tableName: "skills", install: "project", cwd: projectRoot,
+      users: [], dryRun: false, force: false,
+    });
+
+    expect(summary.wrote).toBe(1);
+    expect(summary.skipped).toBe(1);
+    // Only one dir exists; the collider's entry names the conflict.
+    expect(readdirSync(projectSkillsRoot)).toHaveLength(1);
+    const collider = summary.entries.find(e => e.action === "skipped");
+    expect(collider?.destination).toContain("collision");
+  });
+
+  it("rejects an over-long name whose truncated-away tail carries traversal syntax", async () => {
+    // First 64 chars are a valid slug; the discarded tail hides `..`. Capping
+    // before validating would admit it — validation must see the RAW name.
+    const evil = "a".repeat(60) + "-b/../../etc";
+    const { fn } = makeMockQuery([sampleRow({ name: evil, author: "sasun" })]);
+    const summary = await runPull({
+      query: fn, tableName: "skills", install: "project", cwd: projectRoot,
+      users: [], dryRun: false, force: false,
+    });
+    expect(summary.wrote).toBe(0);
+    expect(summary.skipped).toBe(1);
+    expect(summary.entries[0].destination).toContain("invalid name");
   });
 
   it("skips the SELECT when tableExists reports the skills table absent", async () => {

--- a/tests/claude-code/skillify-pull.test.ts
+++ b/tests/claude-code/skillify-pull.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../src/skillify/pull.js";
 import { lstatSync, readlinkSync, symlinkSync } from "node:fs";
 import { loadManifest, recordPull } from "../../src/skillify/manifest.js";
+import { capSkillName } from "../../src/skillify/skill-writer.js";
 import { setFakeHome, clearFakeHome } from "../shared/fake-home.js";
 
 let projectRoot: string;
@@ -634,6 +635,72 @@ describe("runPull", () => {
     // First skill's file is untouched.
     expect(readdirSync(projectSkillsRoot)).toHaveLength(1);
     expect(readFileSync(join(projectSkillsRoot, dir, "SKILL.md"), "utf-8")).toBe(contentAfterRun1);
+  });
+
+  it("detects a collision against a LEGACY manifest entry (no rawName) via the name fallback", async () => {
+    // Pre-rawName entries have no persisted raw identity; the collision check
+    // must fall back to `name` so a new colliding row is still blocked.
+    const b = "collide-prefix-aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-hhhh-iiii-zzz400000";
+    const dirName = `${capSkillName(b)}--al`;
+    // Back the manifest entry with a real dir on disk (matches how a real pull
+    // leaves state) so the entry is retained on reload.
+    mkdirSync(join(projectSkillsRoot, dirName), { recursive: true });
+    writeFileSync(join(projectSkillsRoot, dirName, "SKILL.md"),
+      `---\nname: legacy-owner\ndescription: x\nversion: 1\ncreated_by_agent: cc\ncreated_at: t\nupdated_at: t\n---\n\nowner body`);
+    recordPull({
+      // Legacy shape: NO rawName field.
+      dirName, name: "legacy-owner", author: "al", projectKey: "pk",
+      remoteVersion: 1, install: "project", installRoot: projectSkillsRoot,
+      pulledAt: "2026-05-06T00:00:00.000Z", symlinks: [],
+    });
+
+    const { fn } = makeMockQuery([sampleRow({ name: b, author: "al", version: 9 })]);
+    const summary = await runPull({
+      query: fn, tableName: "skills", install: "project", cwd: projectRoot,
+      users: [], dryRun: false, force: true,
+    });
+
+    expect(summary.wrote).toBe(0);
+    expect(summary.skipped).toBe(1);
+    expect(summary.entries[0].destination).toContain("legacy-owner");
+  });
+
+  it("adopts an untracked canonical file on a later skipped pull, then retires the stale dir", async () => {
+    // Simulates a prior migration whose recordPull failed: the capped file is on
+    // disk but unrecorded, and the stale managed dir still exists. This pull sees
+    // the capped file at the remote version (→ skipped), so it must adopt the
+    // canonical into the manifest and finish retiring the stale dir.
+    const longName = "pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization";
+    const cappedDir = `${capSkillName(longName)}--sasun`;
+    const staleDir = `${longName}--sasun`;
+
+    // Canonical capped file on disk at v2, but NOT recorded in the manifest.
+    mkdirSync(join(projectSkillsRoot, cappedDir), { recursive: true });
+    writeFileSync(join(projectSkillsRoot, cappedDir, "SKILL.md"),
+      `---\nname: ${capSkillName(longName)}\ndescription: "x"\nversion: 2\ncreated_by_agent: cc\ncreated_at: t\nupdated_at: t\n---\n\ncanonical body`);
+    // Stale managed dir + manifest entry.
+    mkdirSync(join(projectSkillsRoot, staleDir), { recursive: true });
+    writeFileSync(join(projectSkillsRoot, staleDir, "SKILL.md"),
+      `---\nname: ${longName}\ndescription: "x"\nversion: 2\ncreated_by_agent: cc\ncreated_at: t\nupdated_at: t\n---\n\nstale body`);
+    recordPull({
+      dirName: staleDir, name: longName, author: "sasun", projectKey: "pk",
+      remoteVersion: 2, install: "project", installRoot: projectSkillsRoot,
+      pulledAt: "2026-05-06T00:00:00.000Z", symlinks: [],
+    });
+    expect(loadManifest().entries.some(e => e.dirName === cappedDir)).toBe(false);
+
+    const { fn } = makeMockQuery([sampleRow({ name: longName, author: "sasun", version: 2 })]);
+    const summary = await runPull({
+      query: fn, tableName: "skills", install: "project", cwd: projectRoot,
+      users: [], dryRun: false, force: false,
+    });
+
+    expect(summary.skipped).toBe(1); // capped already at remote version
+    // Canonical is now recorded (adopted) …
+    expect(loadManifest().entries.some(e => e.dirName === cappedDir)).toBe(true);
+    // … and the stale dir + entry are retired.
+    expect(existsSync(join(projectSkillsRoot, staleDir))).toBe(false);
+    expect(loadManifest().entries.some(e => e.dirName === staleDir)).toBe(false);
   });
 
   it("rejects an over-long name whose truncated-away tail carries traversal syntax", async () => {

--- a/tests/claude-code/skillify-skill-writer.test.ts
+++ b/tests/claude-code/skillify-skill-writer.test.ts
@@ -10,6 +10,8 @@ import {
   listSkills,
   resolveSkillsRoot,
   assertValidSkillName,
+  capSkillName,
+  MAX_SKILL_NAME_LEN,
 } from "../../src/skillify/skill-writer.js";
 
 let projectRoot: string;
@@ -72,6 +74,30 @@ describe("writeNewSkill", () => {
     });
     expect(existsSync(join(skillsRoot, "n"))).toBe(true);
     expect(existsSync(result.path)).toBe(true);
+  });
+
+  it("length-caps an over-long name and returns the canonical name", () => {
+    const long = "pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization";
+    const result = writeNewSkill({
+      skillsRoot, name: long, description: "", body: VALID_BODY, sourceSessions: [], agent: "x",
+    });
+    // result.name is the capped on-disk name (what callers must record) …
+    expect(result.name.length).toBeLessThanOrEqual(64);
+    expect(result.name).toBe(capSkillName(long));
+    // … the dir + frontmatter use it, not the raw name.
+    expect(existsSync(join(skillsRoot, result.name, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(skillsRoot, long))).toBe(false);
+    const fm = readFileSync(join(skillsRoot, result.name, "SKILL.md"), "utf-8");
+    expect(fm).toContain(`name: ${result.name}`);
+  });
+
+  it("validates the RAW name before capping — rejects an invalid truncated-away tail", () => {
+    // First chars form a valid slug; the tail (dropped by capping) hides `..`.
+    // Validating the capped prefix would miss it — writeNewSkill must see raw.
+    const evil = "a".repeat(60) + "-b/../../x";
+    expect(() =>
+      writeNewSkill({ skillsRoot, name: evil, description: "", body: VALID_BODY, sourceSessions: [], agent: "x" })
+    ).toThrow(/path separator|kebab-case/);
   });
 });
 
@@ -347,9 +373,77 @@ describe("assertValidSkillName (path-traversal guard)", () => {
     expect(() => assertValidSkillName(42 as any)).toThrow(/empty/);
   });
 
-  it("rejects names longer than 100 chars", () => {
+  it("rejects names longer than 100 chars (path-safety ceiling, not the loader limit)", () => {
+    // assertValidSkillName is a path-safety validator with a generous ceiling
+    // so it can vet a long remote name's characters before capSkillName trims
+    // the length. The 64-char loader limit is capSkillName's job, not this one.
     expect(() => assertValidSkillName("a".repeat(101))).toThrow(/too long/);
     expect(() => assertValidSkillName("a".repeat(100))).not.toThrow();
+    // A legacy 65-100 char name must still validate (push/merge look it up).
+    expect(() => assertValidSkillName("a".repeat(80))).not.toThrow();
+  });
+});
+
+describe("capSkillName (64-char frontmatter-name ceiling)", () => {
+  const HASH_SUFFIX = /-[a-z0-9]{5}$/;
+
+  it("leaves short names untouched", () => {
+    expect(capSkillName("my-skill")).toBe("my-skill");
+    expect(capSkillName("a".repeat(MAX_SKILL_NAME_LEN))).toHaveLength(MAX_SKILL_NAME_LEN);
+  });
+
+  it("truncates a >64 name to <=64 with a hyphen-aligned prefix + hash suffix", () => {
+    const long = "pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization";
+    expect(long.length).toBeGreaterThan(MAX_SKILL_NAME_LEN);
+    const capped = capSkillName(long);
+    expect(capped.length).toBeLessThanOrEqual(MAX_SKILL_NAME_LEN);
+    expect(capped).toMatch(HASH_SUFFIX);
+    // The prefix before the hash is a hyphen-delimited prefix of the original.
+    const prefix = capped.replace(HASH_SUFFIX, "");
+    expect(long.startsWith(prefix)).toBe(true);
+    expect(long[prefix.length]).toBe("-");
+  });
+
+  it("is idempotent — re-capping a capped name is a no-op", () => {
+    const long = "pg-incident-tactical-relief-insufficient-structural-root-phased-fix";
+    const capped = capSkillName(long);
+    expect(capSkillName(capped)).toBe(capped);
+  });
+
+  it("gives distinct results to two long names sharing a prefix (no collision)", () => {
+    // Same prefix through the hyphen boundary, different tail — must NOT collapse
+    // onto one identity (which would overwrite/version-confuse the two skills).
+    const base = "aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-hhhh-iiii-jjjj-kkkk-llll";
+    const a = capSkillName(`${base}-alpha-one-tail`);
+    const b = capSkillName(`${base}-alpha-two-tail`);
+    expect(a).not.toBe(b);
+    expect(a.length).toBeLessThanOrEqual(MAX_SKILL_NAME_LEN);
+    expect(b.length).toBeLessThanOrEqual(MAX_SKILL_NAME_LEN);
+  });
+
+  it("disambiguates names differing only in the last char (low-order hash digits)", () => {
+    // djb2 makes `…-0` and `…-1` differ by 1 in the final hash; a hash that
+    // kept the HIGH-order base-36 digits would slice that difference away and
+    // collide. The suffix must come from the low-order digits.
+    const base = "seg-".repeat(16); // 64 chars, > ceiling once a tail is added
+    const a = capSkillName(`${base}alpha0`);
+    const b = capSkillName(`${base}alpha1`);
+    expect(a.length).toBeLessThanOrEqual(MAX_SKILL_NAME_LEN);
+    expect(b.length).toBeLessThanOrEqual(MAX_SKILL_NAME_LEN);
+    expect(a).not.toBe(b);
+  });
+
+  it("produces a result that still passes assertValidSkillName", () => {
+    const long = "a-" + "b".repeat(200);
+    const capped = capSkillName(long);
+    expect(() => assertValidSkillName(capped)).not.toThrow();
+    expect(capped.endsWith("-")).toBe(false);
+  });
+
+  it("hard-truncates a hyphenless name that overflows", () => {
+    const capped = capSkillName("x".repeat(200));
+    expect(capped.length).toBeLessThanOrEqual(MAX_SKILL_NAME_LEN);
+    expect(capped.length).toBeGreaterThan(0);
   });
 
   it("rejects uppercase / underscores / spaces / dots", () => {

--- a/tests/claude-code/skillify-skill-writer.test.ts
+++ b/tests/claude-code/skillify-skill-writer.test.ts
@@ -102,6 +102,32 @@ describe("writeNewSkill", () => {
 });
 
 describe("mergeSkill", () => {
+  it("does NOT cap — updates a legacy >64-char target in place, no truncated fork", () => {
+    // Round-1 regression: a MERGE into a pre-cap over-long skill must find and
+    // update THAT dir (preserving version/lineage), not create a truncated v1.
+    // Verified end-to-end against the real functions on a real FS (2026-07-20).
+    const long = "pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization"; // 69 chars
+    expect(long.length).toBeGreaterThan(64);
+    mkdirSync(join(skillsRoot, long), { recursive: true });
+    writeFileSync(join(skillsRoot, long, "SKILL.md"),
+      `---\nname: ${long}\ndescription: old\nversion: 1\ncreated_by_agent: cc\ncreated_at: t\nupdated_at: t\n---\n\nlegacy body`);
+    const before = listSkills(skillsRoot).length;
+
+    const result = mergeSkill({
+      skillsRoot, name: long, description: "new",
+      body: "## Y\nmerged body", newSourceSessions: ["s2"], agent: "cc", editor: "bob",
+    });
+
+    // Target found + updated in place (uncapped), no new truncated dir.
+    expect(result.name).toBe(long);
+    expect(result.version).toBe(2);
+    expect(result.path).toBe(join(skillsRoot, long, "SKILL.md"));
+    expect(listSkills(skillsRoot).length).toBe(before);
+    const text = readFileSync(join(skillsRoot, long, "SKILL.md"), "utf-8");
+    expect(text).toContain("merged body");
+    expect(text).toMatch(/^version: 2$/m);
+  });
+
   it("bumps version, preserves created_at, updates updated_at, dedups source_sessions", () => {
     writeNewSkill({
       skillsRoot, name: "m", description: "v1 desc", body: "v1 body",


### PR DESCRIPTION
## Summary

Codex's skill loader silently drops any skill whose frontmatter `name` exceeds 64 chars (`invalid name: exceeds maximum length of 64 characters`). `hivemind skillify` was minting and installing skills over that limit, so they never loaded — e.g. `pg-deeplake-multi-layer-issue-diagnosis-and-workaround-prioritization` (68 chars).

The 64-char ceiling applies to the frontmatter `name`, not the directory name (verified empirically: a 64-char name loads, 66+ is rejected; `<name>--<author>` dirs well over 64 load fine as long as the `name` fits).

### Changes

- **skill-writer**: `capSkillName()` truncates >64 names at a hyphen boundary with a low-order hash suffix for disambiguation; `writeNewSkill` validates the raw name, then caps, and returns the canonical on-disk name. `assertValidSkillName` stays a path-safety validator (100-char ceiling), decoupled from the loader limit.
- **worker**: caps only `KEEP` (never `MERGE`, so legacy over-long merge targets keep their version/author/lineage); records the canonical `result.name` in local state and the org row.
- **pull**: validates the raw name before capping; migrates a prior un-capped install to the capped dir (preserving content not older than remote), gated on manifest ownership; retires the stale dir only after the canonical install is recorded (dir removed before its manifest entry, retried on later pulls); detects cap collisions within a run and across runs via a persisted `rawName`, skipping (never overwriting) the collider.
- **manifest**: `PulledEntry` gains an optional `rawName` (persisted raw row name) for cross-run collision detection.
- **mine-local**: records the canonical capped name in the local manifest.

Existing over-long rows in the org table are left unchanged and self-heal on the next pull.

## Version Bump

None in this PR — bug fix only, no `package.json` change; the release is cut separately by the maintainer flow.

## Test plan

- `npx tsc --noEmit` clean.
- `npx vitest run` — **4588 tests pass**.
- New/updated tests cover: capping / hashing / idempotency / low-order-collision, raw-name validation (incl. traversal in a truncated tail), equal- and newer-version stale migration, manifest-ownership guards (unmanaged dir never deleted), within-run and cross-run cap-collision skips.
- Reviewed with `codex review` (multiple rounds; core confirmed sound) and CodeRabbit (2 Major data-integrity items addressed in e829418b).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic, loader-safe capping for overlong skill names with collision-proof uniqueness.
  - Pull now supports capped installs end-to-end, including collision handling, stale-install retirement, and optional name re-rendering for capped directories.
  - Persisted pull metadata now optionally includes the original (pre-cap) remote name to improve duplicate detection.

- **Bug Fixes**
  - Canonical skill names are now consistently used across manifest writing, deduping, and subsequent worker processing.
  - Improved safety: raw-name validation and traversal detection now prevent malicious names from slipping past capping.
  - Unmanaged directories remain protected from cleanup; stale migrations preserve local edits unless forced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->