### PR TITLE
feat(storage): add sqlite and postgres backends

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,24 @@ jobs:
     name: Typecheck and Test
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: hivemind_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d hivemind_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      HIVEMIND_TEST_POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/hivemind_test
+
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Core TypeScript lives in `src/`. CLI code is under `src/cli/` and `src/commands/`; shared hooks are in `src/hooks/shared/`, with runtime integrations in `src/hooks/{claude-code,codex,cursor,hermes,pi}/`. Graph, embedding, notification, and skill-generation code has matching subdirectories. Keep runtime packaging in `harnesses/`, documentation in `docs/`, utilities in `scripts/`, and QA records in `library/`.
+
+Tests live in `tests/` and are grouped by runtime (`tests/codex/`, `tests/openclaw/`, etc.). Put agent-independent coverage in `tests/shared/`; do not add new shared tests to the legacy `tests/claude-code/` location. Build output (`dist/`, `bundle/`, and harness bundles) is generated and should not be edited by hand.
+
+## Build, Test, and Development Commands
+
+- `npm install` installs dependencies; Node.js 22 or newer is required.
+- `npm run build` type-checks, synchronizes versions, and builds all CLI and runtime bundles.
+- `npm run dev` runs TypeScript in watch mode.
+- `npm test` runs the full Vitest suite once. Target a file with `npx vitest run tests/shared/atomic-write.test.ts`.
+- `npm run typecheck` checks types without emitting files.
+- `npm run ci` runs type checks, duplication detection, and tests.
+- `npm run pack:check` validates the package contents before publishing.
+
+## Coding Style & Naming Conventions
+
+Use strict TypeScript, ES modules, two-space indentation, double quotes, and semicolons. Include `.js` extensions in relative imports for compiled Node ESM. Use `camelCase` for functions and variables, `PascalCase` for types and interfaces, and kebab-case filenames such as `session-start.ts`. Prefer shared helpers over copying logic between integrations. There is no standalone formatter; match nearby code. The pre-commit hook type-checks staged TypeScript.
+
+## Testing Guidelines
+
+Use Vitest with `*.test.ts` names and mirror the relevant runtime or subsystem. Cover success, failure, and platform-specific branches; inject filesystem, timing, or process seams instead of relying on live services. Run `npx vitest run --coverage` when changing covered modules. New source files should be added to the per-file thresholds in `vitest.config.ts`, normally at 80% for statements, branches, functions, and lines.
+
+## Commit & Pull Request Guidelines
+
+Follow the repository's Conventional Commit style: `fix(windows): ...`, `feat(graph): ...`, `test(summary): ...`, or `docs: ...`. Keep commits focused and imperative. PRs must include a clear summary and test plan, add relevant tests, and confirm `npm test`. Link issues and include screenshots for dashboard or documentation UI changes. Bump `package.json` using semantic versioning only when the PR should trigger a release; otherwise explicitly mark that no release is needed.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ HIVEMIND_DEBUG=1 claude
 
 ## ⚠️ Data collection notice
 
-This plugin captures session activity and stores it in your Deeplake workspace:
+This plugin captures session activity and stores it in your selected Hivemind backend:
 
 | Data                  | What's captured                    |
 |-----------------------|------------------------------------|
@@ -303,7 +303,7 @@ This plugin captures session activity and stores it in your Deeplake workspace:
 | Subagent activity     | Subagent tool calls and responses  |
 | Codified skills       | Patterns extracted from traces     |
 
-**All users in your Deeplake workspace can read this data.** That's the design. Shared capability requires shared substrate. A DATA NOTICE is displayed at the start of every session. Workspace-level isolation prevents data leakage between orgs.
+**All users with access to the selected workspace can read this data.** That's the design. Shared capability requires shared substrate. A DATA NOTICE is displayed at the start of every session. Deeplake isolates by workspace; SQLite isolates by database file; PostgreSQL isolates by schema.
 
 ## Configuration
 
@@ -313,6 +313,11 @@ This plugin captures session activity and stores it in your Deeplake workspace:
 | `HIVEMIND_ORG_ID`         | _(none)_                  | Organization ID (auto-set by login)        |
 | `HIVEMIND_WORKSPACE_ID`   | `default`                 | Workspace name                             |
 | `HIVEMIND_API_URL`        | `https://api.deeplake.ai` | API endpoint                               |
+| `HIVEMIND_BACKEND`        | `deeplake`                | Storage provider: `deeplake`, `sqlite`, or `postgres` |
+| `HIVEMIND_SQLITE_PATH`    | `~/.deeplake/hivemind.sqlite3` | SQLite database path                 |
+| `HIVEMIND_POSTGRES_URL`   | _(none)_                  | PostgreSQL connection URL; never persisted or printed |
+| `HIVEMIND_POSTGRES_SCHEMA`| `hivemind`                | PostgreSQL schema used as the workspace boundary |
+| `HIVEMIND_VECTOR_SCAN_LIMIT` | `2000`                 | Maximum locally scored embedded rows per search |
 | `HIVEMIND_TABLE`          | `memory`                  | SQL table for summaries and virtual FS     |
 | `HIVEMIND_SESSIONS_TABLE` | `sessions`                | SQL table for per-event session capture    |
 | `HIVEMIND_MEMORY_PATH`    | `~/.deeplake/memory`      | Path that triggers interception            |
@@ -328,6 +333,25 @@ This plugin captures session activity and stores it in your Deeplake workspace:
 | `HIVEMIND_RECALL_MIN_OVERLAP` | `2`                   | Proactive recall (lexical mode): min distinct prompt keywords a summary must share to be injected. Higher = stricter. |
 | `HIVEMIND_RECALL_TIMEOUT_MS` | `1000`                 | Proactive recall: hard cap on the synchronous search path; on timeout it skips rather than delay the turn. |
 | `HIVEMIND_DEBUG`          | _(none)_                  | Set to `1` for verbose hook debug logs     |
+
+### Storage backends
+
+Deeplake remains the default and continues to support hosted and BYOC workspaces. Local SQLite needs no account or token:
+
+```bash
+hivemind backend use sqlite
+hivemind backend check
+```
+
+To use PostgreSQL, supply the connection only through the environment. Hivemind validates it before saving the non-secret provider and schema selection:
+
+```bash
+HIVEMIND_POSTGRES_URL='postgresql://user:password@host/database' \
+  hivemind backend use postgres --schema hivemind
+hivemind backend status
+```
+
+Use `hivemind backend use deeplake` to switch back. Switching providers does not migrate data. A SQLite file or PostgreSQL schema represents one workspace, while `.hivemind` org/workspace routing applies only to Deeplake. The compatibility VFS remains mounted at `~/.deeplake/memory` for every provider.
 
 ## Per-directory config (`.hivemind`)
 
@@ -609,4 +633,3 @@ npm run shell
 ## License
 
 Apache License 2.0, © Activeloop, Inc. See [LICENSE](LICENSE) for details.
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,15 @@
 # Architecture
 
+## Storage layer
+
+Runtime features depend on a provider-neutral storage contract for parameterized queries, transactions, table and column discovery, additive schema healing, and cleanup. The factory selects one of three adapters:
+
+- Deeplake uses the existing HTTP SQL transport and server-side vector scoring.
+- SQLite uses Node's built-in `node:sqlite` with WAL, foreign keys, a busy timeout, and JSON-text vectors.
+- PostgreSQL is dynamically imported, uses a bounded `pg` pool, and scopes all tables to a validated schema.
+
+Logical schema types are rendered per provider. SQLite and vanilla PostgreSQL perform bounded application-side cosine scoring when embeddings are present and fall back to lexical results when they are disabled or malformed. Detached workers receive provider metadata only and reload credentials or connection URLs from protected configuration or inherited environment variables.
+
 ## Integration model per agent
 
 | Agent             | Mechanism                          | Hooks/tools wired                                                                       |

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -432,7 +432,7 @@ await build({
   platform: "node",
   format: "esm",
   outdir: "harnesses/openclaw/dist",
-  external: ["node:*"],
+  external: ["node:*", "pg"],
   // Guarantee `globalThis.__hivemind_tuning__` exists as an object before any
   // bundled module's lazy env reads execute. esbuild's `define` rewrites
   // `process.env.HIVEMIND_X` → `globalThis.__hivemind_tuning__.HIVEMIND_X`
@@ -461,6 +461,16 @@ await build({
     "process.env.HIVEMIND_SESSIONS_TABLE": "undefined",
     "process.env.HIVEMIND_MEMORY_PATH": "undefined",
     "process.env.HIVEMIND_CAPTURE": "undefined",
+    "process.env.HIVEMIND_BACKEND": "undefined",
+    "process.env.HIVEMIND_SQLITE_PATH": "undefined",
+    "process.env.HIVEMIND_POSTGRES_URL": "undefined",
+    "process.env.HIVEMIND_POSTGRES_SCHEMA": "undefined",
+    "process.env.HIVEMIND_VECTOR_SCAN_LIMIT": "undefined",
+    "process.env.HIVEMIND_CONFIG_PATH": "undefined",
+    "process.env.HIVEMIND_SKILLS_TABLE": "undefined",
+    "process.env.HIVEMIND_RULES_TABLE": "undefined",
+    "process.env.HIVEMIND_GOALS_TABLE": "undefined",
+    "process.env.HIVEMIND_KPIS_TABLE": "undefined",
     // ----- User-tunable knobs: routed through a globalThis dispatch -----
     // Every read of `process.env.HIVEMIND_X` in transitively-bundled code is
     // rewritten by esbuild to `globalThis.__hivemind_tuning__.HIVEMIND_X`.
@@ -496,6 +506,24 @@ await build({
     // file as a network send trips the critical rule even though the
     // value is just a directory path.
     "process.env.HIVEMIND_STATE_DIR": "globalThis.__hivemind_tuning__.HIVEMIND_STATE_DIR",
+    "process.env.HIVEMIND_BACKEND": "undefined",
+    "process.env.HIVEMIND_SQLITE_PATH": "undefined",
+    "process.env.HIVEMIND_POSTGRES_URL": "undefined",
+    "process.env.HIVEMIND_POSTGRES_SCHEMA": "undefined",
+    "process.env.HIVEMIND_VECTOR_SCAN_LIMIT": "undefined",
+    "process.env.HIVEMIND_CONFIG_PATH": "undefined",
+    "process.env.HIVEMIND_TOKEN": "undefined",
+    "process.env.HIVEMIND_ORG_ID": "undefined",
+    "process.env.HIVEMIND_WORKSPACE_ID": "undefined",
+    "process.env.HIVEMIND_API_URL": "undefined",
+    "process.env.HIVEMIND_TABLE": "undefined",
+    "process.env.HIVEMIND_SESSIONS_TABLE": "undefined",
+    "process.env.HIVEMIND_SKILLS_TABLE": "undefined",
+    "process.env.HIVEMIND_RULES_TABLE": "undefined",
+    "process.env.HIVEMIND_GOALS_TABLE": "undefined",
+    "process.env.HIVEMIND_KPIS_TABLE": "undefined",
+    "process.env.HIVEMIND_CODEBASE_TABLE": "undefined",
+    "process.env.HIVEMIND_MEMORY_PATH": "undefined",
     "process.env.HIVEMIND_GRAPH_CWD": "globalThis.__hivemind_tuning__.HIVEMIND_GRAPH_CWD",
     "process.env.HIVEMIND_GRAPH_ON_STOP": "globalThis.__hivemind_tuning__.HIVEMIND_GRAPH_ON_STOP",
     "process.env.HIVEMIND_GRAPH_PULL": "globalThis.__hivemind_tuning__.HIVEMIND_GRAPH_PULL",
@@ -544,7 +572,7 @@ await build({
   platform: "node",
   format: "esm",
   outdir: "harnesses/openclaw/dist",
-  external: ["node:*"],
+  external: ["node:*", "pg"],
   // Same banner as the main openclaw bundle — see the comment there for
   // the rationale. The worker entry itself overwrites this with the
   // tuning passed in via the config JSON before any shared module's
@@ -595,6 +623,24 @@ await build({
     "process.env.HIVEMIND_DOCS_TABLE": "globalThis.__hivemind_tuning__.HIVEMIND_DOCS_TABLE",
     "process.env.HIVEMIND_SKILLIFY_EVERY_N_TURNS": "globalThis.__hivemind_tuning__.HIVEMIND_SKILLIFY_EVERY_N_TURNS",
     "process.env.HIVEMIND_AUTOPULL_DISABLED": "globalThis.__hivemind_tuning__.HIVEMIND_AUTOPULL_DISABLED",
+    "process.env.HIVEMIND_BACKEND": "undefined",
+    "process.env.HIVEMIND_SQLITE_PATH": "undefined",
+    "process.env.HIVEMIND_POSTGRES_URL": "undefined",
+    "process.env.HIVEMIND_POSTGRES_SCHEMA": "undefined",
+    "process.env.HIVEMIND_VECTOR_SCAN_LIMIT": "undefined",
+    "process.env.HIVEMIND_CONFIG_PATH": "undefined",
+    "process.env.HIVEMIND_TOKEN": "undefined",
+    "process.env.HIVEMIND_ORG_ID": "undefined",
+    "process.env.HIVEMIND_WORKSPACE_ID": "undefined",
+    "process.env.HIVEMIND_API_URL": "undefined",
+    "process.env.HIVEMIND_TABLE": "undefined",
+    "process.env.HIVEMIND_SESSIONS_TABLE": "undefined",
+    "process.env.HIVEMIND_SKILLS_TABLE": "undefined",
+    "process.env.HIVEMIND_RULES_TABLE": "undefined",
+    "process.env.HIVEMIND_GOALS_TABLE": "undefined",
+    "process.env.HIVEMIND_KPIS_TABLE": "undefined",
+    "process.env.HIVEMIND_CODEBASE_TABLE": "undefined",
+    "process.env.HIVEMIND_MEMORY_PATH": "undefined",
     // Skillify state-dir test-isolation override. OpenClaw never needs
     // to redirect state, so this rewrites to `undefined` at runtime and
     // the call-site fallback produces the homedir-based production path.
@@ -610,6 +656,7 @@ chmodSync("harnesses/openclaw/dist/skillify-worker.js", 0o755);
 // stub-unused-child-process plugin. install-openclaw.ts copies all of dist/.
 const openclawGraphWorkerExternals = [
   "node:*",
+  "pg",
   "node-liblzma",
   "@mongodb-js/zstd",
   "@huggingface/transformers",
@@ -678,6 +725,11 @@ const openclawGraphWorkerDefine = {
     // redirect the config path, so rewrite to undefined — the call site's
     // `?? homedir()/.deeplake/config.json` fallback yields the correct path.
     "process.env.HIVEMIND_CONFIG_PATH": "undefined",
+    "process.env.HIVEMIND_BACKEND": "undefined",
+    "process.env.HIVEMIND_SQLITE_PATH": "undefined",
+    "process.env.HIVEMIND_POSTGRES_URL": "undefined",
+    "process.env.HIVEMIND_POSTGRES_SCHEMA": "undefined",
+    "process.env.HIVEMIND_VECTOR_SCAN_LIMIT": "undefined",
   },
 };
 

--- a/harnesses/claude-code/skills/hivemind-graph/SKILL.md
+++ b/harnesses/claude-code/skills/hivemind-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hivemind-graph
-description: Query the local code graph (functions, classes, calls, imports) through the Deeplake mount at memory/graph/. Use when the user asks structural questions about the codebase — "what calls X?", "what does Y import?", "where is Z defined?", "what's the architecture / which subsystems exist?", "what's the impact of changing this?". The graph is an AST-derived map of the repo, queried as files (no build needed — it rebuilds automatically).
+description: Query the local code graph (functions, classes, calls, imports) through the Hivemind memory mount at memory/graph/. Use when the user asks structural questions about the codebase — "what calls X?", "what does Y import?", "where is Z defined?", "what's the architecture / which subsystems exist?", "what's the impact of changing this?". The graph is an AST-derived map of the repo, queried as files (no build needed — it rebuilds automatically).
 allowed-tools: Read Bash
 ---
 
@@ -9,7 +9,7 @@ allowed-tools: Read Bash
 A deterministic, AST-derived map of the current repository — every function,
 class, method, interface, type, enum, const, and module, plus the edges between
 them (`calls`, `imports`, `extends`, `implements`, `method_of`). It is queried as
-synthesized files under the Deeplake mount; there are no real files on disk and
+synthesized files under the Hivemind memory mount; there are no real files on disk and
 no network call in the read path.
 
 The graph **builds and refreshes automatically** (on Stop / SessionEnd, gated by

--- a/harnesses/codex/skills/deeplake-memory/SKILL.md
+++ b/harnesses/codex/skills/deeplake-memory/SKILL.md
@@ -87,7 +87,7 @@ Only use bash commands (cat, ls, grep, echo, jq, head, tail, sed, awk, etc.) to 
 
 ## Limits
 
-Do NOT spawn subagents to read deeplake memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
+Do NOT spawn subagents to read Hivemind memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
 
 ## Getting Started
 

--- a/harnesses/codex/skills/hivemind-graph/SKILL.md
+++ b/harnesses/codex/skills/hivemind-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hivemind-graph
-description: Query the local code graph (functions, classes, calls, imports) through the Deeplake mount at memory/graph/. Use when the user asks structural questions about the codebase — "what calls X?", "what does Y import?", "where is Z defined?", "what is the architecture / which subsystems exist?". The graph is an AST-derived map of the repo, queried as files (no build needed — it rebuilds automatically).
+description: Query the local code graph (functions, classes, calls, imports) through the Hivemind memory mount at memory/graph/. Use when the user asks structural questions about the codebase — "what calls X?", "what does Y import?", "where is Z defined?", "what is the architecture / which subsystems exist?". The graph is an AST-derived map of the repo, queried as files (no build needed — it rebuilds automatically).
 allowed-tools: Bash
 ---
 
@@ -9,7 +9,7 @@ allowed-tools: Bash
 A deterministic, AST-derived map of the current repository — every function,
 class, method, interface, type, enum, const, and module, plus the edges between
 them (`calls`, `imports`, `extends`, `implements`, `method_of`). It is queried as
-synthesized files under the Deeplake mount; there are no real files on disk and
+synthesized files under the Hivemind memory mount; there are no real files on disk and
 no network call in the read path.
 
 The graph **builds and refreshes automatically** (on Stop / SessionEnd, gated by

--- a/harnesses/hermes/skills/hivemind-graph/SKILL.md
+++ b/harnesses/hermes/skills/hivemind-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hivemind-graph
-description: Query the local code graph (functions, classes, calls, imports) through the Deeplake mount at memory/graph/. Use when the user asks structural questions about the codebase — "what calls X?", "what does Y import?", "where is Z defined?", "what is the architecture / which subsystems exist?". The graph is an AST-derived map of the repo, queried as files (no build needed — it rebuilds automatically).
+description: Query the local code graph (functions, classes, calls, imports) through the Hivemind memory mount at memory/graph/. Use when the user asks structural questions about the codebase — "what calls X?", "what does Y import?", "where is Z defined?", "what is the architecture / which subsystems exist?". The graph is an AST-derived map of the repo, queried as files (no build needed — it rebuilds automatically).
 allowed-tools: terminal
 ---
 
@@ -9,7 +9,7 @@ allowed-tools: terminal
 A deterministic, AST-derived map of the current repository — every function,
 class, method, interface, type, enum, const, and module, plus the edges between
 them (`calls`, `imports`, `extends`, `implements`, `method_of`). It is queried as
-synthesized files under the Deeplake mount; there are no real files on disk and
+synthesized files under the Hivemind memory mount; there are no real files on disk and
 no network call in the read path.
 
 The graph **builds and refreshes automatically** (on Stop / SessionEnd, gated by

--- a/harnesses/openclaw/package.json
+++ b/harnesses/openclaw/package.json
@@ -2,7 +2,7 @@
   "name": "hivemind",
   "version": "0.7.145",
   "type": "module",
-  "description": "Hivemind — cloud-backed persistent shared memory for AI agents, powered by DeepLake",
+  "description": "Hivemind — persistent shared memory for AI agents with pluggable storage",
   "license": "Apache-2.0",
   "openclaw": {
     "extensions": [

--- a/harnesses/openclaw/src/index.ts
+++ b/harnesses/openclaw/src/index.ts
@@ -546,8 +546,6 @@ function tryAcquireOpenclawSkillifyLock(projectKey: string): boolean {
 }
 
 interface OpenclawSpawnArgs {
-  apiUrl: string;
-  token: string;
   orgId: string;
   workspaceId: string;
   userName: string;
@@ -638,10 +636,7 @@ function spawnOpenclawSkillifyWorker(a: OpenclawSpawnArgs): boolean {
   // rather than a per-project tree that would bear no relation to the user's
   // actual project layout.
   const config = {
-    apiUrl: a.apiUrl,
-    token: a.token,
-    orgId: a.orgId,
-    workspaceId: a.workspaceId,
+    storage: { kind: "deeplake" as const, orgId: a.orgId, workspaceId: a.workspaceId },
     sessionsTable,
     skillsTable,
     userName: a.userName,
@@ -1604,8 +1599,6 @@ export default definePluginEntry({
             // runtime. CodeRabbit on #172.
             try {
               if (spawnOpenclawSkillifyWorker({
-                apiUrl: cfg.apiUrl,
-                token: cfg.token,
                 orgId: cfg.orgId,
                 workspaceId: cfg.workspaceId,
                 userName: cfg.userName,

--- a/harnesses/pi/extension-source/hivemind.ts
+++ b/harnesses/pi/extension-source/hivemind.ts
@@ -5,7 +5,7 @@
 //
 // Subscribes to the agent lifecycle events documented in
 // `pi-mono/packages/coding-agent/src/core/extensions/types.ts` to:
-//   - inject deeplake memory context at session_start
+//   - inject Hivemind memory context at session_start
 //   - capture user prompts (input event)
 //   - capture tool call results (tool_result event)
 //   - capture assistant messages (message_end event)
@@ -875,10 +875,7 @@ function spawnWikiWorker(
   const configPath = join(tmpDir, "config.json");
   const project = (cwd ?? "").split("/").pop() || "unknown";
   const config = {
-    apiUrl: creds.apiUrl,
-    token: creds.token,
-    orgId: creds.orgId,
-    workspaceId: creds.workspaceId,
+    storage: { kind: "deeplake" as const, orgId: creds.orgId, workspaceId: creds.workspaceId },
     memoryTable: MEMORY_TABLE,
     sessionsTable: SESSIONS_TABLE,
     sessionId,
@@ -975,10 +972,7 @@ function spawnPiSkillifyWorker(creds: Creds, sessionId: string, cwd: string): vo
   // gate-runner falls back to its agent dispatch which for `agent: "pi"`
   // resolves to the `pi --print` invocation we'd want for consistency.
   const config = {
-    apiUrl: creds.apiUrl,
-    token: creds.token,
-    orgId: creds.orgId,
-    workspaceId: creds.workspaceId,
+    storage: { kind: "deeplake" as const, orgId: creds.orgId, workspaceId: creds.workspaceId },
     sessionsTable: SESSIONS_TABLE,
     skillsTable: process.env.HIVEMIND_SKILLS_TABLE || "skills",
     userName: creds.userName,
@@ -1309,7 +1303,7 @@ function piRenderSkillifyCommands(): string {
     .join("\n");
 }
 
-const CONTEXT_PREAMBLE = `DEEPLAKE MEMORY: Persistent memory at ~/.deeplake/memory/ shared across sessions, users, and agents in your org.
+const CONTEXT_PREAMBLE = `HIVEMIND MEMORY: Persistent memory at ~/.deeplake/memory/ shared across sessions, users, and agents in your workspace.
 
 Three hivemind tools are registered:
   hivemind_search { query, limit? }   keyword search across summaries + sessions

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "deeplake": "^0.3.30",
         "js-yaml": "^4.1.1",
         "just-bash": "^2.14.0",
+        "pg": "^8.23.0",
         "yargs-parser": "^22.0.0",
         "zod": "^4.3.6"
       },
@@ -23,6 +24,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.0.0",
+        "@types/pg": "^8.21.0",
         "@types/yargs-parser": "^21.0.3",
         "@vitest/coverage-v8": "^4.1.3",
         "esbuild": "^0.28.0",
@@ -34,7 +36,7 @@
         "vitest": "^4.0.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.13.0"
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^3.0.0",
@@ -1721,9 +1723,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1739,9 +1738,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1759,9 +1755,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1778,9 +1771,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1796,9 +1786,6 @@
       "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1832,9 +1819,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1867,9 +1851,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1891,9 +1872,6 @@
       "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1917,9 +1895,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1942,9 +1917,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1966,9 +1938,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2013,9 +1982,6 @@
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2573,9 +2539,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2593,9 +2556,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2613,9 +2573,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2633,9 +2590,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3611,6 +3565,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/sarif": {
@@ -5922,9 +5888,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5946,9 +5909,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6721,15 +6681,14 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -6737,7 +6696,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.4.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -6749,52 +6708,47 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
-      "license": "MIT",
-      "optional": true
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
-      "optional": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
-      "license": "MIT",
-      "optional": true
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -6811,7 +6765,6 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -6886,7 +6839,6 @@
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -6896,7 +6848,6 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6906,7 +6857,6 @@
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6916,7 +6866,6 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -7837,7 +7786,6 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -9267,7 +9215,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@deeplake/hivemind",
   "version": "0.7.145",
-  "description": "Cloud-backed persistent shared memory for AI agents powered by Deeplake",
+  "description": "Persistent shared memory for AI agents with pluggable storage",
   "type": "module",
   "repository": {
     "type": "git",
@@ -60,6 +60,7 @@
     "deeplake": "^0.3.30",
     "js-yaml": "^4.1.1",
     "just-bash": "^2.14.0",
+    "pg": "^8.23.0",
     "yargs-parser": "^22.0.0",
     "zod": "^4.3.6"
   },
@@ -84,6 +85,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.0.0",
+    "@types/pg": "^8.21.0",
     "@types/yargs-parser": "^21.0.3",
     "@vitest/coverage-v8": "^4.1.3",
     "esbuild": "^0.28.0",
@@ -95,6 +97,6 @@
     "vitest": "^4.0.0"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,7 @@ import { docsInstallLines, docsHintShown, markDocsHintShown } from "../docs/inst
 import { runUpdate } from "./update.js";
 import { renderCliHelpBlock } from "./skillify-spec.js";
 import { maybeAutoMineLocal } from "../skillify/spawn-mine-local-worker.js";
+import { runBackendCommand, selectedBackend } from "../commands/backend.js";
 
 const AUTH_SUBCOMMANDS = new Set([
   "whoami",
@@ -87,6 +88,13 @@ Usage:
                             Run device-flow login (open browser). --ref
                             attributes a new signup to a referrer code.
   hivemind status           Show which assistants are wired up.
+  hivemind backend status
+  hivemind backend use deeplake
+  hivemind backend use sqlite [--path <file>]
+  hivemind backend use postgres [--schema <name>]
+  hivemind backend check
+      Select and validate the persistence provider. PostgreSQL reads its
+      connection URL only from HIVEMIND_POSTGRES_URL.
   hivemind update [--dry-run]
       Check npm for a newer @deeplake/hivemind, upgrade the CLI, and refresh
       every detected agent bundle. Single command for all agents.
@@ -144,7 +152,7 @@ Codebase graph (per-repo AST snapshot + cloud sync):
                                              snapshot for HEAD into local.
   hivemind graph uninstall                   Remove the managed post-commit
                                              hook.
-  Agents query the local snapshot via the Deeplake mount at
+  Agents query the local snapshot via the Hivemind memory mount at
   ~/.deeplake/memory/graph/{index.md,find/<pattern>,show/<handle-or-pattern>}.
 
 Skill management (mine + share reusable Claude skills across the org):
@@ -373,7 +381,7 @@ async function runInstallAll(args: string[]): Promise<void> {
   log(`Installing hivemind ${getVersion()} for: ${targets.join(", ")}`);
   log("");
 
-  if (!skipAuth && !isLoggedIn()) {
+  if (!skipAuth && selectedBackend() === "deeplake" && !isLoggedIn()) {
     await runAuthGate(args);
   }
 
@@ -410,7 +418,10 @@ async function runInstallAll(args: string[]): Promise<void> {
   await runInstallDocsOnboarding({
     cwd: process.cwd(),
     interactive: Boolean(process.stdin.isTTY && process.stdout.isTTY),
-    loggedIn: isLoggedIn(),
+    // Local providers are fully usable without Deeplake credentials. The
+    // onboarding helper's legacy `loggedIn` flag really means "storage is
+    // available", so base the gate on provider-neutral configuration.
+    loggedIn: loadConfig() !== null,
     home: homedir(),
     gitTopLevel: (cwd) => tryGitTopLevel(cwd),
     loadCfg: () => loadConfig(),
@@ -510,8 +521,17 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (cmd === "login") { await ensureLoggedIn(parseRef(args.slice(1))); return; }
+  if (cmd === "login") {
+    if (selectedBackend() !== "deeplake") throw new Error("hivemind login is only available with the deeplake backend");
+    await ensureLoggedIn(parseRef(args.slice(1)));
+    return;
+  }
   if (cmd === "status") { runStatus(); return; }
+  if (cmd === "backend") {
+    const code = await runBackendCommand(args.slice(1));
+    if (code !== 0) process.exit(code);
+    return;
+  }
   if (cmd === "update") {
     const code = await runUpdate({ dryRun: hasFlag(args.slice(1), "--dry-run") });
     process.exit(code);
@@ -617,6 +637,9 @@ async function main(): Promise<void> {
 
   // Account / org / workspace subcommands — passthrough to the auth-login dispatcher.
   if (AUTH_SUBCOMMANDS.has(cmd)) {
+    if (selectedBackend() !== "deeplake" && cmd !== "autoupdate") {
+      throw new Error(`hivemind ${cmd} is only available with the deeplake backend`);
+    }
     await runAuthCommand(args);
     return;
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -637,7 +637,10 @@ async function main(): Promise<void> {
 
   // Account / org / workspace subcommands — passthrough to the auth-login dispatcher.
   if (AUTH_SUBCOMMANDS.has(cmd)) {
-    if (selectedBackend() !== "deeplake" && cmd !== "autoupdate") {
+    // `sessions prune` operates through the provider-neutral StorageBackend
+    // and is valid for SQLite/PostgreSQL. The other account-management
+    // commands still require Deeplake's auth and organization APIs.
+    if (selectedBackend() !== "deeplake" && cmd !== "autoupdate" && cmd !== "sessions") {
       throw new Error(`hivemind ${cmd} is only available with the deeplake backend`);
     }
     await runAuthCommand(args);

--- a/src/cli/install-mcp-shared.ts
+++ b/src/cli/install-mcp-shared.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { HOME, pkgRoot, ensureDir, copyDir, writeVersionStamp, log } from "./util.js";
 import { getVersion } from "./version.js";
+import { homedir } from "node:os";
 
 // Shared installer logic for the hivemind MCP server.
 //
@@ -14,24 +15,31 @@ export const MCP_DIR = join(HIVEMIND_DIR, "mcp");
 export const MCP_SERVER_PATH = join(MCP_DIR, "server.js");
 export const MCP_PACKAGE_JSON = join(MCP_DIR, "package.json");
 
+function paths(home = homedir()): { hivemindDir: string; mcpDir: string; serverPath: string } {
+  const hivemindDir = join(home, ".hivemind");
+  const mcpDir = join(hivemindDir, "mcp");
+  return { hivemindDir, mcpDir, serverPath: join(mcpDir, "server.js") };
+}
+
 /** Copy the bundled MCP server into ~/.hivemind/mcp/ if missing or out of date. */
 export function ensureMcpServerInstalled(): void {
+  const active = paths();
   const srcDir = join(pkgRoot(), "mcp", "bundle");
   if (!existsSync(srcDir)) {
     throw new Error(
       `MCP server bundle missing at ${srcDir}. Run 'npm run build' to produce it before installing Tier B consumers.`,
     );
   }
-  ensureDir(MCP_DIR);
-  copyDir(srcDir, MCP_DIR);
-  writeVersionStamp(HIVEMIND_DIR, getVersion());
-  log(`  hivemind-mcp   server installed -> ${MCP_SERVER_PATH}`);
+  ensureDir(active.mcpDir);
+  copyDir(srcDir, active.mcpDir);
+  writeVersionStamp(active.hivemindDir, getVersion());
+  log(`  hivemind-mcp   server installed -> ${active.serverPath}`);
 }
 
 /** Standard MCP server descriptor for stdio transport. */
 export function buildMcpServerEntry(): Record<string, unknown> {
   return {
     command: "node",
-    args: [MCP_SERVER_PATH],
+    args: [paths().serverPath],
   };
 }

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -105,9 +105,10 @@ export interface DetectedPlatform {
 // Claude Code CLI). Cowork reads MCP servers from claude_desktop_config.json
 // inside this dir, shared with Claude Desktop chat.
 export function claudeDesktopConfigDir(): string {
-  if (process.platform === "darwin") return join(HOME, "Library", "Application Support", "Claude");
-  if (process.platform === "win32") return join(process.env.APPDATA ?? join(HOME, "AppData", "Roaming"), "Claude");
-  return join(HOME, ".config", "Claude");
+  const home = homedir();
+  if (process.platform === "darwin") return join(home, "Library", "Application Support", "Claude");
+  if (process.platform === "win32") return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Claude");
+  return join(home, ".config", "Claude");
 }
 
 // Hivemind's value is bidirectional shared memory — every supported agent

--- a/src/commands/auth-login.ts
+++ b/src/commands/auth-login.ts
@@ -27,6 +27,7 @@ import {
 import { sessionPrune } from "./session-prune.js";
 import { loadConfig } from "../config.js";
 import { renderWhoami } from "./whoami.js";
+import { getAutoupdateEnabled, setAutoupdateEnabled } from "../user-config.js";
 
 /**
  * Dispatch one auth subcommand.
@@ -187,16 +188,15 @@ export async function runAuthCommand(args: string[]): Promise<void> {
     }
 
     case "autoupdate": {
-      if (!creds) { console.log("Not logged in."); process.exit(1); }
       const val = args[1]?.toLowerCase();
       if (val === "on" || val === "true") {
-        saveCredentials({ ...creds, autoupdate: true });
+        setAutoupdateEnabled(true);
         console.log("Autoupdate enabled. Plugin will update automatically on session start.");
       } else if (val === "off" || val === "false") {
-        saveCredentials({ ...creds, autoupdate: false });
+        setAutoupdateEnabled(false);
         console.log("Autoupdate disabled. You'll see a notice when updates are available.");
       } else {
-        const current = creds.autoupdate !== false ? "on" : "off";
+        const current = getAutoupdateEnabled() ? "on" : "off";
         console.log(`Autoupdate is currently: ${current}`);
         console.log("Usage: autoupdate [on|off]");
       }

--- a/src/commands/backend.ts
+++ b/src/commands/backend.ts
@@ -1,0 +1,128 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { loadStorageConfig, type StorageProvider } from "../config.js";
+import { createStorageBackend } from "../storage/factory.js";
+import { readUserConfig, writeUserConfig } from "../user-config.js";
+
+const PROVIDERS = new Set<StorageProvider>(["deeplake", "sqlite", "postgres"]);
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function option(args: string[], name: string): string | undefined {
+  const index = args.findIndex(arg => arg === name || arg.startsWith(`${name}=`));
+  if (index < 0) return undefined;
+  return args[index].includes("=") ? args[index].split("=", 2)[1] : args[index + 1];
+}
+
+export function selectedBackend(): StorageProvider {
+  const raw = process.env.HIVEMIND_BACKEND ?? readUserConfig().storage?.provider ?? "deeplake";
+  if (!PROVIDERS.has(raw as StorageProvider)) throw new Error(`Invalid HIVEMIND_BACKEND: ${raw}`);
+  return raw as StorageProvider;
+}
+
+function displayPath(path: string): string {
+  const home = homedir();
+  return path === home || path.startsWith(`${home}/`) ? `~${path.slice(home.length)}` : path;
+}
+
+export function renderBackendStatus(): string {
+  const persisted = readUserConfig().storage;
+  const provider = selectedBackend();
+  const source = process.env.HIVEMIND_BACKEND ? "environment" : persisted?.provider ? "user config" : "default";
+  const lines = [`Backend: ${provider}`, `Selected by: ${source}`];
+  if (provider === "sqlite") {
+    const path = resolve(process.env.HIVEMIND_SQLITE_PATH ?? persisted?.sqlitePath ?? join(homedir(), ".deeplake", "hivemind.sqlite3"));
+    lines.push(`Database: ${displayPath(path)}`);
+  } else if (provider === "postgres") {
+    lines.push(`Schema: ${process.env.HIVEMIND_POSTGRES_SCHEMA ?? persisted?.postgresSchema ?? "hivemind"}`);
+    lines.push(`Connection: ${process.env.HIVEMIND_POSTGRES_URL ? "configured via environment" : "not configured"}`);
+  } else {
+    lines.push("Connection: Deeplake credentials");
+  }
+  return lines.join("\n");
+}
+
+async function withProviderEnvironment<T>(
+  provider: StorageProvider,
+  overrides: Partial<Record<"HIVEMIND_SQLITE_PATH" | "HIVEMIND_POSTGRES_SCHEMA", string>>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const keys = ["HIVEMIND_BACKEND", ...Object.keys(overrides)] as const;
+  const previous = new Map<string, string | undefined>(keys.map(key => [key, process.env[key]]));
+  process.env.HIVEMIND_BACKEND = provider;
+  for (const [key, value] of Object.entries(overrides)) if (value !== undefined) process.env[key] = value;
+  try { return await fn(); } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+async function checkSelected(): Promise<void> {
+  const provider = selectedBackend();
+  const config = loadStorageConfig();
+  if (!config) {
+    if (provider === "postgres") throw new Error("PostgreSQL backend requires HIVEMIND_POSTGRES_URL");
+    if (provider === "deeplake") throw new Error("Deeplake backend requires login credentials");
+    throw new Error(`Unable to load ${provider} backend configuration`);
+  }
+  const backend = createStorageBackend(config);
+  try {
+    await backend.query("SELECT 1 AS ok");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const redacted = config.kind === "postgres"
+      ? message.split(config.connectionUrl).join("[redacted PostgreSQL URL]")
+      : message;
+    throw new Error(redacted);
+  } finally {
+    await backend.close();
+  }
+}
+
+export async function runBackendCommand(args: string[]): Promise<number> {
+  const sub = args[0] ?? "status";
+  if (sub === "status") {
+    console.log(renderBackendStatus());
+    return 0;
+  }
+  if (sub === "check") {
+    await checkSelected();
+    console.log(`${selectedBackend()} backend: ok`);
+    return 0;
+  }
+  if (sub !== "use") throw new Error("Usage: hivemind backend status | use <deeplake|sqlite|postgres> | check");
+
+  const provider = args[1] as StorageProvider | undefined;
+  if (!provider || !PROVIDERS.has(provider)) {
+    throw new Error("Usage: hivemind backend use deeplake | sqlite [--path <file>] | postgres [--schema <name>]");
+  }
+
+  if (provider === "deeplake") {
+    writeUserConfig({ storage: { provider: "deeplake" } });
+    console.log("Backend set to deeplake.");
+    return 0;
+  }
+
+  if (provider === "sqlite") {
+    const path = resolve(option(args.slice(2), "--path") ?? join(homedir(), ".deeplake", "hivemind.sqlite3"));
+    await withProviderEnvironment("sqlite", { HIVEMIND_SQLITE_PATH: path }, async () => {
+      await checkSelected();
+    });
+    writeUserConfig({ storage: { provider: "sqlite", sqlitePath: path } });
+    console.log(`Backend set to sqlite (${displayPath(path)}).`);
+    return 0;
+  }
+
+  const schema = option(args.slice(2), "--schema") ?? "hivemind";
+  if (!IDENTIFIER.test(schema)) throw new Error(`Invalid PostgreSQL schema: ${schema}`);
+  if (!process.env.HIVEMIND_POSTGRES_URL) {
+    throw new Error("PostgreSQL backend requires HIVEMIND_POSTGRES_URL; the URL is never persisted");
+  }
+  await withProviderEnvironment("postgres", { HIVEMIND_POSTGRES_SCHEMA: schema }, async () => {
+    await checkSelected();
+  });
+  writeUserConfig({ storage: { provider: "postgres", postgresSchema: schema } });
+  console.log(`Backend set to postgres (schema ${schema}; connection URL kept in environment).`);
+  return 0;
+}

--- a/src/commands/backend.ts
+++ b/src/commands/backend.ts
@@ -68,6 +68,10 @@ async function checkSelected(): Promise<void> {
   }
   const backend = createStorageBackend(config);
   try {
+    // A successful selection should leave a usable backend, not merely prove
+    // that the database socket/file opens. Initialization is additive and
+    // idempotent, so this also heals older local schemas during `check`.
+    await backend.initializeSchema();
     await backend.query("SELECT 1 AS ok");
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -17,13 +17,13 @@
  *      is a read-only diagnostic that surfaces what the renderer
  *      would produce right now without firing SessionStart.
  *
- * The CLI is thin: load config → construct DeeplakeApi → call
+ * The CLI is thin: load config → construct the storage backend → call
  * renderContextBlock → print. No flags in v1 (the renderer's
  * maxRules / maxGoals defaults of 10 are the v1 contract).
  */
 
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { renderContextBlock } from "../hooks/shared/context-renderer.js";
 
 const USAGE = `
@@ -53,13 +53,7 @@ export async function runContextCommand(args: string[]): Promise<void> {
     throw new Error("unreachable");
   }
 
-  const api = new DeeplakeApi(
-    cfg.token,
-    cfg.apiUrl,
-    cfg.orgId,
-    cfg.workspaceId,
-    cfg.tableName,
-  );
+  const api = createStorageBackend(cfg, cfg.tableName);
 
   const known = await api.knownTablesOrNull();
   const tableExists = known ? (name: string) => known.includes(name) : undefined;

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -25,7 +25,8 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { loadConfig } from "../config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { getVersion } from "../cli/version.js";
 import {
   setDoc,
@@ -67,6 +68,7 @@ import { defaultGit } from "../docs/candidates.js";
 import { currentScope } from "../docs/branch-scope.js";
 import { deriveProjectKey } from "../utils/repo-identity.js";
 import { makeDocEmbedder } from "../docs/embed.js";
+import { storageQuery } from "../docs/read.js";
 import { backfillDocEmbeddings } from "../docs/backfill.js";
 import { loadCurrentSnapshot } from "../graph/load-current.js";
 import { isMissingTableError } from "../deeplake-schema.js";
@@ -204,8 +206,8 @@ function requireConfig(): NonNullable<ReturnType<typeof loadConfig>> {
   return cfg;
 }
 
-function makeApi(cfg: NonNullable<ReturnType<typeof loadConfig>>): DeeplakeApi {
-  return new DeeplakeApi(cfg.token, cfg.apiUrl, cfg.orgId, cfg.workspaceId, cfg.tableName);
+function makeApi(cfg: NonNullable<ReturnType<typeof loadConfig>>): StorageBackend {
+  return createStorageBackend(cfg, cfg.tableName);
 }
 
 function flagValue(args: string[], name: string): string | undefined {
@@ -386,7 +388,7 @@ export async function runDocsCommand(args: string[]): Promise<void> {
   const cfg = requireConfig();
   const api = makeApi(cfg);
   const tableName = cfg.docsTableName;
-  const query = api.query.bind(api);
+  const query = storageQuery(api);
   const pluginVersion = getVersion();
 
   // Only write subcommands need DDL — read-only show/list (and refresh

--- a/src/commands/flush-memory.ts
+++ b/src/commands/flush-memory.ts
@@ -21,7 +21,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { type Config } from "../config.js";
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { uploadSummary, type QueryFn, type UploadParams, type UploadResult } from "../hooks/upload-summary.js";
 import { EmbedClient } from "../embeddings/client.js";
 import { embeddingsDisabled } from "../embeddings/disable.js";
@@ -84,7 +84,7 @@ export function defaultDeps(pluginVersion?: string): FlushDeps {
     loadConfig: loadRoutedConfig,
     makeQuery: (config) =>
       (sql: string) =>
-        new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName).query(sql),
+        createStorageBackend(config, config.tableName).query(sql),
     upload: uploadSummary,
     embed: defaultEmbed,
     pluginVersion,

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -36,8 +36,10 @@
 
 import { randomUUID } from "node:crypto";
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { sqlIdent, sqlStr } from "../utils/sql.js";
+import { escapedStringPrefix } from "../storage/sql-dialect.js";
 
 type QueryFn = (sql: string) => Promise<Array<Record<string, unknown>>>;
 
@@ -77,19 +79,13 @@ function parseAgentFlag(args: string[]): { agent: string; rest: string[] } {
   return { agent, rest };
 }
 
-function loadApiOrDie(table: string): { api: DeeplakeApi; query: QueryFn; userName: string } {
+function loadApiOrDie(table: string): { api: StorageBackend; query: QueryFn; userName: string } {
   const cfg = loadRoutedConfig();
   if (!cfg) {
     process.stderr.write("hivemind: not logged in. Run `hivemind login` first.\n");
     process.exit(1);
   }
-  const api = new DeeplakeApi(
-    cfg.token,
-    cfg.apiUrl,
-    cfg.orgId,
-    cfg.workspaceId,
-    table,
-  );
+  const api = createStorageBackend(cfg, table);
   const query: QueryFn = (sql) => api.query(sql) as Promise<Array<Record<string, unknown>>>;
   return { api, query, userName: cfg.userName };
 }
@@ -114,7 +110,7 @@ async function goalAdd(text: string, agent: string = "manual"): Promise<void> {
     `'${sqlStr(goalId)}', ` +
     `'${sqlStr(cfg.userName)}', ` +
     `'opened', ` +
-    `E'${sqlStr(text)}', ` +
+    `${escapedStringPrefix(api.dialect)}'${sqlStr(text)}', ` +
     `1, ` +
     `'${sqlStr(ts)}', ` +
     `'${sqlStr(ts)}', ` +
@@ -224,7 +220,7 @@ async function kpiAdd(args: string[]): Promise<void> {
     `'${randomUUID()}', ` +
     `'${sqlStr(goalId)}', ` +
     `'${sqlStr(kpiId)}', ` +
-    `E'${sqlStr(content)}', ` +
+    `${escapedStringPrefix(api.dialect)}'${sqlStr(content)}', ` +
     `1, ` +
     `'${sqlStr(ts)}', ` +
     `'${sqlStr(ts)}', ` +
@@ -293,7 +289,7 @@ async function kpiBump(goalId: string, kpiId: string, deltaStr: string): Promise
   }
   const ts = new Date().toISOString();
   await query(
-    `UPDATE "${safe}" SET content = E'${sqlStr(newContent)}', updated_at = '${sqlStr(ts)}' WHERE goal_id = '${sqlStr(goalId)}' AND kpi_id = '${sqlStr(kpiId)}'`
+    `UPDATE "${safe}" SET content = ${escapedStringPrefix(api.dialect)}'${sqlStr(newContent)}', updated_at = '${sqlStr(ts)}' WHERE goal_id = '${sqlStr(goalId)}' AND kpi_id = '${sqlStr(kpiId)}'`
   );
   process.stdout.write(`${goalId}/${kpiId} +${delta}\n`);
 }

--- a/src/commands/graph.ts
+++ b/src/commands/graph.ts
@@ -16,9 +16,9 @@ import { tryGitTopLevel } from "../graph/git-hook-install.js";
 import { loadCurrentSnapshot } from "../graph/load-current.js";
 import { spawnDetachedNodeWorker } from "../utils/spawn-detached.js";
 import { readFileSync, readdirSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { join, relative, resolve, sep } from "node:path";
 
-import { createHash } from "node:crypto";
 
 import { getVersion } from "../cli/version.js";
 import { fileContentHash, readCache, writeCache } from "../graph/cache.js";
@@ -29,7 +29,10 @@ import {
   loadSnapshotByCommit,
   printDiffHuman,
 } from "../graph/diff.js";
-import { extractFile } from "../graph/extract/index.js";
+
+function workTreeIdFor(cwd: string): string {
+  return createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+}
 import {
   loadGraphIgnore,
   ignoreDirSet,
@@ -469,6 +472,11 @@ export async function runBuildCommand(args: string[]): Promise<void> {
   const sourceFiles = discoverSourceFiles(cwd, ignoreConfig);
   console.log(`Discovered ${sourceFiles.length} source files. Extracting...`);
 
+  // The parser stack includes optional native tree-sitter packages. Load it
+  // only for graph builds so lightweight commands such as `graph diff` and
+  // `graph history` remain usable when those optional packages are absent.
+  const { extractFile } = await import("../graph/extract/index.js");
+
   const extractions: FileExtraction[] = [];
   let skipped = 0;
   let totalParseErrors = 0;
@@ -658,10 +666,6 @@ export async function runPullCommand(args: string[]): Promise<void> {
  * (e.g., main checkout + git worktree for a feature branch). NOT cross-machine
  * stable; pair with user_id in the cloud PK to keep rows distinct across machines.
  */
-function workTreeIdFor(cwd: string): string {
-  return createHash("sha256").update(cwd).digest("hex").slice(0, 16);
-}
-
 // ─── Source-file discovery ─────────────────────────────────────────────────
 
 function discoverSourceFiles(rootDir: string, config: GraphIgnoreConfig): string[] {

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -23,7 +23,8 @@
  */
 
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { getVersion } from "../cli/version.js";
 import {
   insertRule,
@@ -62,14 +63,8 @@ function requireConfig(): ReturnType<typeof loadRoutedConfig> & object {
   return cfg;
 }
 
-function makeApi(cfg: NonNullable<ReturnType<typeof loadRoutedConfig>>): DeeplakeApi {
-  return new DeeplakeApi(
-    cfg.token,
-    cfg.apiUrl,
-    cfg.orgId,
-    cfg.workspaceId,
-    cfg.tableName, // unused by ensureRulesTable but the constructor needs it
-  );
+function makeApi(cfg: NonNullable<ReturnType<typeof loadRoutedConfig>>): StorageBackend {
+  return createStorageBackend(cfg, cfg.rulesTableName);
 }
 
 function parseScope(args: string[]): "team" | null {
@@ -176,7 +171,7 @@ export async function runRulesCommand(args: string[]): Promise<void> {
         text,
         assigned_by: cfg.userName,
         plugin_version: pluginVersion,
-      });
+      }, api.dialect);
       console.log(`Added rule ${out.rule_id} (v${out.version}).`);
     } catch (err) {
       console.error(`Add failed: ${(err as Error).message}`);
@@ -237,7 +232,7 @@ export async function runRulesCommand(args: string[]): Promise<void> {
         text: newText,
         assigned_by: cfg.userName,
         plugin_version: pluginVersion,
-      });
+      }, api.dialect);
       console.log(`Edited rule ${out.rule_id} → v${out.version}.`);
     } catch (err) {
       console.error(`Edit failed: ${(err as Error).message}`);
@@ -259,7 +254,7 @@ export async function runRulesCommand(args: string[]): Promise<void> {
         rule_id: ruleId,
         assigned_by: cfg.userName,
         plugin_version: pluginVersion,
-      });
+      }, api.dialect);
       console.log(`Marked rule ${out.rule_id} done (v${out.version}).`);
     } catch (err) {
       console.error(`Done failed: ${(err as Error).message}`);

--- a/src/commands/session-prune.ts
+++ b/src/commands/session-prune.ts
@@ -12,7 +12,8 @@
  */
 
 import { loadConfig, type Config } from "../config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { sqlStr } from "../utils/sql.js";
 import { confirm } from "../cli/util.js";
 
@@ -68,7 +69,7 @@ function extractSessionId(path: string): string {
 // ── Core ─────────────────────────────────────────────────────────────────────
 
 async function listSessions(
-  api: DeeplakeApi,
+  api: StorageBackend,
   sessionsTable: string,
   author: string,
 ): Promise<SessionInfo[]> {
@@ -94,14 +95,8 @@ async function deleteSessions(
 ): Promise<{ sessionsDeleted: number; summariesDeleted: number }> {
   if (sessionPaths.length === 0) return { sessionsDeleted: 0, summariesDeleted: 0 };
 
-  const sessionsApi = new DeeplakeApi(
-    config.token, config.apiUrl, config.orgId, config.workspaceId,
-    config.sessionsTableName,
-  );
-  const memoryApi = new DeeplakeApi(
-    config.token, config.apiUrl, config.orgId, config.workspaceId,
-    config.tableName,
-  );
+  const sessionsApi = createStorageBackend(config, config.sessionsTableName);
+  const memoryApi = createStorageBackend(config, config.tableName);
 
   let sessionsDeleted = 0;
   let summariesDeleted = 0;
@@ -144,10 +139,7 @@ export async function sessionPrune(argv: string[]): Promise<void> {
   const { before, sessionId, all, yes } = parseArgs(argv);
   const author = config.userName;
 
-  const sessionsApi = new DeeplakeApi(
-    config.token, config.apiUrl, config.orgId, config.workspaceId,
-    config.sessionsTableName,
-  );
+  const sessionsApi = createStorageBackend(config, config.sessionsTableName);
 
   // Fetch all sessions for this author
   const sessions = await listSessions(sessionsApi, config.sessionsTableName, author);

--- a/src/commands/skillify.ts
+++ b/src/commands/skillify.ts
@@ -31,7 +31,7 @@ import { runPush } from "../skillify/push.js";
 import { runUnpull } from "../skillify/unpull.js";
 import { loadConfig } from "../config.js";
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { runMineLocal } from "./mine-local.js";
 import { renderSubcommandUsageBlock } from "../cli/skillify-spec.js";
 
@@ -227,9 +227,7 @@ async function pullSkills(args: string[]): Promise<void> {
     console.error("Not logged in. Run: hivemind login");
     process.exit(1);
   }
-  const api = new DeeplakeApi(
-    config.token, config.apiUrl, config.orgId, config.workspaceId, config.skillsTableName,
-  );
+  const api = createStorageBackend(config, config.skillsTableName);
   // Wrap api.query so it matches the QueryFn signature expected by runPull.
   const query = (sql: string) => api.query(sql) as Promise<Record<string, unknown>[]>;
 
@@ -290,9 +288,7 @@ async function pushSkills(args: string[]): Promise<void> {
   if (!config) {
     throw new Error("Not logged in. Run: hivemind login");
   }
-  const api = new DeeplakeApi(
-    config.token, config.apiUrl, config.orgId, config.workspaceId, config.skillsTableName,
-  );
+  const api = createStorageBackend(config, config.skillsTableName);
   const query = (sql: string) => api.query(sql) as Promise<Record<string, unknown>[]>;
   const scopeCfg = loadScopeConfig();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,58 @@
 import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { homedir, userInfo } from "node:os";
+import { readUserConfig } from "./user-config.js";
 
+export type StorageProvider = "deeplake" | "sqlite" | "postgres";
+
+export interface CommonStorageConfig {
+  kind: StorageProvider;
+  userName: string;
+  workspaceId: string;
+  tableName: string;
+  sessionsTableName: string;
+  skillsTableName: string;
+  rulesTableName: string;
+  goalsTableName: string;
+  kpisTableName: string;
+  docsTableName: string;
+  codebaseTableName: string;
+  memoryPath: string;
+  vectorScanLimit: number;
+}
+
+export interface DeeplakeStorageConfig extends CommonStorageConfig {
+  kind: "deeplake";
+  apiUrl: string;
+  token: string;
+  orgId: string;
+  orgName: string;
+}
+
+export interface SqliteStorageConfig extends CommonStorageConfig {
+  kind: "sqlite";
+  path: string;
+  orgId: "local";
+  orgName: "local";
+}
+
+export interface PostgresStorageConfig extends CommonStorageConfig {
+  kind: "postgres";
+  connectionUrl: string;
+  schema: string;
+  orgId: "local";
+  orgName: "local";
+}
+
+export type StorageConfig = DeeplakeStorageConfig | SqliteStorageConfig | PostgresStorageConfig;
+
+/**
+ * Runtime configuration. Legacy Deeplake-shaped fields remain present so
+ * older integrations and third-party harnesses continue to compile. New code
+ * should use `storage`, whose discriminant is the provider kind.
+ */
 export interface Config {
+  storage?: StorageConfig;
   token: string;
   orgId: string;
   orgName: string;
@@ -18,6 +68,7 @@ export interface Config {
   docsTableName: string;
   codebaseTableName: string;
   memoryPath: string;
+  vectorScanLimit?: number;
 }
 
 interface Credentials {
@@ -29,56 +80,129 @@ interface Credentials {
   apiUrl?: string;
 }
 
-export function loadConfig(): Config | null {
+const PROVIDERS = new Set<StorageProvider>(["deeplake", "sqlite", "postgres"]);
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function providerFrom(raw: unknown): StorageProvider {
+  const value = typeof raw === "string" ? raw.toLowerCase() : "";
+  if (!PROVIDERS.has(value as StorageProvider)) {
+    if (value) throw new Error(`Invalid HIVEMIND_BACKEND: ${String(raw)}`);
+    return "deeplake";
+  }
+  return value as StorageProvider;
+}
+
+function positiveInteger(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function commonStorage(home: string, creds: Credentials | null): Omit<CommonStorageConfig, "kind"> {
+  return {
+    userName: creds?.userName || userInfo().username || "unknown",
+    workspaceId: process.env.HIVEMIND_WORKSPACE_ID ?? creds?.workspaceId ?? "default",
+    tableName: process.env.HIVEMIND_TABLE ?? "memory",
+    sessionsTableName: process.env.HIVEMIND_SESSIONS_TABLE ?? "sessions",
+    skillsTableName: process.env.HIVEMIND_SKILLS_TABLE ?? "skills",
+    rulesTableName: process.env.HIVEMIND_RULES_TABLE ?? "hivemind_rules",
+    goalsTableName: process.env.HIVEMIND_GOALS_TABLE ?? "hivemind_goals",
+    kpisTableName: process.env.HIVEMIND_KPIS_TABLE ?? "hivemind_kpis",
+    docsTableName: process.env.HIVEMIND_DOCS_TABLE ?? "hivemind_docs",
+    codebaseTableName: process.env.HIVEMIND_CODEBASE_TABLE ?? "codebase",
+    memoryPath: process.env.HIVEMIND_MEMORY_PATH ?? join(home, ".deeplake", "memory"),
+    vectorScanLimit: positiveInteger(process.env.HIVEMIND_VECTOR_SCAN_LIMIT, 2000),
+  };
+}
+
+export function loadStorageConfig(): StorageConfig | null {
   const home = homedir();
   const credPath = join(home, ".deeplake", "credentials.json");
-
   let creds: Credentials | null = null;
   if (existsSync(credPath)) {
     try {
       creds = JSON.parse(readFileSync(credPath, "utf-8"));
     } catch {
-      return null;
+      creds = null;
     }
   }
 
-  // Using `process.env.X` directly (not aliasing) so esbuild's `define` in the
-  // openclaw build can stub these to `undefined` at bundle-time.
+  const persisted = readUserConfig().storage;
+  const provider = providerFrom(process.env.HIVEMIND_BACKEND ?? persisted?.provider);
+  const common = commonStorage(home, creds);
+
+  if (provider === "sqlite") {
+    const path = process.env.HIVEMIND_SQLITE_PATH ?? persisted?.sqlitePath ?? join(home, ".deeplake", "hivemind.sqlite3");
+    return { ...common, kind: "sqlite", path: resolve(path), orgId: "local", orgName: "local" };
+  }
+
+  if (provider === "postgres") {
+    const connectionUrl = process.env.HIVEMIND_POSTGRES_URL;
+    if (!connectionUrl) return null;
+    const schema = process.env.HIVEMIND_POSTGRES_SCHEMA ?? persisted?.postgresSchema ?? "hivemind";
+    if (!IDENTIFIER.test(schema)) throw new Error(`Invalid PostgreSQL schema: ${schema}`);
+    return { ...common, kind: "postgres", connectionUrl, schema, orgId: "local", orgName: "local" };
+  }
+
   const token = process.env.HIVEMIND_TOKEN ?? creds?.token;
   const orgId = process.env.HIVEMIND_ORG_ID ?? creds?.orgId;
   if (!token || !orgId) return null;
-
   return {
+    ...common,
+    kind: "deeplake",
     token,
     orgId,
     orgName: creds?.orgName ?? orgId,
-    userName: creds?.userName || userInfo().username || "unknown",
-    workspaceId: process.env.HIVEMIND_WORKSPACE_ID ?? creds?.workspaceId ?? "default",
     apiUrl: process.env.HIVEMIND_API_URL ?? creds?.apiUrl ?? "https://api.deeplake.ai",
-    tableName: process.env.HIVEMIND_TABLE ?? "memory",
-    sessionsTableName: process.env.HIVEMIND_SESSIONS_TABLE ?? "sessions",
-    skillsTableName: process.env.HIVEMIND_SKILLS_TABLE ?? "skills",
-    // Defaults match the table name written into the SQL — keep aligned
-    // with RULES_COLUMNS in deeplake-schema.ts and with the e2e test-org
-    // override convention (memory_test / sessions_test → goals_test, etc.)
-    // documented in CLAUDE.md.
-    rulesTableName: process.env.HIVEMIND_RULES_TABLE ?? "hivemind_rules",
-    // Goals + KPIs (refined design — VFS path classifier maps
-    //   memory/goal/<user>/<status>/<uuid>.md → hivemind_goals row
-    //   memory/kpi/<uuid>/<kpi_id>.md → hivemind_kpis row
-    // See src/shell/deeplake-fs.ts for the translation logic and
-    // GOALS_COLUMNS / KPIS_COLUMNS in deeplake-schema.ts for the
-    // table shape.
-    goalsTableName: process.env.HIVEMIND_GOALS_TABLE ?? "hivemind_goals",
-    kpisTableName: process.env.HIVEMIND_KPIS_TABLE ?? "hivemind_kpis",
-    // Per-file documentation kept fresh on code deltas. INSERT-only
-    // version-bumped table (see DOCS_COLUMNS in deeplake-schema.ts).
-    // Phase 1: written/read through the `hivemind docs` CLI + worker via the
-    // src/docs store. NOT yet routed through the VFS path classifier — when
-    // VFS routing lands it MUST use the INSERT-only store, never the goals
-    // UPDATE-or-INSERT path (which is vulnerable to UPDATE-coalescing).
-    docsTableName: process.env.HIVEMIND_DOCS_TABLE ?? "hivemind_docs",
-    codebaseTableName: process.env.HIVEMIND_CODEBASE_TABLE ?? "codebase",
-    memoryPath: process.env.HIVEMIND_MEMORY_PATH ?? join(home, ".deeplake", "memory"),
   };
+}
+
+export function configFromStorage(storage: StorageConfig): Config {
+  return {
+    storage,
+    token: storage.kind === "deeplake" ? storage.token : "",
+    apiUrl: storage.kind === "deeplake" ? storage.apiUrl : "",
+    orgId: storage.orgId,
+    orgName: storage.orgName,
+    userName: storage.userName,
+    workspaceId: storage.workspaceId,
+    tableName: storage.tableName,
+    sessionsTableName: storage.sessionsTableName,
+    skillsTableName: storage.skillsTableName,
+    rulesTableName: storage.rulesTableName,
+    goalsTableName: storage.goalsTableName,
+    kpisTableName: storage.kpisTableName,
+    docsTableName: storage.docsTableName,
+    codebaseTableName: storage.codebaseTableName,
+    memoryPath: storage.memoryPath,
+    vectorScanLimit: storage.vectorScanLimit,
+  };
+}
+
+export function storageFromConfig(config: Config): StorageConfig {
+  if (config.storage) return config.storage;
+  return {
+    kind: "deeplake",
+    token: config.token,
+    apiUrl: config.apiUrl,
+    orgId: config.orgId,
+    orgName: config.orgName,
+    userName: config.userName,
+    workspaceId: config.workspaceId,
+    tableName: config.tableName,
+    sessionsTableName: config.sessionsTableName,
+    skillsTableName: config.skillsTableName,
+    rulesTableName: config.rulesTableName,
+    goalsTableName: config.goalsTableName,
+    kpisTableName: config.kpisTableName,
+    docsTableName: config.docsTableName,
+    codebaseTableName: config.codebaseTableName,
+    memoryPath: config.memoryPath,
+    vectorScanLimit: config.vectorScanLimit ?? 2000,
+  };
+}
+
+export function loadConfig(): Config | null {
+  const storage = loadStorageConfig();
+  return storage ? configFromStorage(storage) : null;
 }

--- a/src/deeplake-api.ts
+++ b/src/deeplake-api.ts
@@ -17,6 +17,12 @@ import {
 } from "./deeplake-schema.js";
 import { enqueueNotification } from "./notifications/queue.js";
 import { loadCredentials } from "./commands/auth-creds.js";
+import type {
+  BackendTableNames,
+  ExecuteResult,
+  SqlValue,
+  StorageBackend,
+} from "./storage/backend.js";
 
 // index-marker-store touches node:fs. Load it lazily so bundlers that split
 // chunks (e.g. the openclaw plugin build) can put fs operations in a separate
@@ -38,14 +44,14 @@ function summarizeSql(sql: string, maxLen = 220): string {
 /**
  * SQL tracing is opt-in and evaluated on every call so callers can flip the
  * env vars after module load (e.g. the one-shot shell bundle silences
- * `[deeplake-sql]` stderr writes so they don't land in Claude Code's
+ * `[hivemind-sql]` stderr writes so they don't land in Claude Code's
  * Bash-tool result — Claude Code merges child stderr into tool_result).
  */
 function traceSql(msg: string): void {
   const traceEnabled = process.env.HIVEMIND_TRACE_SQL === "1"
     || process.env.HIVEMIND_DEBUG === "1";
   if (!traceEnabled) return;
-  process.stderr.write(`[deeplake-sql] ${msg}\n`);
+  process.stderr.write(`[hivemind-sql] ${msg}\n`);
   if (process.env.HIVEMIND_DEBUG === "1") log(msg);
 }
 
@@ -211,10 +217,41 @@ export interface WriteRow {
   lastUpdateDate?: string;
 }
 
-export class DeeplakeApi {
+function deeplakeSqlLiteral(value: SqlValue): string {
+  if (value === null) return "NULL";
+  if (value instanceof Date) return `'${sqlStr(value.toISOString())}'`;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("Non-finite SQL number");
+    return String(value);
+  }
+  if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
+  if (Array.isArray(value)) return `ARRAY[${value.map(Number).join(",")}]::float4[]`;
+  if (typeof value === "object") return `'${sqlStr(JSON.stringify(value))}'::jsonb`;
+  return `E'${sqlStr(value)}'`;
+}
+
+function interpolateParameters(sql: string, params: readonly SqlValue[]): string {
+  return sql.replace(/\$(\d+)/g, (_all, index: string) => {
+    const position = Number(index) - 1;
+    if (position < 0 || position >= params.length) throw new Error(`Missing SQL parameter $${index}`);
+    return deeplakeSqlLiteral(params[position]);
+  });
+}
+
+export class DeeplakeApi implements StorageBackend {
+  readonly kind = "deeplake" as const;
+  readonly dialect = "deeplake" as const;
+  readonly capabilities = {
+    serverVectorSearch: true,
+    transactions: false,
+    json: "native",
+    vectors: "server",
+  } as const;
   private _pendingRows: WriteRow[] = [];
   private _sem = new Semaphore(MAX_CONCURRENCY);
   private _tablesCache: string[] | null = null;
+  private _retryLogger?: (message: string) => void;
+  private _skipRetryDelay = false;
 
   constructor(
     private token: string,
@@ -222,16 +259,35 @@ export class DeeplakeApi {
     private orgId: string,
     private workspaceId: string,
     readonly tableName: string,
+    private tableNames?: BackendTableNames,
   ) {}
 
+  /** Detached workers keep their own retry log and already have a hard wall clock. */
+  configureWorkerRetries(logger: (message: string) => void): void {
+    this._retryLogger = logger;
+    this._skipRetryDelay = true;
+  }
+
+  private async retryWait(message: string, delay: number, signal?: AbortSignal): Promise<void> {
+    this._retryLogger?.(`${message}, retrying in ${this._skipRetryDelay ? 0 : delay.toFixed(0)}ms`);
+    if (!this._skipRetryDelay) await sleep(delay, signal);
+  }
+
   /** Execute SQL with retry on transient errors and bounded concurrency. */
-  async query(sql: string, signal?: AbortSignal): Promise<Record<string, unknown>[]> {
+  async query(
+    sql: string,
+    paramsOrSignal: readonly SqlValue[] | AbortSignal = [],
+    signal?: AbortSignal,
+  ): Promise<Record<string, unknown>[]> {
+    const params = paramsOrSignal instanceof AbortSignal ? [] : paramsOrSignal;
+    const activeSignal = paramsOrSignal instanceof AbortSignal ? paramsOrSignal : signal;
+    const renderedSql = params.length > 0 ? interpolateParameters(sql, params) : sql;
     const startedAt = Date.now();
-    const summary = summarizeSql(sql);
+    const summary = summarizeSql(renderedSql);
     traceSql(`query start: ${summary}`);
     await this._sem.acquire();
     try {
-      const rows = await this._queryWithRetry(sql, signal);
+      const rows = await this._queryWithRetry(renderedSql, activeSignal);
       traceSql(`query ok (${Date.now() - startedAt}ms, rows=${rows.length}): ${summary}`);
       return rows;
     } catch (e: unknown) {
@@ -241,6 +297,46 @@ export class DeeplakeApi {
     } finally {
       this._sem.release();
     }
+  }
+
+  async execute(sql: string, params: readonly SqlValue[] = []): Promise<ExecuteResult> {
+    const rows = await this.query(sql, params);
+    return { rowCount: rows.length };
+  }
+
+  async transaction<T>(fn: (tx: StorageBackend) => Promise<T>): Promise<T> {
+    // Deeplake's SQL endpoint does not expose multi-statement transactions.
+    // Keep the neutral callback shape and advertise the limitation through
+    // capabilities so callers that require atomicity can branch explicitly.
+    return fn(this);
+  }
+
+  async getColumns(table: string): Promise<string[]> {
+    const safe = sqlIdent(table);
+    const rows = await this.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = $1 AND table_schema = $2`,
+      [safe, this.workspaceId],
+    );
+    return rows.map(row => String(row.column_name));
+  }
+
+  async initializeSchema(): Promise<void> {
+    if (!this.tableNames) {
+      await this.ensureTable(this.tableName);
+      return;
+    }
+    await this.ensureTable(this.tableNames.memory);
+    await this.ensureSessionsTable(this.tableNames.sessions);
+    await this.ensureSkillsTable(this.tableNames.skills);
+    await this.ensureRulesTable(this.tableNames.rules);
+    await this.ensureGoalsTable(this.tableNames.goals);
+    await this.ensureKpisTable(this.tableNames.kpis);
+    await this.ensureDocsTable(this.tableNames.docs);
+    await this.ensureCodebaseTable(this.tableNames.codebase);
+  }
+
+  async close(): Promise<void> {
+    // HTTP requests are connectionless from this adapter's perspective.
   }
 
   private async _queryWithRetry(sql: string, externalSignal?: AbortSignal): Promise<Record<string, unknown>[]> {
@@ -279,7 +375,7 @@ export class DeeplakeApi {
         if (attempt < MAX_RETRIES) {
           const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
           log(`query retry ${attempt + 1}/${MAX_RETRIES} (fetch error: ${lastError.message}) in ${delay.toFixed(0)}ms`);
-          await sleep(delay, externalSignal);
+          await this.retryWait(`fetch failed (${lastError.message})`, delay, externalSignal);
           continue;
         }
         throw lastError;
@@ -295,15 +391,16 @@ export class DeeplakeApi {
       const retryable403 =
         isSessionInsertQuery(sql) &&
         (resp.status === 401 || (resp.status === 403 && (text.length === 0 || isTransientHtml403(text))));
+      const retryableWorkerAuth = this._skipRetryDelay && (resp.status === 401 || resp.status === 403);
       // Deeplake returns HTTP 500 (not 409) when ADD COLUMN IF NOT EXISTS / CREATE
       // INDEX IF NOT EXISTS hit an already-present object. The error is
       // deterministic — retrying just burns ~4s of exponential backoff per call,
       // and SessionStart issues several of these on every run. Fail fast.
       const alreadyExists = resp.status === 500 && isDuplicateIndexError(text);
-      if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403)) {
+      if (!alreadyExists && attempt < MAX_RETRIES && (RETRYABLE_CODES.has(resp.status) || retryable403 || retryableWorkerAuth)) {
         const delay = BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200;
         log(`query retry ${attempt + 1}/${MAX_RETRIES} (${resp.status}) in ${delay.toFixed(0)}ms`);
-        await sleep(delay, externalSignal);
+        await this.retryWait(`API ${resp.status}`, delay, externalSignal);
         continue;
       }
       // Surface a session-start banner for the "out of credits" case before
@@ -721,4 +818,3 @@ export class DeeplakeApi {
 export function _resetSdkStateForTesting(): void {
   _signalledBalanceExhausted = false;
 }
-

--- a/src/deeplake-schema.ts
+++ b/src/deeplake-schema.ts
@@ -27,70 +27,110 @@
 
 import { sqlIdent, sqlStr } from "./utils/sql.js";
 
+export type LogicalColumnType = "text" | "integer" | "timestamp" | "json" | "vector";
+export type StorageDialect = "deeplake" | "sqlite" | "postgres";
+
 export interface ColumnDef {
   /** Bare column identifier, e.g. `contributors`. */
   name: string;
-  /** Column SQL minus the name, e.g. `TEXT NOT NULL DEFAULT '[]'`. */
-  sql: string;
+  /** Provider-neutral storage type. */
+  type: LogicalColumnType;
+  /** Defaults to true. */
+  nullable?: boolean;
+  /** Logical default value. Omitted columns have no DEFAULT clause. */
+  default?: string | number;
+  /**
+   * Compatibility rendering for existing callers and tests. New code should
+   * use renderColumnSql() with an explicit dialect.
+   */
+  readonly sql: string;
+}
+
+function column(
+  name: string,
+  type: LogicalColumnType,
+  options: { nullable?: boolean; default?: string | number } = {},
+): ColumnDef {
+  const logical = { name, type, ...options };
+  return Object.freeze({ ...logical, sql: renderColumnSql(logical, "deeplake") });
+}
+
+function defaultSql(value: string | number): string {
+  return typeof value === "number" ? String(value) : `'${sqlStr(value)}'`;
+}
+
+export function renderColumnSql(
+  col: Pick<ColumnDef, "type" | "nullable" | "default">,
+  dialect: StorageDialect,
+): string {
+  const typeSql: Record<StorageDialect, Record<LogicalColumnType, string>> = {
+    deeplake: { text: "TEXT", integer: "BIGINT", timestamp: "TIMESTAMP", json: "JSONB", vector: "FLOAT4[]" },
+    postgres: { text: "TEXT", integer: "BIGINT", timestamp: "TIMESTAMP", json: "JSONB", vector: "DOUBLE PRECISION[]" },
+    sqlite: { text: "TEXT", integer: "INTEGER", timestamp: "TEXT", json: "TEXT", vector: "TEXT" },
+  };
+  let sql = typeSql[dialect][col.type];
+  if (col.nullable === false) sql += " NOT NULL";
+  if (col.default !== undefined) sql += ` DEFAULT ${defaultSql(col.default)}`;
+  return sql;
 }
 
 // ── Schema definitions ──────────────────────────────────────────────────────
 
 /** Memory table — wiki summaries written by the SessionStart workers. */
 export const MEMORY_COLUMNS: readonly ColumnDef[] = Object.freeze([
-  { name: "id",                sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "path",              sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "filename",          sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "summary",           sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "summary_embedding", sql: "FLOAT4[]" },
-  { name: "author",            sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "mime_type",         sql: "TEXT NOT NULL DEFAULT 'text/plain'" },
-  { name: "size_bytes",        sql: "BIGINT NOT NULL DEFAULT 0" },
-  { name: "project",           sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "description",       sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "agent",             sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "plugin_version",    sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "creation_date",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "last_update_date",  sql: "TEXT NOT NULL DEFAULT ''" },
+  column("id", "text", { nullable: false, default: "" }),
+  column("path", "text", { nullable: false, default: "" }),
+  column("filename", "text", { nullable: false, default: "" }),
+  column("summary", "text", { nullable: false, default: "" }),
+  column("summary_embedding", "vector"),
+  column("author", "text", { nullable: false, default: "" }),
+  column("mime_type", "text", { nullable: false, default: "text/plain" }),
+  column("size_bytes", "integer", { nullable: false, default: 0 }),
+  column("project", "text", { nullable: false, default: "" }),
+  column("description", "text", { nullable: false, default: "" }),
+  column("agent", "text", { nullable: false, default: "" }),
+  column("plugin_version", "text", { nullable: false, default: "" }),
+  column("creation_date", "text", { nullable: false, default: "" }),
+  column("last_update_date", "text", { nullable: false, default: "" }),
 ]);
 
 /** Sessions table — raw per-turn agent events. */
 export const SESSIONS_COLUMNS: readonly ColumnDef[] = Object.freeze([
-  { name: "id",                sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "path",              sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "filename",          sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "message",           sql: "JSONB" },
-  { name: "message_embedding", sql: "FLOAT4[]" },
-  { name: "author",            sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "mime_type",         sql: "TEXT NOT NULL DEFAULT 'application/json'" },
-  { name: "size_bytes",        sql: "BIGINT NOT NULL DEFAULT 0" },
-  { name: "project",           sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "description",       sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "agent",             sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "plugin_version",    sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "creation_date",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "last_update_date",  sql: "TEXT NOT NULL DEFAULT ''" },
+  column("id", "text", { nullable: false, default: "" }),
+  column("path", "text", { nullable: false, default: "" }),
+  column("filename", "text", { nullable: false, default: "" }),
+  column("message", "json"),
+  column("message_embedding", "vector"),
+  column("author", "text", { nullable: false, default: "" }),
+  column("mime_type", "text", { nullable: false, default: "application/json" }),
+  column("size_bytes", "integer", { nullable: false, default: 0 }),
+  column("project", "text", { nullable: false, default: "" }),
+  column("description", "text", { nullable: false, default: "" }),
+  column("agent", "text", { nullable: false, default: "" }),
+  column("plugin_version", "text", { nullable: false, default: "" }),
+  column("creation_date", "text", { nullable: false, default: "" }),
+  column("last_update_date", "text", { nullable: false, default: "" }),
 ]);
 
 /** Skills table — one row per skill version. */
 export const SKILLS_COLUMNS: readonly ColumnDef[] = Object.freeze([
-  { name: "id",              sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "name",            sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "project",         sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "project_key",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "local_path",      sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "install",         sql: "TEXT NOT NULL DEFAULT 'project'" },
-  { name: "source_sessions", sql: "TEXT NOT NULL DEFAULT '[]'" },
-  { name: "source_agent",    sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "scope",           sql: "TEXT NOT NULL DEFAULT 'me'" },
-  { name: "author",          sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "contributors",    sql: "TEXT NOT NULL DEFAULT '[]'" },
-  { name: "description",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "trigger_text",    sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "body",            sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "version",         sql: "BIGINT NOT NULL DEFAULT 1" },
-  { name: "created_at",      sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "updated_at",      sql: "TEXT NOT NULL DEFAULT ''" },
+  column("id", "text", { nullable: false, default: "" }),
+  column("name", "text", { nullable: false, default: "" }),
+  column("project", "text", { nullable: false, default: "" }),
+  column("project_key", "text", { nullable: false, default: "" }),
+  column("local_path", "text", { nullable: false, default: "" }),
+  column("install", "text", { nullable: false, default: "project" }),
+  column("source_sessions", "text", { nullable: false, default: "[]" }),
+  column("source_agent", "text", { nullable: false, default: "" }),
+  column("scope", "text", { nullable: false, default: "me" }),
+  column("author", "text", { nullable: false, default: "" }),
+  column("contributors", "text", { nullable: false, default: "[]" }),
+  column("description", "text", { nullable: false, default: "" }),
+  column("trigger_text", "text", { nullable: false, default: "" }),
+  column("body", "text", { nullable: false, default: "" }),
+  column("version", "integer", { nullable: false, default: 1 }),
+  column("created_at", "text", { nullable: false, default: "" }),
+  column("updated_at", "text", { nullable: false, default: "" }),
 ]);
 
 /**
@@ -102,16 +142,16 @@ export const SKILLS_COLUMNS: readonly ColumnDef[] = Object.freeze([
  * quirk that bit the wiki worker.
  */
 export const RULES_COLUMNS: readonly ColumnDef[] = Object.freeze([
-  { name: "id",             sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "rule_id",        sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "text",           sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "scope",          sql: "TEXT NOT NULL DEFAULT 'team'" },
-  { name: "status",         sql: "TEXT NOT NULL DEFAULT 'active'" },
-  { name: "assigned_by",    sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "version",        sql: "BIGINT NOT NULL DEFAULT 1" },
-  { name: "created_at",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "agent",          sql: "TEXT NOT NULL DEFAULT 'manual'" },
-  { name: "plugin_version", sql: "TEXT NOT NULL DEFAULT ''" },
+  column("id", "text", { nullable: false, default: "" }),
+  column("rule_id", "text", { nullable: false, default: "" }),
+  column("text", "text", { nullable: false, default: "" }),
+  column("scope", "text", { nullable: false, default: "team" }),
+  column("status", "text", { nullable: false, default: "active" }),
+  column("assigned_by", "text", { nullable: false, default: "" }),
+  column("version", "integer", { nullable: false, default: 1 }),
+  column("created_at", "text", { nullable: false, default: "" }),
+  column("agent", "text", { nullable: false, default: "manual" }),
+  column("plugin_version", "text", { nullable: false, default: "" }),
 ]);
 
 /**
@@ -134,16 +174,16 @@ export const RULES_COLUMNS: readonly ColumnDef[] = Object.freeze([
  * Deeplake; logical join only).
  */
 export const GOALS_COLUMNS: readonly ColumnDef[] = Object.freeze([
-  { name: "id",             sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "goal_id",        sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "owner",          sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "status",         sql: "TEXT NOT NULL DEFAULT 'opened'" },
-  { name: "content",        sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "version",        sql: "BIGINT NOT NULL DEFAULT 1" },
-  { name: "created_at",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "updated_at",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "agent",          sql: "TEXT NOT NULL DEFAULT 'manual'" },
-  { name: "plugin_version", sql: "TEXT NOT NULL DEFAULT ''" },
+  column("id", "text", { nullable: false, default: "" }),
+  column("goal_id", "text", { nullable: false, default: "" }),
+  column("owner", "text", { nullable: false, default: "" }),
+  column("status", "text", { nullable: false, default: "opened" }),
+  column("content", "text", { nullable: false, default: "" }),
+  column("version", "integer", { nullable: false, default: 1 }),
+  column("created_at", "text", { nullable: false, default: "" }),
+  column("updated_at", "text", { nullable: false, default: "" }),
+  column("agent", "text", { nullable: false, default: "manual" }),
+  column("plugin_version", "text", { nullable: false, default: "" }),
 ]);
 
 /**
@@ -163,15 +203,15 @@ export const GOALS_COLUMNS: readonly ColumnDef[] = Object.freeze([
  * KPI conceptually means writing a tombstone version, deferred to v1.1.
  */
 export const KPIS_COLUMNS: readonly ColumnDef[] = Object.freeze([
-  { name: "id",             sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "goal_id",        sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "kpi_id",         sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "content",        sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "version",        sql: "BIGINT NOT NULL DEFAULT 1" },
-  { name: "created_at",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "updated_at",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "agent",          sql: "TEXT NOT NULL DEFAULT 'manual'" },
-  { name: "plugin_version", sql: "TEXT NOT NULL DEFAULT ''" },
+  column("id", "text", { nullable: false, default: "" }),
+  column("goal_id", "text", { nullable: false, default: "" }),
+  column("kpi_id", "text", { nullable: false, default: "" }),
+  column("content", "text", { nullable: false, default: "" }),
+  column("version", "integer", { nullable: false, default: 1 }),
+  column("created_at", "text", { nullable: false, default: "" }),
+  column("updated_at", "text", { nullable: false, default: "" }),
+  column("agent", "text", { nullable: false, default: "manual" }),
+  column("plugin_version", "text", { nullable: false, default: "" }),
 ]);
 
 /**
@@ -192,32 +232,32 @@ export const KPIS_COLUMNS: readonly ColumnDef[] = Object.freeze([
  * overwritten by a fast edit).
  */
 export const DOCS_COLUMNS: readonly ColumnDef[] = Object.freeze([
-  { name: "id",             sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "doc_id",         sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "path",           sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "content",        sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "anchors",        sql: "TEXT NOT NULL DEFAULT '[]'" },
-  { name: "tier",           sql: "TEXT NOT NULL DEFAULT 'fast'" },
-  { name: "status",         sql: "TEXT NOT NULL DEFAULT 'active'" },
-  { name: "project",        sql: "TEXT NOT NULL DEFAULT ''" },
+  column("id", "text", { nullable: false, default: "" }),
+  column("doc_id", "text", { nullable: false, default: "" }),
+  column("path", "text", { nullable: false, default: "" }),
+  column("content", "text", { nullable: false, default: "" }),
+  column("anchors", "text", { nullable: false, default: "[]" }),
+  column("tier", "text", { nullable: false, default: "fast" }),
+  column("status", "text", { nullable: false, default: "active" }),
+  column("project", "text", { nullable: false, default: "" }),
   // Which shared view a row belongs to: `main` = the canonical truth
   // (written only by the elected refresh turn); `u:<user>|b:<branch>` =
   // a personal branch overlay (v2, opt-in). Reads default to `main`.
-  { name: "scope",          sql: "TEXT NOT NULL DEFAULT 'main'" },
+  column("scope", "text", { nullable: false, default: "main" }),
   // Per-page source fingerprint: JSON `{file: git-blob-sha}` the page was
   // generated from. Drives freshness (stale iff it differs from HEAD's), the
   // overlay-divergence decision, the origin publish gate, and merge promotion.
   // Read only where needed (scoped reads) so generic reads stay heal-safe.
-  { name: "source_fp",      sql: "TEXT NOT NULL DEFAULT '{}'" },
-  { name: "version",        sql: "BIGINT NOT NULL DEFAULT 1" },
-  { name: "created_at",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "updated_at",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "agent",          sql: "TEXT NOT NULL DEFAULT 'manual'" },
-  { name: "plugin_version", sql: "TEXT NOT NULL DEFAULT ''" },
+  column("source_fp", "text", { nullable: false, default: "{}" }),
+  column("version", "integer", { nullable: false, default: 1 }),
+  column("created_at", "text", { nullable: false, default: "" }),
+  column("updated_at", "text", { nullable: false, default: "" }),
+  column("agent", "text", { nullable: false, default: "manual" }),
+  column("plugin_version", "text", { nullable: false, default: "" }),
   // Semantic-search vector over `content` (nomic, DOC_PREFIX). Nullable/empty
   // when embeddings are off or not yet backfilled — `docs/find/` guards with
   // ARRAY_LENGTH(...) > 0, exactly like grep-core does for summaries.
-  { name: "content_embedding", sql: "FLOAT4[]" },
+  column("content_embedding", "vector"),
 ]);
 
 // ── Module-load lint ────────────────────────────────────────────────────────
@@ -240,9 +280,7 @@ function validateSchema(label: string, cols: readonly ColumnDef[]): void {
       throw new Error(`${label}: duplicate column "${col.name}"`);
     }
     seen.add(col.name);
-    const notNull = /\bNOT\s+NULL\b/i.test(col.sql);
-    const hasDefault = /\bDEFAULT\b/i.test(col.sql);
-    if (notNull && !hasDefault) {
+    if (col.nullable === false && col.default === undefined) {
       throw new Error(
         `${label}: column "${col.name}" is NOT NULL but has no DEFAULT — ` +
         `ALTER TABLE ADD COLUMN on a populated table would fail.`,
@@ -264,29 +302,29 @@ function validateSchema(label: string, cols: readonly ColumnDef[]): void {
  */
 export const CODEBASE_COLUMNS: readonly ColumnDef[] = Object.freeze([
   // Identity key (matches the PK below)
-  { name: "org_id",          sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "workspace_id",    sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "repo_slug",       sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "user_id",         sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "worktree_id",     sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "commit_sha",      sql: "TEXT NOT NULL DEFAULT ''" },
+  column("org_id", "text", { nullable: false, default: "" }),
+  column("workspace_id", "text", { nullable: false, default: "" }),
+  column("repo_slug", "text", { nullable: false, default: "" }),
+  column("user_id", "text", { nullable: false, default: "" }),
+  column("worktree_id", "text", { nullable: false, default: "" }),
+  column("commit_sha", "text", { nullable: false, default: "" }),
 
   // Observation metadata
-  { name: "parent_sha",      sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "branch",          sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "ts",              sql: "TIMESTAMP" },
-  { name: "pushed_by",       sql: "TEXT NOT NULL DEFAULT ''" },
+  column("parent_sha", "text", { nullable: false, default: "" }),
+  column("branch", "text", { nullable: false, default: "" }),
+  column("ts", "timestamp"),
+  column("pushed_by", "text", { nullable: false, default: "" }),
 
   // Snapshot payload
-  { name: "snapshot_sha256", sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "snapshot_jsonb",  sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "node_count",      sql: "BIGINT NOT NULL DEFAULT 0" },
-  { name: "edge_count",      sql: "BIGINT NOT NULL DEFAULT 0" },
+  column("snapshot_sha256", "text", { nullable: false, default: "" }),
+  column("snapshot_jsonb", "text", { nullable: false, default: "" }),
+  column("node_count", "integer", { nullable: false, default: 0 }),
+  column("edge_count", "integer", { nullable: false, default: 0 }),
 
   // Generator metadata (for drift diagnostics — what hivemind version produced this?)
-  { name: "generator",         sql: "TEXT NOT NULL DEFAULT 'hivemind-graph'" },
-  { name: "generator_version", sql: "TEXT NOT NULL DEFAULT ''" },
-  { name: "schema_version",    sql: "BIGINT NOT NULL DEFAULT 1" },
+  column("generator", "text", { nullable: false, default: "hivemind-graph" }),
+  column("generator_version", "text", { nullable: false, default: "" }),
+  column("schema_version", "integer", { nullable: false, default: 1 }),
 ]);
 
 validateSchema("MEMORY_COLUMNS", MEMORY_COLUMNS);
@@ -300,11 +338,16 @@ validateSchema("CODEBASE_COLUMNS", CODEBASE_COLUMNS);
 
 // ── SQL builders ────────────────────────────────────────────────────────────
 
-/** Render a `CREATE TABLE IF NOT EXISTS … USING deeplake` from a column list. */
-export function buildCreateTableSql(tableName: string, cols: readonly ColumnDef[]): string {
+/** Render a CREATE TABLE statement from a provider-neutral column list. */
+export function buildCreateTableSql(
+  tableName: string,
+  cols: readonly ColumnDef[],
+  dialect: StorageDialect = "deeplake",
+): string {
   const safe = sqlIdent(tableName);
-  const colSql = cols.map(c => `${c.name} ${c.sql}`).join(", ");
-  return `CREATE TABLE IF NOT EXISTS "${safe}" (${colSql}) USING deeplake`;
+  const colSql = cols.map(c => `${c.name} ${renderColumnSql(c, dialect)}`).join(", ");
+  const suffix = dialect === "deeplake" ? " USING deeplake" : "";
+  return `CREATE TABLE IF NOT EXISTS "${safe}" (${colSql})${suffix}`;
 }
 
 /** Render a `SELECT column_name` against `information_schema.columns`. */
@@ -360,6 +403,7 @@ export async function healMissingColumns(args: {
   tableName: string;
   workspaceId: string;
   columns: readonly ColumnDef[];
+  dialect?: StorageDialect;
   /** Optional logger for `[schema-heal] …` lines. */
   log?: (msg: string) => void;
 }): Promise<HealResult> {
@@ -382,7 +426,9 @@ export async function healMissingColumns(args: {
   const altered: string[] = [];
   for (const col of missingCols) {
     try {
-      await args.query(`ALTER TABLE "${safeTable}" ADD COLUMN ${col.name} ${col.sql}`);
+      await args.query(
+        `ALTER TABLE "${safeTable}" ADD COLUMN ${col.name} ${renderColumnSql(col, args.dialect ?? "deeplake")}`,
+      );
       altered.push(col.name);
       args.log?.(`schema-heal: added "${args.tableName}"."${col.name}"`);
     } catch (e: unknown) {

--- a/src/dir-config.ts
+++ b/src/dir-config.ts
@@ -135,6 +135,13 @@ export function resolveDirConfig(
   const found = findDirConfig(cwd);
   if (!found) return { config: base, collect: true, found: null };
 
+  // A SQLite file or PostgreSQL schema is already the workspace boundary.
+  // `.hivemind` org/workspace routing is a Deeplake control-plane feature;
+  // collect:false remains provider-neutral.
+  if (base.storage && base.storage.kind !== "deeplake") {
+    return { config: base, collect: found.raw.collect !== false, found };
+  }
+
   const orgLocked = !!(envOverride ? envOverride.HIVEMIND_ORG_ID : process.env.HIVEMIND_ORG_ID);
   const wsLocked = !!(envOverride ? envOverride.HIVEMIND_WORKSPACE_ID : process.env.HIVEMIND_WORKSPACE_ID);
   const config: Config = {
@@ -143,6 +150,14 @@ export function resolveDirConfig(
     orgName: orgLocked ? base.orgName : (found.raw.orgName ?? found.raw.orgId ?? base.orgName),
     workspaceId: wsLocked ? base.workspaceId : (found.raw.workspaceId ?? base.workspaceId),
   };
+  if (config.storage?.kind === "deeplake") {
+    config.storage = {
+      ...config.storage,
+      orgId: config.orgId,
+      orgName: config.orgName,
+      workspaceId: config.workspaceId,
+    };
+  }
   return { config, collect: found.raw.collect !== false, found };
 }
 

--- a/src/docs/backfill.ts
+++ b/src/docs/backfill.ts
@@ -8,7 +8,7 @@
 import { embeddingSqlLiteral } from "../embeddings/sql.js";
 import { sqlIdent, sqlStr } from "../utils/sql.js";
 import { runPool } from "./pool.js";
-import type { QueryFn } from "./read.js";
+import { queryDialect, type QueryFn } from "./read.js";
 import type { DocEmbedder } from "./embed.js";
 
 export interface BackfillReport {
@@ -35,7 +35,7 @@ export async function backfillDocEmbeddings(
     const vec = await embed(String(r["content"] ?? ""));
     if (!vec || vec.length === 0) return; // embedder off / failed → leave NULL
     await query(
-      `UPDATE "${safe}" SET content_embedding = ${embeddingSqlLiteral(vec)} ` +
+      `UPDATE "${safe}" SET content_embedding = ${embeddingSqlLiteral(vec, queryDialect(query))} ` +
       `WHERE id = '${sqlStr(String(r["id"]))}'`,
     );
     embedded++;

--- a/src/docs/meta.ts
+++ b/src/docs/meta.ts
@@ -21,7 +21,8 @@
 
 import { sqlIdent, sqlStr } from "../utils/sql.js";
 import { docRowId } from "./write.js";
-import type { QueryFn } from "./read.js";
+import { queryDialect, type QueryFn } from "./read.js";
+import { escapedStringPrefix } from "../storage/sql-dialect.js";
 
 /** Parsed `_meta` content. */
 export interface RefreshMeta {
@@ -98,12 +99,13 @@ async function writeMetaRow(
 ): Promise<void> {
   const safe = sqlIdent(tableName);
   const id = docRowId(project, scope, META_DOC_ID);
+  const stringPrefix = escapedStringPrefix(queryDialect(query));
   await query(`DELETE FROM "${safe}" WHERE id = '${sqlStr(id)}'`);
   await query(
     `INSERT INTO "${safe}" ` +
       `(id, doc_id, path, content, anchors, tier, status, project, scope, version, ` +
       `created_at, updated_at, agent, plugin_version) VALUES (` +
-      `'${sqlStr(id)}', '${META_DOC_ID}', '', E'${sqlStr(JSON.stringify(meta))}', '[]', ` +
+      `'${sqlStr(id)}', '${META_DOC_ID}', '', ${stringPrefix}'${sqlStr(JSON.stringify(meta))}', '[]', ` +
       `'slow', 'meta', '${sqlStr(project)}', '${sqlStr(scope)}', 1, ` +
       `'${sqlStr(now)}', '${sqlStr(now)}', 'refresh-meta', '')`,
   );

--- a/src/docs/read.ts
+++ b/src/docs/read.ts
@@ -16,8 +16,23 @@
 import { sqlIdent, sqlLike, sqlStr } from "../utils/sql.js";
 import { stableUnionRows } from "./stable-read.js";
 import { pickByScopePrecedence } from "./branch-scope.js";
+import type { StorageDialect } from "../deeplake-schema.js";
+import type { StorageBackend } from "../storage/backend.js";
 
-export type QueryFn = (sql: string) => Promise<Array<Record<string, unknown>>>;
+export type QueryFn = ((sql: string) => Promise<Array<Record<string, unknown>>>) & {
+  dialect?: StorageDialect;
+};
+
+/** Preserve provider metadata when adapting a StorageBackend to legacy query seams. */
+export function storageQuery(backend: StorageBackend): QueryFn {
+  const query: QueryFn = (sql: string) => backend.query(sql);
+  query.dialect = backend.dialect;
+  return query;
+}
+
+export function queryDialect(query: QueryFn): StorageDialect {
+  return query.dialect ?? "deeplake";
+}
 
 /** Doc tier — `fast` per-file docs vs `slow` protected project knowledge. */
 export type DocTier = "fast" | "slow";

--- a/src/docs/vfs-handler.ts
+++ b/src/docs/vfs-handler.ts
@@ -28,12 +28,15 @@ import { parseFilesIndex, WIKI_DOC_PREFIX } from "./wiki-generate.js";
 import { readPrivateDoc } from "./private-store.js";
 import { MAIN_SCOPE, type GitRunner } from "./branch-scope.js";
 import type { DocEmbedder } from "./embed.js";
+import type { StorageDialect } from "../deeplake-schema.js";
 
 export type DocsVfsResult =
   | { kind: "ok"; body: string }
   | { kind: "not-found"; message: string };
 
 export interface DocsVfsOptions {
+  /** SQL dialect used by the query seam. Defaults to Deeplake for compatibility. */
+  dialect?: StorageDialect;
   /** Query embedder (kind='query') for semantic `find/`. Absent → lexical only. */
   embedQuery?: DocEmbedder;
   /** Project scope for shared org tables (legacy '' rows always included). */
@@ -82,7 +85,7 @@ export async function handleDocsVfs(
       limit: 20,
       project: opts.project,
     };
-    const hits = await searchDocs(query, tableName, searchOpts);
+    const hits = await searchDocs(query, tableName, searchOpts, opts.dialect);
     if (hits.length === 0) return { kind: "ok", body: `No docs match "${q}".` };
     const lines = [`${hits.length} doc(s) match "${q}"${queryEmbedding ? " (semantic + keyword)" : " (keyword)"}:`, ""];
     for (const h of hits) lines.push(`## ${h.path}\n${firstDocLine(h.content)}`);

--- a/src/docs/write.ts
+++ b/src/docs/write.ts
@@ -23,7 +23,8 @@ import { randomUUID } from "node:crypto";
 import { sqlIdent, sqlStr } from "../utils/sql.js";
 import { embeddingSqlLiteral } from "../embeddings/sql.js";
 import type { DocAnchor, DocRow, DocTier, QueryFn } from "./read.js";
-import { getDocLatest } from "./read.js";
+import { getDocLatest, queryDialect } from "./read.js";
+import { escapedStringPrefix } from "../storage/sql-dialect.js";
 
 export interface InsertDocInput {
   /** Documented source file path, e.g. `src/shell/deeplake-fs.ts`. Stable key. */
@@ -147,6 +148,8 @@ export async function insertDoc(
   const now = new Date().toISOString();
   const anchors = serializeAnchors(input.anchors ?? []);
   const tier: DocTier = input.tier ?? "fast";
+  const dialect = queryDialect(query);
+  const stringPrefix = escapedStringPrefix(dialect);
 
   const sql =
     `INSERT INTO "${safe}" ` +
@@ -156,19 +159,19 @@ export async function insertDoc(
     `'${sqlStr(rowId)}', ` +
     `'${sqlStr(input.doc_id)}', ` +
     `'${sqlStr(input.path)}', ` +
-    `E'${sqlStr(input.content)}', ` +
-    `E'${sqlStr(anchors)}', ` +
+    `${stringPrefix}'${sqlStr(input.content)}', ` +
+    `${stringPrefix}'${sqlStr(anchors)}', ` +
     `'${sqlStr(tier)}', ` +
     `'active', ` +
     `'${sqlStr(input.project ?? "")}', ` +
     `'${sqlStr(input.scope ?? "main")}', ` +
-    `E'${sqlStr(input.source_fp ?? "{}")}', ` +
+    `${stringPrefix}'${sqlStr(input.source_fp ?? "{}")}', ` +
     `1, ` +
     `'${sqlStr(now)}', ` +
     `'${sqlStr(now)}', ` +
     `'${sqlStr(input.agent ?? "manual")}', ` +
     `'${sqlStr(input.plugin_version ?? "")}', ` +
-    `${embeddingSqlLiteral(input.content_embedding)}` +
+    `${embeddingSqlLiteral(input.content_embedding, dialect)}` +
     `)`;
   await query(sql);
   return { doc_id: input.doc_id, version: 1 };
@@ -259,6 +262,8 @@ export async function upsertDoc(
   const id = docRowId(input.project, scope, input.doc_id);
   const anchors = serializeAnchors(input.anchors ?? []);
   const tier: DocTier = input.tier ?? "fast";
+  const dialect = queryDialect(query);
+  const stringPrefix = escapedStringPrefix(dialect);
 
   const retries = opts.retries ?? WRITE_RETRIES;
   const backoff = opts.backoffMs ?? WRITE_BACKOFF_MS;
@@ -288,11 +293,11 @@ export async function upsertDoc(
         `created_at, updated_at, agent, plugin_version, content_embedding) ` +
         `VALUES (` +
         `'${sqlStr(id)}', '${sqlStr(input.doc_id)}', '${sqlStr(input.path)}', ` +
-        `E'${sqlStr(input.content)}', E'${sqlStr(anchors)}', '${sqlStr(tier)}', ` +
-        `'active', '${sqlStr(input.project ?? "")}', '${sqlStr(scope)}', E'${sqlStr(input.source_fp ?? "{}")}', 1, ` +
+        `${stringPrefix}'${sqlStr(input.content)}', ${stringPrefix}'${sqlStr(anchors)}', '${sqlStr(tier)}', ` +
+        `'active', '${sqlStr(input.project ?? "")}', '${sqlStr(scope)}', ${stringPrefix}'${sqlStr(input.source_fp ?? "{}")}', 1, ` +
         `'${sqlStr(now)}', '${sqlStr(now)}', ` +
         `'${sqlStr(input.agent ?? "manual")}', '${sqlStr(input.plugin_version ?? "")}', ` +
-        `${embeddingSqlLiteral(input.content_embedding)}` +
+        `${embeddingSqlLiteral(input.content_embedding, dialect)}` +
         `)`;
       await query(sql);
       return { doc_id: input.doc_id, version: 1 };
@@ -425,14 +430,16 @@ async function updateInPlace(
   const status = next.status ?? (previous.status as "active" | "archived");
   const path = next.path ?? previous.path;
   const project = next.project ?? previous.project;
+  const dialect = queryDialect(query);
+  const stringPrefix = escapedStringPrefix(dialect);
 
   // One UPDATE, all columns — the F0 safety rule. created_at + doc_id are not
   // touched (immutable identity/creation stamp).
   const sql =
     `UPDATE "${safe}" SET ` +
     `path = '${sqlStr(path)}', ` +
-    `content = E'${sqlStr(content)}', ` +
-    `anchors = E'${sqlStr(anchors)}', ` +
+    `content = ${stringPrefix}'${sqlStr(content)}', ` +
+    `anchors = ${stringPrefix}'${sqlStr(anchors)}', ` +
     `tier = '${sqlStr(tier)}', ` +
     `status = '${sqlStr(status)}', ` +
     `project = '${sqlStr(project)}', ` +
@@ -442,13 +449,13 @@ async function updateInPlace(
     // rank the doc by its previous meaning forever, and `docs reindex` only
     // heals MISSING vectors, never stale ones. Missing beats lying.
     `${next.content_embedding !== undefined
-      ? `content_embedding = ${embeddingSqlLiteral(next.content_embedding)}, `
+      ? `content_embedding = ${embeddingSqlLiteral(next.content_embedding, dialect)}, `
       : next.content !== undefined && next.content !== previous.content
         ? `content_embedding = NULL, `
         : ""}` +
     // Fingerprint moves with the content: a patch that lands new bytes stamps
     // the new source state so freshness reflects what the page now describes.
-    `${next.source_fp !== undefined ? `source_fp = E'${sqlStr(next.source_fp)}', ` : ""}` +
+    `${next.source_fp !== undefined ? `source_fp = ${stringPrefix}'${sqlStr(next.source_fp)}', ` : ""}` +
     `version = ${nextVersion}, ` +
     `updated_at = '${sqlStr(now)}', ` +
     `agent = '${sqlStr(next.agent ?? "manual")}', ` +

--- a/src/embeddings/sql.ts
+++ b/src/embeddings/sql.ts
@@ -1,8 +1,12 @@
-// Helpers for embedding values in SQL. Deeplake stores vectors as `FLOAT4[]`;
-// the literal form is `ARRAY[f1, f2, ...]::float4[]`. When the embedding is
-// missing (daemon unavailable, timeout, etc.) we emit `NULL`.
+import type { StorageDialect } from "../deeplake-schema.js";
 
-export function embeddingSqlLiteral(vec: number[] | null | undefined): string {
+// Helpers for embedding values in SQL. Deeplake stores vectors as `FLOAT4[]`,
+// PostgreSQL as DOUBLE PRECISION[], and SQLite as JSON text.
+
+export function embeddingSqlLiteral(
+  vec: number[] | null | undefined,
+  dialect: StorageDialect = "deeplake",
+): string {
   if (!vec || vec.length === 0) return "NULL";
   // FLOAT4 is IEEE-754 single-precision. `toFixed` would lose precision; use
   // the raw JS Number → string conversion which yields the shortest round-trip.
@@ -12,5 +16,7 @@ export function embeddingSqlLiteral(vec: number[] | null | undefined): string {
     if (!Number.isFinite(v)) return "NULL";
     parts.push(String(v));
   }
+  if (dialect === "sqlite") return `'[${parts.join(",")}]'`;
+  if (dialect === "postgres") return `ARRAY[${parts.join(",")}]::double precision[]`;
   return `ARRAY[${parts.join(",")}]::float4[]`;
 }

--- a/src/graph/deeplake-pull.ts
+++ b/src/graph/deeplake-pull.ts
@@ -43,15 +43,16 @@ import { dirname, join } from "node:path";
  * (.last-build.json + latest-commit.txt) are partitioned by this id so two
  * checkouts of the same project don't overwrite each other.
  */
+import { type Config } from "../config.js";
+import { loadRoutedConfig } from "../dir-config.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
+import { sqlIdent, sqlStr } from "../utils/sql.js";
+import { deriveProjectKey } from "../utils/repo-identity.js";
+
 function workTreeIdFor(cwd: string): string {
   return createHash("sha256").update(cwd).digest("hex").slice(0, 16);
 }
-
-import { type Config } from "../config.js";
-import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
-import { sqlIdent, sqlStr } from "../utils/sql.js";
-import { deriveProjectKey } from "../utils/repo-identity.js";
 import { writeLastBuild, readLastBuild } from "./last-build.js";
 import { appendHistoryEntry } from "./history.js";
 import { computeSnapshotSha256, repoDir } from "./snapshot.js";
@@ -70,8 +71,8 @@ export type PullOutcome =
 export interface PullDeps {
   /** Override for tests. Defaults to loadConfig(). Returns null when no auth. */
   loadConfig?: () => Config | null;
-  /** Override for tests. Defaults to a real DeeplakeApi. */
-  makeApi?: (config: Config) => DeeplakeApi;
+  /** Override for tests. Defaults to the configured storage backend. */
+  makeApi?: (config: Config) => StorageBackend;
   /** Override for tests. Defaults to `git rev-parse HEAD` in `cwd`. */
   readHead?: (cwd: string) => string | null;
 }
@@ -277,14 +278,8 @@ function defaultReadHead(cwd: string): string | null {
   }
 }
 
-function defaultMakeApi(config: Config): DeeplakeApi {
-  return new DeeplakeApi(
-    config.token,
-    config.apiUrl,
-    config.orgId,
-    config.workspaceId,
-    config.tableName,
-  );
+function defaultMakeApi(config: Config): StorageBackend {
+  return createStorageBackend(config, config.tableName);
 }
 
 /**

--- a/src/graph/deeplake-push.ts
+++ b/src/graph/deeplake-push.ts
@@ -40,7 +40,8 @@ import { createHash } from "node:crypto";
 
 import { loadConfig, type Config } from "../config.js";
 import { resolveDirConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { sqlIdent, sqlStr } from "../utils/sql.js";
 import type { GraphSnapshot } from "./types.js";
 
@@ -58,8 +59,8 @@ export type PushOutcome =
 export interface PushDeps {
   /** Override for tests; defaults to loadConfig(). Returns null when no auth. */
   loadConfig?: () => Config | null;
-  /** Override for tests; defaults to constructing a real DeeplakeApi. */
-  makeApi?: (config: Config) => DeeplakeApi;
+  /** Override for tests; defaults to constructing the configured backend. */
+  makeApi?: (config: Config) => StorageBackend;
   /** Working directory for `.hivemind` resolution; defaults to process.cwd(). */
   cwd?: string;
 }
@@ -196,14 +197,8 @@ export async function pushSnapshot(
   return { kind: "inserted", commitSha };
 }
 
-function defaultMakeApi(config: Config): DeeplakeApi {
-  return new DeeplakeApi(
-    config.token,
-    config.apiUrl,
-    config.orgId,
-    config.workspaceId,
-    config.tableName,
-  );
+function defaultMakeApi(config: Config): StorageBackend {
+  return createStorageBackend(config, config.tableName);
 }
 
 function errorOutcome(stage: string, err: unknown): PushOutcome {

--- a/src/graph/session-context.ts
+++ b/src/graph/session-context.ts
@@ -48,14 +48,14 @@ import { readLastBuild } from "./last-build.js";
 import { repoDir } from "./snapshot.js";
 import { deriveProjectKey } from "../utils/repo-identity.js";
 
-/**
- * Mirror of workTreeIdFor in src/commands/graph.ts. Each consumer of the
- * per-worktree singletons computes worktreeId from its own cwd.
- */
 function workTreeIdFor(cwd: string): string {
   return createHash("sha256").update(cwd).digest("hex").slice(0, 16);
 }
 
+/**
+ * Mirror of workTreeIdFor in src/commands/graph.ts. Each consumer of the
+ * per-worktree singletons computes worktreeId from its own cwd.
+ */
 export interface GraphContextDeps {
   /** Override for tests; defaults to Date.now(). */
   now?: () => number;
@@ -146,7 +146,7 @@ export function graphContextLine(cwd: string, deps: GraphContextDeps = {}): stri
     "  omits instance-method calls (obj.method()), nested/inner functions, and",
     "  dynamic dispatch — so confirm every claim against the file before stating it.",
     "",
-    "  Query via the Deeplake mount (intercepted — use `cat`, not `ls`):",
+    "  Query via the Hivemind memory mount (intercepted — use `cat`, not `ls`):",
     "    cat ~/.deeplake/memory/graph/query/<pattern>   ← start here",
     "        search + 1-hop expand (callers, callees, imports). AND: query/<a>+<b>.",
     "    cat ~/.deeplake/memory/graph/find/<pattern>     substring search → handles",

--- a/src/hooks/bash-command-compiler.ts
+++ b/src/hooks/bash-command-compiler.ts
@@ -1,4 +1,4 @@
-import type { DeeplakeApi } from "../deeplake-api.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { sqlLike } from "../utils/sql.js";
 import { type GrepParams, handleGrepDirect, parseBashGrep } from "./grep-direct.js";
 import { normalizeContent, refineGrepMatches } from "../shell/grep-core.js";
@@ -411,7 +411,7 @@ interface ExecuteCompiledBashDeps {
 }
 
 export async function executeCompiledBashCommand(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryTable: string,
   sessionsTable: string,
   cmd: string,

--- a/src/hooks/capture.ts
+++ b/src/hooks/capture.ts
@@ -11,7 +11,7 @@ import { readStdin } from "../utils/stdin.js";
 import { type Config } from "../config.js";
 import { resolveCaptureConfig } from "./shared/dir-gate.js";
 import { redactSecrets } from "./shared/redact.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { projectNameFromCwd } from "../utils/project-name.js";
 import { log as _log } from "../utils/debug.js";
 import { buildSessionPath } from "../utils/session-path.js";
@@ -98,7 +98,7 @@ async function main(): Promise<void> {
   }
 
   const sessionsTable = config.sessionsTableName;
-  const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, sessionsTable);
+  const api = createStorageBackend(config, sessionsTable);
 
   // Build the event entry
   const ts = new Date().toISOString();
@@ -190,7 +190,7 @@ async function main(): Promise<void> {
   const embedding = embeddingsDisabled()
     ? null
     : await new EmbedClient({ daemonEntry: resolveEmbedDaemonPath() }).embed(line, "document");
-  const embeddingSql = embeddingSqlLiteral(embedding);
+  const embeddingSql = embeddingSqlLiteral(embedding, api.dialect);
 
   const insertSql = buildDirectSessionInsertSql(sessionsTable, {
     // Reuse the event id already embedded in the message JSON so the row PK
@@ -207,7 +207,7 @@ async function main(): Promise<void> {
     agent: "claude_code",
     pluginVersion: PLUGIN_VERSION,
     timestamp: ts,
-  });
+  }, api.dialect);
 
   try {
     await api.query(insertSql);

--- a/src/hooks/codex/capture.ts
+++ b/src/hooks/codex/capture.ts
@@ -16,7 +16,7 @@ import { readStdin } from "../../utils/stdin.js";
 import { type Config } from "../../config.js";
 import { resolveCaptureConfig } from "../shared/dir-gate.js";
 import { redactSecrets } from "../shared/redact.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
 import { projectNameFromCwd } from "../../utils/project-name.js";
 import { log as _log } from "../../utils/debug.js";
 import { buildSessionPath } from "../../utils/session-path.js";
@@ -83,7 +83,7 @@ async function main(): Promise<void> {
   if (!config) return;
 
   const sessionsTable = config.sessionsTableName;
-  const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, sessionsTable);
+  const api = createStorageBackend(config, sessionsTable);
 
   const ts = new Date().toISOString();
   // Reasoning effort + token usage aren't in the hook payload — read them from
@@ -146,7 +146,7 @@ async function main(): Promise<void> {
   const embedding = embeddingsDisabled()
     ? null
     : await new EmbedClient({ daemonEntry: resolveEmbedDaemonPath() }).embed(line, "document");
-  const embeddingSql = embeddingSqlLiteral(embedding);
+  const embeddingSql = embeddingSqlLiteral(embedding, api.dialect);
 
   const insertSql = buildDirectSessionInsertSql(sessionsTable, {
     // Reuse the event id already embedded in the message JSON so the row PK
@@ -163,7 +163,7 @@ async function main(): Promise<void> {
     agent: "codex",
     pluginVersion: PLUGIN_VERSION,
     timestamp: ts,
-  });
+  }, api.dialect);
 
   try {
     await api.query(insertSql);

--- a/src/hooks/codex/pre-tool-use.ts
+++ b/src/hooks/codex/pre-tool-use.ts
@@ -28,7 +28,8 @@ import { spawnSync } from "node:child_process";
 import { readStdin } from "../../utils/stdin.js";
 import { loadConfig } from "../../config.js";
 import { resolveDirConfig } from "../../dir-config.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
+import type { StorageBackend } from "../../storage/backend.js";
 import { sqlLike } from "../../utils/sql.js";
 import { parseBashGrep, handleGrepDirect } from "../grep-direct.js";
 import { tryGraphRead } from "../../graph/graph-command.js";
@@ -102,7 +103,7 @@ function buildIndexContent(rows: Record<string, unknown>[]): string {
 
 interface CodexPreToolDeps {
   config?: ReturnType<typeof loadConfig>;
-  createApi?: (table: string, config: NonNullable<ReturnType<typeof loadConfig>>) => DeeplakeApi;
+  createApi?: (table: string, config: NonNullable<ReturnType<typeof loadConfig>>) => StorageBackend;
   executeCompiledBashCommandFn?: typeof executeCompiledBashCommand;
   readVirtualPathContentsFn?: typeof readVirtualPathContents;
   readVirtualPathContentFn?: typeof readVirtualPathContent;
@@ -122,13 +123,7 @@ export async function processCodexPreToolUse(
 ): Promise<CodexPreToolDecision> {
   const {
     config: baseConfig = loadConfig(),
-    createApi = (table, activeConfig) => new DeeplakeApi(
-      activeConfig.token,
-      activeConfig.apiUrl,
-      activeConfig.orgId,
-      activeConfig.workspaceId,
-      table,
-    ),
+    createApi = (table, activeConfig) => createStorageBackend(activeConfig, table),
     executeCompiledBashCommandFn = executeCompiledBashCommand,
     readVirtualPathContentsFn = readVirtualPathContents,
     readVirtualPathContentFn = readVirtualPathContent,
@@ -226,7 +221,7 @@ export async function processCodexPreToolUse(
       const lsDocs = rewritten.match(/^ls\s+(?:-[a-zA-Z]+\s+)*\/docs\/?\s*$/);
       if (lsDocs) {
         logFn("docs vfs intercept: ls /docs");
-        const r = await handleDocsVfs("", (sql) => api.query(sql), process.env["HIVEMIND_DOCS_TABLE"] ?? config.docsTableName, { project: deriveProjectKey(input.cwd ?? process.cwd()).key });
+        const r = await handleDocsVfs("", (sql) => api.query(sql), process.env["HIVEMIND_DOCS_TABLE"] ?? config.docsTableName, { project: deriveProjectKey(input.cwd ?? process.cwd()).key, dialect: api.dialect });
         const body = r.kind === "ok" ? r.body : "(docs unavailable)";
         return { action: "block", output: body, rewrittenCommand: rewritten };
       }
@@ -295,7 +290,7 @@ export async function processCodexPreToolUse(
         logFn(`docs vfs intercept: ${virtualPath}`);
         const docsTable = process.env["HIVEMIND_DOCS_TABLE"] ?? config.docsTableName;
         const sub = virtualPath === "/docs" ? "" : virtualPath.slice("/docs/".length);
-        const r = await handleDocsVfs(sub, (sql) => api.query(sql), docsTable, { embedQuery: makeQueryEmbedder(), project: deriveProjectKey(input.cwd ?? process.cwd()).key });
+        const r = await handleDocsVfs(sub, (sql) => api.query(sql), docsTable, { embedQuery: makeQueryEmbedder(), project: deriveProjectKey(input.cwd ?? process.cwd()).key, dialect: api.dialect });
         const body = r.kind === "ok" ? r.body : `${virtualPath}: No such file or directory`;
         return { action: "block", output: body, rewrittenCommand: rewritten };
       }

--- a/src/hooks/codex/session-start-setup.ts
+++ b/src/hooks/codex/session-start-setup.ts
@@ -12,7 +12,8 @@ import { homedir } from "node:os";
 import { loadCredentials, saveCredentials } from "../../commands/auth.js";
 import { loadConfig } from "../../config.js";
 import { resolveDirConfig } from "../../dir-config.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
+import type { StorageBackend } from "../../storage/backend.js";
 import { readStdin } from "../../utils/stdin.js";
 import { createPlaceholderSummary } from "../shared/placeholder-summary.js";
 import { log as _log } from "../../utils/debug.js";
@@ -28,10 +29,10 @@ const __bundleDir = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_VERSION = getInstalledVersion(__bundleDir, ".codex-plugin") ?? "";
 
 /** Create a placeholder summary via the shared race-safe writer (see placeholder-summary.ts). */
-async function createPlaceholder(api: DeeplakeApi, table: string, sessionId: string, cwd: string, userName: string, orgName: string, workspaceId: string): Promise<void> {
+async function createPlaceholder(api: StorageBackend, table: string, sessionId: string, cwd: string, userName: string, orgName: string, workspaceId: string): Promise<void> {
   await createPlaceholderSummary(
     (sql) => api.query(sql),
-    { table, sessionId, cwd, userName, orgName, workspaceId, agent: "codex", pluginVersion: PLUGIN_VERSION },
+    { table, sessionId, cwd, userName, orgName, workspaceId, agent: "codex", pluginVersion: PLUGIN_VERSION, dialect: api.dialect },
     wikiLog,
   );
 }
@@ -61,10 +62,12 @@ async function main(): Promise<void> {
   spawnDetachedNodeWorker(join(__bundleDir, "graph-deps-worker.js"));
 
   const creds = loadCredentials();
-  if (!creds?.token) { log("no credentials"); return; }
+  const baseStorageConfig = loadConfig();
+  const storageAvailable = Boolean(baseStorageConfig && ((baseStorageConfig.storage?.kind ?? "deeplake") !== "deeplake" || creds?.token));
+  if (!storageAvailable) { log(creds?.token ? "no storage configuration" : "no credentials"); return; }
 
   // Backfill userName if missing
-  if (!creds.userName) {
+  if (creds && !creds.userName) {
     try {
       const { userInfo } = await import("node:os");
       creds.userName = userInfo().username ?? "unknown";
@@ -83,12 +86,12 @@ async function main(): Promise<void> {
   const captureEnabled = process.env.HIVEMIND_CAPTURE !== "false";
   if (input.session_id) {
     try {
-      const base = loadConfig();
+      const base = baseStorageConfig;
       if (base) {
         const dirRes = resolveDirConfig(base, input.cwd ?? process.cwd());
         const config = dirRes.config;
         if (captureEnabled && dirRes.collect) {
-          const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
+          const api = createStorageBackend(config, config.tableName);
           await api.ensureTable();
           await api.ensureSessionsTable(config.sessionsTableName);
           await createPlaceholder(api, config.tableName, input.session_id, input.cwd ?? "", config.userName, config.orgName, config.workspaceId);

--- a/src/hooks/codex/session-start.ts
+++ b/src/hooks/codex/session-start.ts
@@ -21,12 +21,13 @@ import { log as _log } from "../../utils/debug.js";
 import { getInstalledVersion } from "../../utils/version-check.js";
 import { autoPullSkills } from "../../skillify/auto-pull.js";
 import { spawnGraphPullWorker } from "../../graph/spawn-pull-worker.js";
+import { loadConfig } from "../../config.js";
 const log = (msg: string) => _log("codex-session-start", msg);
 
 const __bundleDir = dirname(fileURLToPath(import.meta.url));
 // Codex DOES NOT have a model-only context channel for SessionStart hooks: any
 // `additionalContext` we emit is rendered as a `hook context: <text>` history
-// cell, user-visible. The big DEEPLAKE MEMORY tier doc + hivemind/skillify
+// cell, user-visible. The big HIVEMIND MEMORY tier doc + hivemind/skillify
 // command list that Claude Code's hook injects via `additionalContext` would
 // clobber the Codex UI every session, so we omit it entirely here. Codex's
 // skill autoloader already exposes the hivemind/* skills as Skill tool entries,
@@ -48,6 +49,8 @@ async function main(): Promise<void> {
   const input = await readStdin<CodexSessionStartInput>();
 
   let creds = loadCredentials();
+  const config = loadConfig();
+  const storageAvailable = Boolean(creds?.token || (config?.storage && config.storage.kind !== "deeplake"));
 
   if (!creds?.token) {
     log("no credentials found — run auth login to authenticate");
@@ -115,7 +118,7 @@ async function main(): Promise<void> {
   //     there is no model-only path. `suppressOutput: true` is parsed but
   //     ignored for SessionStart, so we can't hide it either.
   // Practical consequence: keep additionalContext MINIMAL on Codex. The
-  // bulky DEEPLAKE MEMORY tier doc + hivemind/skillify command list that
+  // bulky HIVEMIND MEMORY tier doc + hivemind/skillify command list that
   // claude-code's hook injects via `context` would clobber the Codex UI
   // every session. Codex's skill autoloader already exposes hivemind/skillify
   // command surfaces via per-skill SKILL.md files; the model can discover
@@ -141,13 +144,16 @@ async function main(): Promise<void> {
   // exit is wasted process churn. The check also keeps the codex
   // session-start "spawn must not fire when unauthenticated" contract
   // (tests/codex/codex-session-start-hook.test.ts).
-  if (creds?.token) spawnGraphPullWorker(input.cwd, __bundleDir);
+  if (storageAvailable) spawnGraphPullWorker(input.cwd, __bundleDir);
 
-  const additionalContext = creds?.token
-    ? `Hivemind: logged in as org ${creds.orgName ?? creds.orgId} (workspace: ${creds.workspaceId ?? "default"}).${versionNotice}`
+  const provider = config?.storage?.kind ?? "deeplake";
+  const additionalContext = storageAvailable
+    ? (provider === "deeplake"
+        ? `Hivemind: logged in as org ${creds?.orgName ?? creds?.orgId} (workspace: ${creds?.workspaceId ?? "default"}).${versionNotice}`
+        : `Hivemind memory backend: ${provider}.${versionNotice}`)
     : `Hivemind: not logged in. Run \`hivemind login\` to enable shared memory + skill sharing.${versionNotice}`;
 
-  const systemMessage = (!creds?.token && localMined > 0)
+  const systemMessage = (!storageAvailable && localMined > 0)
     ? `💡 ${localMined} ${skillNoun} mined from your local sessions live in ~/.claude/skills/. Run 'hivemind login' to share them with your team.`
     : undefined;
   const output: Record<string, unknown> = {

--- a/src/hooks/codex/spawn-wiki-worker.ts
+++ b/src/hooks/codex/spawn-wiki-worker.ts
@@ -96,10 +96,11 @@ export function spawnCodexWikiWorker(opts: SpawnOptions): void {
 
   const configFile = join(tmpDir, "config.json");
   writeFileSync(configFile, JSON.stringify({
-    apiUrl: config.apiUrl,
-    token: config.token,
-    orgId: config.orgId,
-    workspaceId: config.workspaceId,
+    storage: {
+      kind: config.storage?.kind ?? "deeplake",
+      orgId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.orgId : undefined,
+      workspaceId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.workspaceId : undefined,
+    },
     memoryTable: config.tableName,
     sessionsTable: config.sessionsTableName,
     sessionId,

--- a/src/hooks/codex/stop.ts
+++ b/src/hooks/codex/stop.ts
@@ -17,7 +17,7 @@ import { dirname, join } from "node:path";
 import { readStdin } from "../../utils/stdin.js";
 import { loadConfig } from "../../config.js";
 import { resolveDirConfig } from "../../dir-config.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
 import { projectNameFromCwd } from "../../utils/project-name.js";
 import { log as _log } from "../../utils/debug.js";
 import { bundleDirFromImportMeta, spawnCodexWikiWorker, wikiLog } from "./spawn-wiki-worker.js";
@@ -66,7 +66,7 @@ async function main(): Promise<void> {
   if (CAPTURE) {
     try {
       const sessionsTable = config.sessionsTableName;
-      const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, sessionsTable);
+      const api = createStorageBackend(config, sessionsTable);
       const ts = new Date().toISOString();
 
       // Codex Stop doesn't include last_assistant_message, but it provides
@@ -129,7 +129,7 @@ async function main(): Promise<void> {
       const embedding = embeddingsDisabled()
         ? null
         : await new EmbedClient({ daemonEntry: resolveEmbedDaemonPath() }).embed(line, "document");
-      const embeddingSql = embeddingSqlLiteral(embedding);
+      const embeddingSql = embeddingSqlLiteral(embedding, api.dialect);
 
       const insertSql = buildDirectSessionInsertSql(sessionsTable, {
         // Reuse the event id already embedded in the message JSON so the row PK
@@ -146,7 +146,7 @@ async function main(): Promise<void> {
         agent: "codex",
         pluginVersion: PLUGIN_VERSION,
         timestamp: ts,
-      });
+      }, api.dialect);
 
       await api.query(insertSql);
       log("stop event captured");

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -19,14 +19,15 @@ import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
 import { EmbedClient } from "../../embeddings/client.js";
 import { embeddingsDisabled } from "../../embeddings/disable.js";
-import { deeplakeClientHeader } from "../../utils/client-header.js";
+import { createWorkerStorage, queryWorkerStorage } from "../worker-storage.js";
 
 const dlog = (msg: string) => _log("codex-wiki-worker", msg);
 
 interface WorkerConfig {
-  apiUrl: string;
-  token: string;
-  orgId: string;
+  storage?: { kind: "deeplake" | "sqlite" | "postgres"; orgId?: string; workspaceId?: string };
+  apiUrl?: string;
+  token?: string;
+  orgId?: string;
   workspaceId: string;
   memoryTable: string;
   sessionsTable: string;
@@ -60,44 +61,8 @@ function esc(s: string): string {
     .replace(/[\x01-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
-async function query(sql: string, retries = 4): Promise<Record<string, unknown>[]> {
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    const r = await fetch(`${cfg.apiUrl}/workspaces/${cfg.workspaceId}/tables/query`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${cfg.token}`,
-        "Content-Type": "application/json",
-        "X-Activeloop-Org-Id": cfg.orgId,
-        ...deeplakeClientHeader(),
-      },
-      body: JSON.stringify({ query: sql }),
-    });
-    if (r.ok) {
-      const j = await r.json() as { columns?: string[]; rows?: unknown[][] };
-      if (!j.columns || !j.rows) return [];
-      return j.rows.map(row =>
-        Object.fromEntries(j.columns!.map((col, i) => [col, row[i]]))
-      );
-    }
-    // 403 on Deeplake arrives as a CloudFlare/nginx HTML page when the shared
-    // IP hits a rate limit (codex exec bursts while the worker is running),
-    // and 401 shows up transiently when the upstream auth cache expires.
-    // Treat both as retryable with exponential backoff.
-    const retryable = r.status === 401 || r.status === 403 ||
-      r.status === 429 || r.status === 500 || r.status === 502 || r.status === 503;
-    if (attempt < retries && retryable) {
-      // Exponential backoff with jitter — Cloudflare/nginx 403s from IP
-      // rate limiting (codex exec bursts) can take 30-60 s to clear.
-      const base = Math.min(30_000, 2000 * Math.pow(2, attempt));
-      const delay = base + Math.floor(Math.random() * 1000);
-      wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise(resolve => setTimeout(resolve, delay));
-      continue;
-    }
-    throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
-  }
-  return [];
-}
+const storageBackend = createWorkerStorage(cfg, wlog);
+const query = (sql: string): Promise<Record<string, unknown>[]> => queryWorkerStorage(storageBackend, sql);
 
 function cleanup(): void {
   try {
@@ -143,7 +108,8 @@ async function main(): Promise<void> {
     // column, so `total` is cheap and keeps the offset math + stamped offset right.
     wlog("fetching session events");
     const likePat = esc(`/sessions/%${cfg.sessionId}%`);
-    const cntRows = await query(`SELECT count(*) AS n FROM "${cfg.sessionsTable}" WHERE path LIKE E'${likePat}'`);
+    const stringPrefix = cfg.storage?.kind === "sqlite" ? "" : "E";
+    const cntRows = await query(`SELECT count(*) AS n FROM "${cfg.sessionsTable}" WHERE path LIKE ${stringPrefix}'${likePat}'`);
     const total = Number(cntRows[0]?.["n"] ?? 0);
     if (total === 0) {
       wlog("no session events found — exiting");
@@ -151,7 +117,7 @@ async function main(): Promise<void> {
     }
     const fetched = await query(
       `SELECT message, creation_date FROM "${cfg.sessionsTable}" ` +
-      `WHERE path LIKE E'${likePat}' ORDER BY creation_date DESC LIMIT ${WIKI_FALLBACK_MAX_ROWS}`
+      `WHERE path LIKE ${stringPrefix}'${likePat}' ORDER BY creation_date DESC LIMIT ${WIKI_FALLBACK_MAX_ROWS}`
     );
     const rows = fetched.reverse();
 
@@ -298,6 +264,7 @@ async function main(): Promise<void> {
           sessionId: cfg.sessionId,
           text,
           embedding,
+          dialect: cfg.storage?.kind ?? "deeplake",
           pluginVersion: cfg.pluginVersion ?? "",
         });
         wlog(`uploaded ${vpath} (summary=${result.summaryLength}, desc=${result.descLength})`);
@@ -317,6 +284,7 @@ async function main(): Promise<void> {
   } catch (e: any) {
     wlog(`fatal: ${e.message}`);
   } finally {
+    await storageBackend.close().catch(() => undefined);
     cleanup();
     try {
       releaseLock(cfg.sessionId);

--- a/src/hooks/cursor/capture.ts
+++ b/src/hooks/cursor/capture.ts
@@ -16,7 +16,7 @@
 import { readStdin } from "../../utils/stdin.js";
 import { resolveCaptureConfig } from "../shared/dir-gate.js";
 import { redactSecrets } from "../shared/redact.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
 import { projectNameFromCwd } from "../../utils/project-name.js";
 import { log as _log } from "../../utils/debug.js";
 import { buildSessionPath } from "../../utils/session-path.js";
@@ -101,7 +101,7 @@ async function main(): Promise<void> {
   const cwd = resolveCwd(input);
 
   const sessionsTable = config.sessionsTableName;
-  const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, sessionsTable);
+  const api = createStorageBackend(config, sessionsTable);
 
   const ts = new Date().toISOString();
   const meta = {
@@ -162,7 +162,7 @@ async function main(): Promise<void> {
   const embedding = embeddingsDisabled()
     ? null
     : await new EmbedClient({ daemonEntry: resolveEmbedDaemonPath() }).embed(line, "document");
-  const embeddingSql = embeddingSqlLiteral(embedding);
+  const embeddingSql = embeddingSqlLiteral(embedding, api.dialect);
 
   const insertSql = buildDirectSessionInsertSql(sessionsTable, {
     // Reuse the event id already embedded in the message JSON so the row PK
@@ -179,7 +179,7 @@ async function main(): Promise<void> {
     agent: "cursor",
     pluginVersion: PLUGIN_VERSION,
     timestamp: ts,
-  });
+  }, api.dialect);
 
   try {
     await api.query(insertSql);

--- a/src/hooks/cursor/pre-tool-use.ts
+++ b/src/hooks/cursor/pre-tool-use.ts
@@ -29,7 +29,7 @@
 import { readStdin } from "../../utils/stdin.js";
 import { deriveProjectKey } from "../../utils/repo-identity.js";
 import { loadRoutedConfig } from "../../dir-config.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
 import { log as _log } from "../../utils/debug.js";
 import { parseBashGrep, handleGrepDirect } from "../grep-direct.js";
 import { touchesMemory, rewritePaths } from "../memory-path-utils.js";
@@ -88,13 +88,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const api = new DeeplakeApi(
-    config.token,
-    config.apiUrl,
-    config.orgId,
-    config.workspaceId,
-    config.tableName,
-  );
+  const api = createStorageBackend(config, config.tableName);
 
   // Docs VFS dispatch — a cat of /docs/* (browse or find/) answered from the
   // docs table, same rewrite trick as the graph dispatch above. Runs before the
@@ -104,7 +98,7 @@ async function main(): Promise<void> {
   // without a decision and let a memory-touching command reach the host shell.
   let docsBody: string | null = null;
   try {
-    docsBody = await tryDocsRead(rewritten, (sql) => api.query(sql), docsTable, { embedQuery: makeQueryEmbedder(), project: deriveProjectKey(input.cwd ?? process.cwd()).key });
+    docsBody = await tryDocsRead(rewritten, (sql) => api.query(sql), docsTable, { embedQuery: makeQueryEmbedder(), project: deriveProjectKey(input.cwd ?? process.cwd()).key, dialect: api.dialect });
   } catch (err) {
     log(`docs vfs failed: ${(err as Error).message}`);
     docsBody = "(docs temporarily unavailable — try again)";

--- a/src/hooks/cursor/session-start.ts
+++ b/src/hooks/cursor/session-start.ts
@@ -23,7 +23,8 @@ import { dirname, join } from "node:path";
 import { loadCredentials, healDriftedOrgToken } from "../../commands/auth.js";
 import { loadConfig } from "../../config.js";
 import { resolveDirConfig } from "../../dir-config.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
+import type { StorageBackend } from "../../storage/backend.js";
 import { renderContextBlock } from "../shared/context-renderer.js";
 import { createPlaceholderSummary } from "../shared/placeholder-summary.js";
 import { renderSkillifyCommands } from "../../cli/skillify-spec.js";
@@ -43,12 +44,12 @@ const __bundleDir = dirname(fileURLToPath(import.meta.url));
 // Hivemind requires its npm bin (`hivemind` from @deeplake/hivemind) on PATH.
 // Inject text uses bare `hivemind <sub>` form — no per-agent path resolution needed.
 
-const context = `DEEPLAKE MEMORY: Persistent memory at ~/.deeplake/memory/ shared across sessions, users, and agents.
+const context = `HIVEMIND MEMORY: Persistent memory at ~/.deeplake/memory/ shared across sessions, users, and agents.
 
 Structure: index.md (start here) → summaries/*.md → sessions/*.jsonl (last resort). Do NOT jump straight to JSONL.
 Search: use \`grep\` (NOT \`rg\`/ripgrep). Example: grep -ri "keyword" ~/.deeplake/memory/
 IMPORTANT: Only use these bash builtins to interact with ~/.deeplake/memory/: cat, ls, grep, echo, jq, head, tail, sed, awk, wc, sort, find. Do NOT use rg/ripgrep, python, python3, node, curl, or other interpreters — they may not be installed and the memory filesystem only supports the listed builtins.
-Do NOT spawn subagents to read deeplake memory.
+Do NOT spawn subagents to read Hivemind memory.
 
 Organization management — each argument is SEPARATE (do NOT quote subcommands together):
 - hivemind login                              — SSO login
@@ -98,7 +99,7 @@ function resolveCwd(input: CursorSessionStartInput): string {
 
 /** Create a placeholder summary via the shared race-safe writer (see placeholder-summary.ts). */
 async function createPlaceholder(
-  api: DeeplakeApi,
+  api: StorageBackend,
   table: string,
   sessionId: string,
   cwd: string,
@@ -109,7 +110,7 @@ async function createPlaceholder(
 ): Promise<void> {
   await createPlaceholderSummary(
     (sql) => api.query(sql),
-    { table, sessionId, cwd, userName, orgName, workspaceId, agent: "cursor", pluginVersion },
+    { table, sessionId, cwd, userName, orgName, workspaceId, agent: "cursor", pluginVersion, dialect: api.dialect },
   );
 }
 
@@ -151,16 +152,17 @@ async function main(): Promise<void> {
   // Per-directory `.hivemind`: route / opt out for this tree. Resolved once and
   // reused for the placeholder write and the disclosure banner below.
   const baseConfig = loadConfig();
+  const storageAvailable = Boolean(baseConfig && ((baseConfig.storage?.kind ?? "deeplake") !== "deeplake" || creds?.token));
   const dirRes = baseConfig ? resolveDirConfig(baseConfig, cwd) : null;
   const collectHere = captureEnabled && (dirRes?.collect ?? true);
   let rulesBlock = "";
-  if (creds?.token) {
+  if (storageAvailable) {
     try {
       const config = dirRes?.config;
       if (config) {
         const table = config.tableName;
         const sessionsTable = config.sessionsTableName;
-        const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, table);
+        const api = createStorageBackend(config, table);
         if (collectHere) {
           await api.ensureTable();
           await api.ensureSessionsTable(sessionsTable);
@@ -215,7 +217,7 @@ async function main(): Promise<void> {
   // bytes land for the NEXT SessionStart. See src/graph/spawn-pull-worker.ts.
   // Gate on creds: avoid wasted process churn when unauthenticated
   // (pullSnapshot would early-return skipped-no-auth anyway).
-  if (creds?.token) spawnGraphPullWorker(resolveCwd(input), __bundleDir);
+  if (storageAvailable) spawnGraphPullWorker(resolveCwd(input), __bundleDir);
 
   // Disclose the EFFECTIVE identity (after any `.hivemind` overlay).
   const effConfig = dirRes?.config ?? baseConfig;
@@ -223,10 +225,13 @@ async function main(): Promise<void> {
     (dirRes.config.orgId !== baseConfig.orgId || dirRes.config.workspaceId !== baseConfig.workspaceId));
   const effOrg = effConfig ? (effConfig.orgName ?? effConfig.orgId) : (creds?.orgName ?? creds?.orgId);
   const effWs = effConfig ? effConfig.workspaceId : (creds?.workspaceId ?? "default");
-  const identityLine = dirRes && !dirRes.collect
-    ? `Deeplake capture is disabled for this directory (${dirRes.found?.path}); memory search still uses org: ${effOrg}`
-    : `Logged in to Deeplake as org: ${effOrg} (workspace: ${effWs})${routed ? ` · routed by ${dirRes?.found?.path}` : ""}`;
-  const baseContext = creds?.token
+  const provider = effConfig?.storage?.kind ?? "deeplake";
+  const identityLine = provider === "deeplake"
+    ? (dirRes && !dirRes.collect
+        ? `Deeplake capture is disabled for this directory (${dirRes.found?.path}); memory search still uses org: ${effOrg}`
+        : `Logged in to Deeplake as org: ${effOrg} (workspace: ${effWs})${routed ? ` · routed by ${dirRes?.found?.path}` : ""}`)
+    : `Hivemind memory backend: ${provider}${dirRes && !dirRes.collect ? ` · capture disabled by ${dirRes.found?.path}` : ""}`;
+  const baseContext = storageAvailable && effConfig
     ? `${context}\n${identityLine}${versionNotice}`
     : `${context}\nNot logged in to Deeplake. Run: hivemind login${localMinedNote}${versionNotice}`;
   // Cursor cannot route Write/Edit through hivemind hooks (its
@@ -234,7 +239,7 @@ async function main(): Promise<void> {
   // the CLI variant — `hivemind goal add/list/...` invoked as
   // shell commands. Same end state (rows in hivemind_goals /
   // hivemind_kpis), different code path inside the agent.
-  const baseWithGoals = creds?.token ? `${baseContext}\n\n${GOALS_INSTRUCTIONS_CLI}` : baseContext;
+  const baseWithGoals = storageAvailable && effConfig ? `${baseContext}\n\n${GOALS_INSTRUCTIONS_CLI}` : baseContext;
   const withRules = rulesBlock
     ? `${baseWithGoals}\n\n${rulesBlock}`
     : baseWithGoals;

--- a/src/hooks/cursor/spawn-wiki-worker.ts
+++ b/src/hooks/cursor/spawn-wiki-worker.ts
@@ -96,10 +96,11 @@ export function spawnCursorWikiWorker(opts: SpawnOptions): void {
 
   const configFile = join(tmpDir, "config.json");
   writeFileSync(configFile, JSON.stringify({
-    apiUrl: config.apiUrl,
-    token: config.token,
-    orgId: config.orgId,
-    workspaceId: config.workspaceId,
+    storage: {
+      kind: config.storage?.kind ?? "deeplake",
+      orgId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.orgId : undefined,
+      workspaceId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.workspaceId : undefined,
+    },
     memoryTable: config.tableName,
     sessionsTable: config.sessionsTableName,
     sessionId,

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -26,14 +26,15 @@ import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
 import { EmbedClient } from "../../embeddings/client.js";
 import { embeddingsDisabled } from "../../embeddings/disable.js";
-import { deeplakeClientHeader } from "../../utils/client-header.js";
+import { createWorkerStorage, queryWorkerStorage } from "../worker-storage.js";
 
 const dlog = (msg: string) => _log("cursor-wiki-worker", msg);
 
 interface WorkerConfig {
-  apiUrl: string;
-  token: string;
-  orgId: string;
+  storage?: { kind: "deeplake" | "sqlite" | "postgres"; orgId?: string; workspaceId?: string };
+  apiUrl?: string;
+  token?: string;
+  orgId?: string;
   workspaceId: string;
   memoryTable: string;
   sessionsTable: string;
@@ -69,44 +70,8 @@ function esc(s: string): string {
     .replace(/[\x01-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
-async function query(sql: string, retries = 4): Promise<Record<string, unknown>[]> {
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    const r = await fetch(`${cfg.apiUrl}/workspaces/${cfg.workspaceId}/tables/query`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${cfg.token}`,
-        "Content-Type": "application/json",
-        "X-Activeloop-Org-Id": cfg.orgId,
-        ...deeplakeClientHeader(),
-      },
-      body: JSON.stringify({ query: sql }),
-    });
-    if (r.ok) {
-      const j = await r.json() as { columns?: string[]; rows?: unknown[][] };
-      if (!j.columns || !j.rows) return [];
-      return j.rows.map(row =>
-        Object.fromEntries(j.columns!.map((col, i) => [col, row[i]]))
-      );
-    }
-    // 403 on Deeplake arrives as a CloudFlare/nginx HTML page when the shared
-    // IP hits a rate limit (codex exec bursts while the worker is running),
-    // and 401 shows up transiently when the upstream auth cache expires.
-    // Treat both as retryable with exponential backoff.
-    const retryable = r.status === 401 || r.status === 403 ||
-      r.status === 429 || r.status === 500 || r.status === 502 || r.status === 503;
-    if (attempt < retries && retryable) {
-      // Exponential backoff with jitter — Cloudflare/nginx 403s from IP
-      // rate limiting (codex exec bursts) can take 30-60 s to clear.
-      const base = Math.min(30_000, 2000 * Math.pow(2, attempt));
-      const delay = base + Math.floor(Math.random() * 1000);
-      wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise(resolve => setTimeout(resolve, delay));
-      continue;
-    }
-    throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
-  }
-  return [];
-}
+const storageBackend = createWorkerStorage(cfg, wlog);
+const query = (sql: string): Promise<Record<string, unknown>[]> => queryWorkerStorage(storageBackend, sql);
 
 function cleanup(): void {
   try {
@@ -134,12 +99,13 @@ async function main(): Promise<void> {
     // math (`newRowsFromWindow`) and the stamped offset stay correct.
     const dbFetch = async (): Promise<{ rows: Record<string, unknown>[]; total: number }> => {
       const like = esc(`/sessions/%${cfg.sessionId}%`);
-      const cnt = await query(`SELECT count(*) AS n FROM "${cfg.sessionsTable}" WHERE path LIKE E'${like}'`);
+      const stringPrefix = cfg.storage?.kind === "sqlite" ? "" : "E";
+      const cnt = await query(`SELECT count(*) AS n FROM "${cfg.sessionsTable}" WHERE path LIKE ${stringPrefix}'${like}'`);
       const total = Number(cnt[0]?.["n"] ?? 0);
       if (total === 0) return { rows: [], total: 0 };
       const r = await query(
         `SELECT message, creation_date FROM "${cfg.sessionsTable}" ` +
-        `WHERE path LIKE E'${like}' ORDER BY creation_date DESC LIMIT ${WIKI_FALLBACK_MAX_ROWS}`
+        `WHERE path LIKE ${stringPrefix}'${like}' ORDER BY creation_date DESC LIMIT ${WIKI_FALLBACK_MAX_ROWS}`
       );
       return { rows: r.reverse(), total };
     };
@@ -339,6 +305,7 @@ async function main(): Promise<void> {
           sessionId: cfg.sessionId,
           text,
           embedding,
+          dialect: cfg.storage?.kind ?? "deeplake",
           pluginVersion: cfg.pluginVersion ?? "",
         });
         wlog(`uploaded ${vpath} (summary=${result.summaryLength}, desc=${result.descLength})`);
@@ -358,6 +325,7 @@ async function main(): Promise<void> {
   } catch (e: any) {
     wlog(`fatal: ${e.message}`);
   } finally {
+    await storageBackend.close().catch(() => undefined);
     cleanup();
     try {
       releaseLock(cfg.sessionId);

--- a/src/hooks/graph-on-stop.ts
+++ b/src/hooks/graph-on-stop.ts
@@ -55,15 +55,15 @@ import { repoDir } from "../graph/snapshot.js";
 import { isDirectRun } from "../utils/direct-run.js";
 import { deriveProjectKey } from "../utils/repo-identity.js";
 
+function workTreeIdFor(cwd: string): string {
+  return createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+}
+
 /**
  * Mirror of workTreeIdFor in src/commands/graph.ts. Kept inline (rather
  * than as a shared util) so the gate hook stays leanly self-contained —
  * one sha256-hex-truncate, no extra module dependency.
  */
-function workTreeIdFor(cwd: string): string {
-  return createHash("sha256").update(cwd).digest("hex").slice(0, 16);
-}
-
 /**
  * How long between auto-rebuilds. The first SessionEnd after this interval
  * AND after a commit-with-source-changes is the one that fires the build.

--- a/src/hooks/grep-direct.ts
+++ b/src/hooks/grep-direct.ts
@@ -5,7 +5,7 @@
  * which handles dual-table SQL + session-JSON normalization + regex refinement.
  */
 
-import type { DeeplakeApi } from "../deeplake-api.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { grepBothTables, type GrepMatchParams } from "../shell/grep-core.js";
 import { capOutputForClaude } from "../utils/output-cap.js";
 import { EmbedClient } from "../embeddings/client.js";
@@ -308,7 +308,7 @@ export function parseBashGrep(cmd: string): GrepParams | null {
 
 /** Run grep via the shared dual-table core. Returns formatted grep output. */
 export async function handleGrepDirect(
-  api: DeeplakeApi,
+  api: StorageBackend,
   table: string,
   sessionsTable: string,
   params: GrepParams,

--- a/src/hooks/hermes/capture.ts
+++ b/src/hooks/hermes/capture.ts
@@ -17,7 +17,7 @@
 import { readStdin } from "../../utils/stdin.js";
 import { resolveCaptureConfig } from "../shared/dir-gate.js";
 import { redactSecrets } from "../shared/redact.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
 import { projectNameFromCwd } from "../../utils/project-name.js";
 import { log as _log } from "../../utils/debug.js";
 import { buildSessionPath } from "../../utils/session-path.js";
@@ -91,7 +91,7 @@ async function main(): Promise<void> {
   const extra = (input.extra ?? {}) as Record<string, unknown>;
 
   const sessionsTable = config.sessionsTableName;
-  const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, sessionsTable);
+  const api = createStorageBackend(config, sessionsTable);
 
   const ts = new Date().toISOString();
   // Hermes sends `model` + `platform` nested in `extra` (everything that isn't
@@ -152,7 +152,7 @@ async function main(): Promise<void> {
   const embedding = embeddingsDisabled()
     ? null
     : await new EmbedClient({ daemonEntry: resolveEmbedDaemonPath() }).embed(line, "document");
-  const embeddingSql = embeddingSqlLiteral(embedding);
+  const embeddingSql = embeddingSqlLiteral(embedding, api.dialect);
 
   const insertSql = buildDirectSessionInsertSql(sessionsTable, {
     // Reuse the event id already embedded in the message JSON so the row PK
@@ -169,7 +169,7 @@ async function main(): Promise<void> {
     agent: "hermes",
     pluginVersion: PLUGIN_VERSION,
     timestamp: ts,
-  });
+  }, api.dialect);
 
   try {
     await api.query(insertSql);

--- a/src/hooks/hermes/pre-tool-use.ts
+++ b/src/hooks/hermes/pre-tool-use.ts
@@ -22,7 +22,7 @@
 
 import { readStdin } from "../../utils/stdin.js";
 import { loadRoutedConfig } from "../../dir-config.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
 import { log as _log } from "../../utils/debug.js";
 import { parseBashGrep, handleGrepDirect } from "../grep-direct.js";
 import { touchesMemory, rewritePaths } from "../memory-path-utils.js";
@@ -73,13 +73,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const api = new DeeplakeApi(
-    config.token,
-    config.apiUrl,
-    config.orgId,
-    config.workspaceId,
-    config.tableName,
-  );
+  const api = createStorageBackend(config, config.tableName);
 
   try {
     const result = await handleGrepDirect(api, config.tableName, config.sessionsTableName, grepParams);

--- a/src/hooks/hermes/session-start.ts
+++ b/src/hooks/hermes/session-start.ts
@@ -14,7 +14,8 @@ import { dirname, join } from "node:path";
 import { loadCredentials, healDriftedOrgToken } from "../../commands/auth.js";
 import { loadConfig } from "../../config.js";
 import { resolveDirConfig } from "../../dir-config.js";
-import { DeeplakeApi } from "../../deeplake-api.js";
+import { createStorageBackend } from "../../storage/factory.js";
+import type { StorageBackend } from "../../storage/backend.js";
 import { renderContextBlock } from "../shared/context-renderer.js";
 import { createPlaceholderSummary } from "../shared/placeholder-summary.js";
 import { renderSkillifyCommands } from "../../cli/skillify-spec.js";
@@ -34,13 +35,13 @@ const __bundleDir = dirname(fileURLToPath(import.meta.url));
 // Hivemind requires its npm bin (`hivemind` from @deeplake/hivemind) on PATH.
 // Inject text uses bare `hivemind <sub>` form — no per-agent path resolution needed.
 
-const context = `DEEPLAKE MEMORY: Persistent memory at ~/.deeplake/memory/ shared across sessions, users, and agents.
+const context = `HIVEMIND MEMORY: Persistent memory at ~/.deeplake/memory/ shared across sessions, users, and agents.
 
 Structure: index.md (start here) → summaries/*.md → sessions/*.jsonl (last resort). Do NOT jump straight to JSONL.
 Search: use \`grep\` (NOT \`rg\`/ripgrep). Example: grep -ri "keyword" ~/.deeplake/memory/
 You also have hivemind MCP tools registered: hivemind_search, hivemind_read, hivemind_index. Prefer these — one tool call returns ranked hits across all summaries and sessions in a single SQL query.
 IMPORTANT: Only use these bash builtins to interact with ~/.deeplake/memory/: cat, ls, grep, echo, jq, head, tail, sed, awk, wc, sort, find. Do NOT use rg/ripgrep, python, python3, node, curl, or other interpreters.
-Do NOT spawn subagents to read deeplake memory.
+Do NOT spawn subagents to read Hivemind memory.
 
 Organization management — each argument is SEPARATE (do NOT quote subcommands together):
 - hivemind login                              — SSO login
@@ -72,7 +73,7 @@ interface HermesSessionStartInput {
 
 /** Create a placeholder summary via the shared race-safe writer (see placeholder-summary.ts). */
 async function createPlaceholder(
-  api: DeeplakeApi,
+  api: StorageBackend,
   table: string,
   sessionId: string,
   cwd: string,
@@ -83,7 +84,7 @@ async function createPlaceholder(
 ): Promise<void> {
   await createPlaceholderSummary(
     (sql) => api.query(sql),
-    { table, sessionId, cwd, userName, orgName, workspaceId, agent: "hermes", pluginVersion },
+    { table, sessionId, cwd, userName, orgName, workspaceId, agent: "hermes", pluginVersion, dialect: api.dialect },
   );
 }
 
@@ -99,6 +100,7 @@ async function main(): Promise<void> {
   // Per-directory `.hivemind`: route / opt out for this tree. Resolved once and
   // reused for the placeholder write and the disclosure banner below.
   const baseConfig = loadConfig();
+  const storageAvailable = Boolean(baseConfig && ((baseConfig.storage?.kind ?? "deeplake") !== "deeplake" || creds?.token));
   const dirRes = baseConfig ? resolveDirConfig(baseConfig, cwd) : null;
   const collectHere = captureEnabled && (dirRes?.collect ?? true);
 
@@ -128,11 +130,11 @@ async function main(): Promise<void> {
   // is read-only and runs regardless. See cursor session-start for
   // the same layering rationale.
   let rulesBlock = "";
-  if (creds?.token) {
+  if (storageAvailable) {
     try {
       const config = dirRes?.config;
       if (config) {
-        const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
+        const api = createStorageBackend(config, config.tableName);
         if (collectHere) {
           await api.ensureTable();
           await api.ensureSessionsTable(config.sessionsTableName);
@@ -185,7 +187,7 @@ async function main(): Promise<void> {
   // bytes land for the NEXT SessionStart. See src/graph/spawn-pull-worker.ts.
   // Gate on creds: avoid wasted process churn when unauthenticated
   // (pullSnapshot would early-return skipped-no-auth anyway).
-  if (creds?.token) spawnGraphPullWorker(cwd, __bundleDir);
+  if (storageAvailable) spawnGraphPullWorker(cwd, __bundleDir);
 
   // Disclose the EFFECTIVE identity (after any `.hivemind` overlay).
   const effConfig = dirRes?.config ?? baseConfig;
@@ -193,17 +195,20 @@ async function main(): Promise<void> {
     (dirRes.config.orgId !== baseConfig.orgId || dirRes.config.workspaceId !== baseConfig.workspaceId));
   const effOrg = effConfig ? (effConfig.orgName ?? effConfig.orgId) : (creds?.orgName ?? creds?.orgId);
   const effWs = effConfig ? effConfig.workspaceId : (creds?.workspaceId ?? "default");
-  const identityLine = dirRes && !dirRes.collect
-    ? `Deeplake capture is disabled for this directory (${dirRes.found?.path}); memory search still uses org: ${effOrg}`
-    : `Logged in to Deeplake as org: ${effOrg} (workspace: ${effWs})${routed ? ` · routed by ${dirRes?.found?.path}` : ""}`;
-  const baseContext = creds?.token
+  const provider = effConfig?.storage?.kind ?? "deeplake";
+  const identityLine = provider === "deeplake"
+    ? (dirRes && !dirRes.collect
+        ? `Deeplake capture is disabled for this directory (${dirRes.found?.path}); memory search still uses org: ${effOrg}`
+        : `Logged in to Deeplake as org: ${effOrg} (workspace: ${effWs})${routed ? ` · routed by ${dirRes?.found?.path}` : ""}`)
+    : `Hivemind memory backend: ${provider}${dirRes && !dirRes.collect ? ` · capture disabled by ${dirRes.found?.path}` : ""}`;
+  const baseContext = storageAvailable && effConfig
     ? `${context}\n${identityLine}${versionNotice}`
     : `${context}\nNot logged in to Deeplake. Run: hivemind login${localMinedNote}${versionNotice}`;
   // Hermes' pre-tool-use intercepts only `terminal` — it cannot
   // route Write/Edit. Use the CLI variant: agent invokes
   // `hivemind goal add/list/...` via terminal. End state in tables
   // is identical to the VFS-routed path.
-  const baseWithGoals = creds?.token ? `${baseContext}\n\n${GOALS_INSTRUCTIONS_CLI}` : baseContext;
+  const baseWithGoals = storageAvailable && effConfig ? `${baseContext}\n\n${GOALS_INSTRUCTIONS_CLI}` : baseContext;
   // Code-graph inject. Unlike harnesses/claude-code/cursor this is user-visible in the
   // Hermes TUI (Hermes has no model-only SessionStart channel), but an
   // always-present structural index is worth the extra lines. graphContextLine

--- a/src/hooks/hermes/spawn-wiki-worker.ts
+++ b/src/hooks/hermes/spawn-wiki-worker.ts
@@ -97,10 +97,11 @@ export function spawnHermesWikiWorker(opts: SpawnOptions): void {
 
   const configFile = join(tmpDir, "config.json");
   writeFileSync(configFile, JSON.stringify({
-    apiUrl: config.apiUrl,
-    token: config.token,
-    orgId: config.orgId,
-    workspaceId: config.workspaceId,
+    storage: {
+      kind: config.storage?.kind ?? "deeplake",
+      orgId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.orgId : undefined,
+      workspaceId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.workspaceId : undefined,
+    },
     memoryTable: config.tableName,
     sessionsTable: config.sessionsTableName,
     sessionId,

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -25,14 +25,15 @@ import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
 import { EmbedClient } from "../../embeddings/client.js";
 import { embeddingsDisabled } from "../../embeddings/disable.js";
-import { deeplakeClientHeader } from "../../utils/client-header.js";
+import { createWorkerStorage, queryWorkerStorage } from "../worker-storage.js";
 
 const dlog = (msg: string) => _log("hermes-wiki-worker", msg);
 
 interface WorkerConfig {
-  apiUrl: string;
-  token: string;
-  orgId: string;
+  storage?: { kind: "deeplake" | "sqlite" | "postgres"; orgId?: string; workspaceId?: string };
+  apiUrl?: string;
+  token?: string;
+  orgId?: string;
   workspaceId: string;
   memoryTable: string;
   sessionsTable: string;
@@ -69,44 +70,8 @@ function esc(s: string): string {
     .replace(/[\x01-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
-async function query(sql: string, retries = 4): Promise<Record<string, unknown>[]> {
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    const r = await fetch(`${cfg.apiUrl}/workspaces/${cfg.workspaceId}/tables/query`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${cfg.token}`,
-        "Content-Type": "application/json",
-        "X-Activeloop-Org-Id": cfg.orgId,
-        ...deeplakeClientHeader(),
-      },
-      body: JSON.stringify({ query: sql }),
-    });
-    if (r.ok) {
-      const j = await r.json() as { columns?: string[]; rows?: unknown[][] };
-      if (!j.columns || !j.rows) return [];
-      return j.rows.map(row =>
-        Object.fromEntries(j.columns!.map((col, i) => [col, row[i]]))
-      );
-    }
-    // 403 on Deeplake arrives as a CloudFlare/nginx HTML page when the shared
-    // IP hits a rate limit (codex exec bursts while the worker is running),
-    // and 401 shows up transiently when the upstream auth cache expires.
-    // Treat both as retryable with exponential backoff.
-    const retryable = r.status === 401 || r.status === 403 ||
-      r.status === 429 || r.status === 500 || r.status === 502 || r.status === 503;
-    if (attempt < retries && retryable) {
-      // Exponential backoff with jitter — Cloudflare/nginx 403s from IP
-      // rate limiting (codex exec bursts) can take 30-60 s to clear.
-      const base = Math.min(30_000, 2000 * Math.pow(2, attempt));
-      const delay = base + Math.floor(Math.random() * 1000);
-      wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise(resolve => setTimeout(resolve, delay));
-      continue;
-    }
-    throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
-  }
-  return [];
-}
+const storageBackend = createWorkerStorage(cfg, wlog);
+const query = (sql: string): Promise<Record<string, unknown>[]> => queryWorkerStorage(storageBackend, sql);
 
 function cleanup(): void {
   try {
@@ -134,12 +99,13 @@ async function main(): Promise<void> {
     // math (`newRowsFromWindow`) and the stamped offset stay correct.
     const dbFetch = async (): Promise<{ rows: Record<string, unknown>[]; total: number }> => {
       const like = esc(`/sessions/%${cfg.sessionId}%`);
-      const cnt = await query(`SELECT count(*) AS n FROM "${cfg.sessionsTable}" WHERE path LIKE E'${like}'`);
+      const stringPrefix = cfg.storage?.kind === "sqlite" ? "" : "E";
+      const cnt = await query(`SELECT count(*) AS n FROM "${cfg.sessionsTable}" WHERE path LIKE ${stringPrefix}'${like}'`);
       const total = Number(cnt[0]?.["n"] ?? 0);
       if (total === 0) return { rows: [], total: 0 };
       const r = await query(
         `SELECT message, creation_date FROM "${cfg.sessionsTable}" ` +
-        `WHERE path LIKE E'${like}' ORDER BY creation_date DESC LIMIT ${WIKI_FALLBACK_MAX_ROWS}`
+        `WHERE path LIKE ${stringPrefix}'${like}' ORDER BY creation_date DESC LIMIT ${WIKI_FALLBACK_MAX_ROWS}`
       );
       return { rows: r.reverse(), total };
     };
@@ -351,6 +317,7 @@ async function main(): Promise<void> {
           sessionId: cfg.sessionId,
           text,
           embedding,
+          dialect: cfg.storage?.kind ?? "deeplake",
           pluginVersion: cfg.pluginVersion ?? "",
         });
         wlog(`uploaded ${vpath} (summary=${result.summaryLength}, desc=${result.descLength})`);
@@ -370,6 +337,7 @@ async function main(): Promise<void> {
   } catch (e: any) {
     wlog(`fatal: ${e.message}`);
   } finally {
+    await storageBackend.close().catch(() => undefined);
     cleanup();
     try {
       releaseLock(cfg.sessionId);

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -28,14 +28,15 @@ import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
 import { EmbedClient } from "../../embeddings/client.js";
 import { embeddingsDisabled } from "../../embeddings/disable.js";
-import { deeplakeClientHeader } from "../../utils/client-header.js";
+import { createWorkerStorage, queryWorkerStorage } from "../worker-storage.js";
 
 const dlog = (msg: string) => _log("pi-wiki-worker", msg);
 
 interface WorkerConfig {
-  apiUrl: string;
-  token: string;
-  orgId: string;
+  storage?: { kind: "deeplake" | "sqlite" | "postgres"; orgId?: string; workspaceId?: string };
+  apiUrl?: string;
+  token?: string;
+  orgId?: string;
   workspaceId: string;
   memoryTable: string;
   sessionsTable: string;
@@ -71,44 +72,8 @@ function esc(s: string): string {
     .replace(/[\x01-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
-async function query(sql: string, retries = 4): Promise<Record<string, unknown>[]> {
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    const r = await fetch(`${cfg.apiUrl}/workspaces/${cfg.workspaceId}/tables/query`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${cfg.token}`,
-        "Content-Type": "application/json",
-        "X-Activeloop-Org-Id": cfg.orgId,
-        ...deeplakeClientHeader(),
-      },
-      body: JSON.stringify({ query: sql }),
-    });
-    if (r.ok) {
-      const j = await r.json() as { columns?: string[]; rows?: unknown[][] };
-      if (!j.columns || !j.rows) return [];
-      return j.rows.map(row =>
-        Object.fromEntries(j.columns!.map((col, i) => [col, row[i]]))
-      );
-    }
-    // 403 on Deeplake arrives as a CloudFlare/nginx HTML page when the shared
-    // IP hits a rate limit (codex exec bursts while the worker is running),
-    // and 401 shows up transiently when the upstream auth cache expires.
-    // Treat both as retryable with exponential backoff.
-    const retryable = r.status === 401 || r.status === 403 ||
-      r.status === 429 || r.status === 500 || r.status === 502 || r.status === 503;
-    if (attempt < retries && retryable) {
-      // Exponential backoff with jitter — Cloudflare/nginx 403s from IP
-      // rate limiting (codex exec bursts) can take 30-60 s to clear.
-      const base = Math.min(30_000, 2000 * Math.pow(2, attempt));
-      const delay = base + Math.floor(Math.random() * 1000);
-      wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise(resolve => setTimeout(resolve, delay));
-      continue;
-    }
-    throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
-  }
-  return [];
-}
+const storageBackend = createWorkerStorage(cfg, wlog);
+const query = (sql: string): Promise<Record<string, unknown>[]> => queryWorkerStorage(storageBackend, sql);
 
 function cleanup(): void {
   try {
@@ -128,7 +93,8 @@ async function main(): Promise<void> {
     // column, so `total` is cheap and keeps the offset math + stamped offset right.
     wlog("fetching session events");
     const likePat = esc(`/sessions/%${cfg.sessionId}%`);
-    const cntRows = await query(`SELECT count(*) AS n FROM "${cfg.sessionsTable}" WHERE path LIKE E'${likePat}'`);
+    const stringPrefix = cfg.storage?.kind === "sqlite" ? "" : "E";
+    const cntRows = await query(`SELECT count(*) AS n FROM "${cfg.sessionsTable}" WHERE path LIKE ${stringPrefix}'${likePat}'`);
     const total = Number(cntRows[0]?.["n"] ?? 0);
     if (total === 0) {
       wlog("no session events found — exiting");
@@ -136,7 +102,7 @@ async function main(): Promise<void> {
     }
     const fetched = await query(
       `SELECT message, creation_date FROM "${cfg.sessionsTable}" ` +
-      `WHERE path LIKE E'${likePat}' ORDER BY creation_date DESC LIMIT ${WIKI_FALLBACK_MAX_ROWS}`
+      `WHERE path LIKE ${stringPrefix}'${likePat}' ORDER BY creation_date DESC LIMIT ${WIKI_FALLBACK_MAX_ROWS}`
     );
     const rows = fetched.reverse();
 
@@ -294,6 +260,7 @@ async function main(): Promise<void> {
           sessionId: cfg.sessionId,
           text,
           embedding,
+          dialect: cfg.storage?.kind ?? "deeplake",
           pluginVersion: cfg.pluginVersion ?? "",
         });
         wlog(`uploaded ${vpath} (summary=${result.summaryLength}, desc=${result.descLength})`);
@@ -313,6 +280,7 @@ async function main(): Promise<void> {
   } catch (e: any) {
     wlog(`fatal: ${e.message}`);
   } finally {
+    await storageBackend.close().catch(() => undefined);
     cleanup();
     try {
       releaseLock(cfg.sessionId);

--- a/src/hooks/plugin-cache-gc.ts
+++ b/src/hooks/plugin-cache-gc.ts
@@ -13,7 +13,7 @@
  * also cleaned up.
  */
 
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
 import { log as _log } from "../utils/debug.js";
 import {
@@ -24,6 +24,7 @@ import {
   readCurrentVersionFromManifest,
   resolveVersionedPluginDir,
 } from "../utils/plugin-cache.js";
+import { isDirectRun } from "../utils/direct-run.js";
 
 const defaultLog = (msg: string) => _log("plugin-cache-gc", msg);
 
@@ -61,8 +62,7 @@ export function runGc(bundleDir: string, opts: RunGcOptions = {}): void {
 // Imports from tests take the `runGc` export directly and skip this.
 /* c8 ignore start — script-mode bootstrap, covered by bundle integration test */
 const __bundleDir = dirname(fileURLToPath(import.meta.url));
-const __entryUrl = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
-if (import.meta.url === __entryUrl) {
+if (isDirectRun(import.meta.url)) {
   try { runGc(__bundleDir); }
   catch (e: any) { defaultLog(`fatal: ${e.message}`); }
 }

--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -9,7 +9,8 @@ import { readStdin } from "../utils/stdin.js";
 import { loadConfig } from "../config.js";
 import { resolveDirConfig } from "../dir-config.js";
 import { armSkillOptOnSkillUse } from "./shared/skillopt-hook.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { sqlLike } from "../utils/sql.js";
 import { log as _log } from "../utils/debug.js";
 import { isDirectRun } from "../utils/direct-run.js";
@@ -250,7 +251,7 @@ export function extractGrepParams(
 
 interface ClaudePreToolDeps {
   config?: ReturnType<typeof loadConfig>;
-  createApi?: (table: string, config: NonNullable<ReturnType<typeof loadConfig>>) => DeeplakeApi;
+  createApi?: (table: string, config: NonNullable<ReturnType<typeof loadConfig>>) => StorageBackend;
   executeCompiledBashCommandFn?: typeof executeCompiledBashCommand;
   handleGrepDirectFn?: typeof handleGrepDirect;
   handleGraphVfsFn?: typeof handleGraphVfs;
@@ -268,13 +269,7 @@ interface ClaudePreToolDeps {
 export async function processPreToolUse(input: PreToolUseInput, deps: ClaudePreToolDeps = {}): Promise<ClaudePreToolDecision | null> {
   const {
     config: baseConfig = loadConfig(),
-    createApi = (table, activeConfig) => new DeeplakeApi(
-      activeConfig.token,
-      activeConfig.apiUrl,
-      activeConfig.orgId,
-      activeConfig.workspaceId,
-      table,
-    ),
+    createApi = (table, activeConfig) => createStorageBackend(activeConfig, table),
     executeCompiledBashCommandFn = executeCompiledBashCommand,
     handleGrepDirectFn = handleGrepDirect,
     handleGraphVfsFn = handleGraphVfs,
@@ -471,7 +466,7 @@ export async function processPreToolUse(input: PreToolUseInput, deps: ClaudePreT
       logFn(`docs vfs: ${subpath || "(root)"}`);
       const docsCwd = input.cwd ?? process.cwd();
       const docsGit = defaultGit(docsCwd);
-      const result = await handleDocsVfsFn(subpath, (sql) => api.query(sql), config.docsTableName, { embedQuery: makeQueryEmbedder(), project: deriveProjectKey(docsCwd).key, readerScope: currentScope(docsGit), git: docsGit });
+      const result = await handleDocsVfsFn(subpath, (sql) => api.query(sql), config.docsTableName, { embedQuery: makeQueryEmbedder(), project: deriveProjectKey(docsCwd).key, readerScope: currentScope(docsGit), git: docsGit, dialect: api.dialect });
       const body = result.kind === "ok" ? result.body : `(${result.kind}) ${result.message}`;
       if (input.tool_name === "Read") {
         const file_path = writeReadCacheFileFn(input.session_id, virtualPath, body);
@@ -480,7 +475,7 @@ export async function processPreToolUse(input: PreToolUseInput, deps: ClaudePreT
       return buildAllowDecision(safeEchoCommand(capOutputForClaude(body, { kind: "docs" })), `[hivemind docs] /docs/${subpath}`);
     }
     if (lsDir === "/docs" || lsDir === "/docs/") {
-      const result = await handleDocsVfsFn("", (sql) => api.query(sql), config.docsTableName, { project: deriveProjectKey(input.cwd ?? process.cwd()).key });
+      const result = await handleDocsVfsFn("", (sql) => api.query(sql), config.docsTableName, { project: deriveProjectKey(input.cwd ?? process.cwd()).key, dialect: api.dialect });
       const body = result.kind === "ok" ? result.body : `(${result.kind}) ${result.message}`;
       if (input.tool_name === "Read") {
         const file_path = writeReadCacheFileFn(input.session_id, "/docs/_listing.txt", body);

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -30,7 +30,7 @@
 import { readStdin } from "../utils/stdin.js";
 import { loadConfig } from "../config.js";
 import { resolveDirConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { EmbedClient } from "../embeddings/client.js";
 import { embedSummaryWithWarmup } from "../embeddings/embed-summary.js";
 import { embeddingsDisabled } from "../embeddings/disable.js";
@@ -114,7 +114,7 @@ async function findHit(
   signal: AbortSignal,
 ): Promise<FindResult> {
   const prompt = input.prompt ?? "";
-  const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
+  const api = createStorageBackend(config, config.tableName);
   // Pass the budget's abort signal so a timeout actually CANCELS the in-flight
   // query rather than leaving the socket/retry loop running.
   const q = (sql: string) => api.query(sql, signal) as Promise<Array<Record<string, unknown>>>;
@@ -200,7 +200,7 @@ async function main(): Promise<void> {
 
   const session = input.session_id;
   const baseConfig = loadConfig();
-  if (!baseConfig?.token) {
+  if (!baseConfig) {
     log("skip no-config");
     recordRecallEvent({ event: "no-config", gate: reason, session });
     return;

--- a/src/hooks/session-notifications.ts
+++ b/src/hooks/session-notifications.ts
@@ -18,6 +18,7 @@ import { drainSessionStart, registerRule } from "../notifications/index.js";
 import { bumpSessionCount } from "../notifications/state.js";
 import { referralInviteRule } from "../notifications/rules/referral-invite.js";
 import { log as _log } from "../utils/debug.js";
+import { loadConfig } from "../config.js";
 
 const log = (msg: string) => _log("session-notifications", msg);
 
@@ -60,7 +61,8 @@ async function main(): Promise<void> {
   // out the first sessions.
   const sessionCount = bumpSessionCount(sessionId);
 
-  const creds = loadCredentials();
+  const config = loadConfig();
+  const creds = config?.storage?.kind && config.storage.kind !== "deeplake" ? null : loadCredentials();
   await drainSessionStart({ agent: "claude-code", creds, sessionId, source, sessionCount });
 }
 

--- a/src/hooks/session-queue.ts
+++ b/src/hooks/session-queue.ts
@@ -16,6 +16,7 @@ import { homedir } from "node:os";
 import { sqlIdent, sqlStr } from "../utils/sql.js";
 
 export interface SessionQueueApi {
+  dialect?: "deeplake" | "sqlite" | "postgres";
   query(sql: string): Promise<Record<string, unknown>[]>;
   ensureSessionsTable(name?: string): Promise<void>;
 }
@@ -124,7 +125,11 @@ export function appendQueuedSessionRow(row: QueuedSessionRow, queueDir = DEFAULT
   return queuePath;
 }
 
-export function buildSessionInsertSql(sessionsTable: string, rows: QueuedSessionRow[]): string {
+export function buildSessionInsertSql(
+  sessionsTable: string,
+  rows: QueuedSessionRow[],
+  dialect: "deeplake" | "sqlite" | "postgres" = "deeplake",
+): string {
   if (rows.length === 0) throw new Error("buildSessionInsertSql: rows must not be empty");
   const table = sqlIdent(sessionsTable);
   const values = rows.map((row) => {
@@ -134,24 +139,41 @@ export function buildSessionInsertSql(sessionsTable: string, rows: QueuedSession
     // would corrupt the JSON and the jsonb cast would 400. Mirrors the
     // capture.ts direct-INSERT path.
     const jsonForSql = coerceJsonbPayload(row.message).replace(/'/g, "''");
+    const jsonValue = dialect === "sqlite" ? `'${jsonForSql}'` : `'${jsonForSql}'::jsonb`;
     return (
-      `('${sqlStr(row.id)}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', '${jsonForSql}'::jsonb, ` +
+      `('${sqlStr(row.id)}', '${sqlStr(row.path)}', '${sqlStr(row.filename)}', ${jsonValue}, ` +
       `'${sqlStr(row.author)}', ${row.sizeBytes}, '${sqlStr(row.project)}', '${sqlStr(row.description)}', ` +
-      `'${sqlStr(row.agent)}', '${sqlStr(row.pluginVersion ?? "")}', '${sqlStr(row.creationDate)}', '${sqlStr(row.lastUpdateDate)}')`
+      `'${sqlStr(row.agent)}', '${sqlStr(row.pluginVersion ?? "")}', '${sqlStr(row.creationDate)}', '${sqlStr(row.lastUpdateDate)}' ` +
+      `)`
     );
-  }).join(", ");
+  });
+
+  if (dialect !== "sqlite") {
+    const joined = values.join(", ");
+    const columns = "id, path, filename, message, author, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date";
+    return (
+      `INSERT INTO "${table}" (${columns}) ` +
+      `SELECT v.id, v.path, v.filename, v.message, v.author, v.size_bytes, v.project, v.description, v.agent, v.plugin_version, v.creation_date, v.last_update_date ` +
+      `FROM (VALUES ${joined}) AS v(${columns}) ` +
+      `WHERE NOT EXISTS (SELECT 1 FROM "${table}" AS t WHERE t.id = v.id)`
+    );
+  }
+
+  const selects = values.map((value, index) => {
+    const row = rows[index];
+    return `SELECT * FROM (VALUES ${value}) WHERE NOT EXISTS (SELECT 1 FROM "${table}" AS t WHERE t.id = '${sqlStr(row.id)}')`;
+  }).join(" UNION ALL ");
 
   // Idempotent batch insert: skip any row whose id already exists, so a flush
   // that re-sends the batch after a transient 5xx (the insert committed but the
   // gateway returned 502/503) cannot duplicate rows. The sessions table has no
   // UNIQUE constraint on id, so this anti-join is the multi-row equivalent of
   // buildDirectSessionInsertSql's `WHERE NOT EXISTS` guard on the single-row
-  // capture path. Verified lag-safe against the real backend.
+  // capture path. SELECT ... UNION ALL is portable across all three providers;
+  // SQLite does not support PostgreSQL's column alias list after VALUES.
   return (
     `INSERT INTO "${table}" (id, path, filename, message, author, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) ` +
-    `SELECT v.id, v.path, v.filename, v.message, v.author, v.size_bytes, v.project, v.description, v.agent, v.plugin_version, v.creation_date, v.last_update_date ` +
-    `FROM (VALUES ${values}) AS v(id, path, filename, message, author, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) ` +
-    `WHERE NOT EXISTS (SELECT 1 FROM "${table}" AS t WHERE t.id = v.id)`
+    selects
   );
 }
 
@@ -327,7 +349,7 @@ async function flushInflightFile(
   const queueDir = dirname(inflightPath);
   for (let i = 0; i < rows.length; i += maxBatchRows) {
     const chunk = rows.slice(i, i + maxBatchRows);
-    const sql = buildSessionInsertSql(sessionsTable, chunk);
+    const sql = buildSessionInsertSql(sessionsTable, chunk, api.dialect);
     try {
       await api.query(sql);
     } catch (e: any) {

--- a/src/hooks/session-start-setup.ts
+++ b/src/hooks/session-start-setup.ts
@@ -11,7 +11,7 @@ import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { loadCredentials, saveCredentials } from "../commands/auth.js";
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { readStdin } from "../utils/stdin.js";
 import { log as _log } from "../utils/debug.js";
 import { makeWikiLogger } from "../utils/wiki-log.js";
@@ -45,10 +45,12 @@ async function main(): Promise<void> {
   spawnDetachedNodeWorker(join(__bundleDir, "graph-deps-worker.js"));
 
   const creds = loadCredentials();
-  if (!creds?.token) { log("no credentials"); return; }
+  const storageConfig = loadRoutedConfig(input.cwd ?? process.cwd());
+  const storageAvailable = Boolean(storageConfig && ((storageConfig.storage?.kind ?? "deeplake") !== "deeplake" || creds?.token));
+  if (!storageAvailable) { log(creds?.token ? "no storage configuration" : "no credentials"); return; }
 
   // Backfill userName if missing
-  if (!creds.userName) {
+  if (creds && !creds.userName) {
     try {
       const { userInfo } = await import("node:os");
       creds.userName = userInfo().username ?? "unknown";
@@ -66,9 +68,9 @@ async function main(): Promise<void> {
 
   if (input.session_id) {
     try {
-      const config = loadRoutedConfig(input.cwd ?? process.cwd());
+      const config = storageConfig;
       if (config) {
-        const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
+        const api = createStorageBackend(config, config.tableName);
         await api.ensureTable();
         await api.ensureSessionsTable(config.sessionsTableName);
         log("setup complete");

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -3,7 +3,7 @@
 /**
  * SessionStart hook:
  * 1. If no credentials → run device flow login (opens browser)
- * 2. Inject Deeplake memory instructions into Claude's context
+ * 2. Inject Hivemind memory instructions into Claude's context
  */
 
 import { fileURLToPath } from "node:url";
@@ -15,7 +15,8 @@ import { homedir } from "node:os";
 import { loadCredentials, saveCredentials, healDriftedOrgToken } from "../commands/auth.js";
 import { loadConfig } from "../config.js";
 import { resolveDirConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { readStdin } from "../utils/stdin.js";
 import { log as _log } from "../utils/debug.js";
 import { getInstalledVersion } from "../utils/version-check.js";
@@ -40,12 +41,12 @@ const __bundleDir = dirname(fileURLToPath(import.meta.url));
 // — no per-agent path resolution needed. Marketplace-only installs without
 // `npm i -g @deeplake/hivemind` are unsupported (documented in README + RELEASE_CHECKLIST).
 
-const context = `DEEPLAKE MEMORY: You have TWO memory sources. ALWAYS check BOTH when the user asks you to recall, remember, or look up ANY information:
+const context = `HIVEMIND MEMORY: You have TWO memory sources. ALWAYS check BOTH when the user asks you to recall, remember, or look up ANY information:
 
 1. Your built-in memory (~/.claude/) — personal per-project notes
-2. Deeplake global memory (~/.deeplake/memory/) — global memory shared across all sessions, users, and agents in the org
+2. Hivemind shared memory (~/.deeplake/memory/) — persistent memory for the selected backend workspace
 
-Deeplake memory has THREE tiers — pick the right one for the question:
+Hivemind memory has THREE tiers — pick the right one for the question:
 1. ~/.deeplake/memory/index.md   — auto-generated index, top 50 most-recently-updated entries with \`Created\` + \`Last Updated\` + \`Project\` + \`Description\` columns. ~5 KB. **For "what's recent / who did X this week / since <date>" queries, START HERE** and trust the \`Last Updated\` column over any \`Started:\` line in summary bodies.
 2. ~/.deeplake/memory/summaries/ — condensed wiki summaries per session (~3 KB each). For keyword/topic recall, search these.
 3. ~/.deeplake/memory/sessions/  — raw full-dialogue JSONL (~5 KB each). FALLBACK only — use when summaries don't contain the exact quote/turn you need.
@@ -90,7 +91,7 @@ Embeddings (semantic memory search) — opt-in, persisted in ~/.deeplake/config.
 
 IMPORTANT: Only use bash commands (cat, ls, grep, echo, jq, head, tail, etc.) to interact with ~/.deeplake/memory/. Do NOT use python, python3, node, curl, or other interpreters — they are not available in the memory filesystem. Avoid bash brace expansions like \`{1..10}\` (not fully supported); spell out paths explicitly. Bash output is capped at 10MB total — avoid \`for f in *.json; do cat $f\` style loops on the whole sessions dir.
 
-LIMITS: Do NOT spawn subagents to read deeplake memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
+LIMITS: Do NOT spawn subagents to read Hivemind memory. If a file returns empty after 2 attempts, skip it and move on. Report what you found rather than exhaustively retrying.
 
 Debugging: Set HIVEMIND_DEBUG=1 to enable verbose logging to ~/.deeplake/hook-debug.log`;
 
@@ -103,10 +104,10 @@ const { log: wikiLog } = makeWikiLogger(join(HOME, ".claude", "hooks"));
  * finalized+embedded row is never reverted to an 'in progress' stub by a
  * resumed/concurrent SessionStart (the production clobber).
  */
-async function createPlaceholder(api: DeeplakeApi, table: string, sessionId: string, cwd: string, userName: string, orgName: string, workspaceId: string, pluginVersion: string): Promise<void> {
+async function createPlaceholder(api: StorageBackend, table: string, sessionId: string, cwd: string, userName: string, orgName: string, workspaceId: string, pluginVersion: string): Promise<void> {
   await createPlaceholderSummary(
     (sql) => api.query(sql),
-    { table, sessionId, cwd, userName, orgName, workspaceId, agent: "claude_code", pluginVersion },
+    { table, sessionId, cwd, userName, orgName, workspaceId, agent: "claude_code", pluginVersion, dialect: api.dialect },
     wikiLog,
   );
 }
@@ -202,6 +203,7 @@ async function main(): Promise<void> {
   // back to the global identity when no `.hivemind` applies.
   const sessionCwd = input.cwd ?? process.cwd();
   const baseConfig = loadConfig();
+  const storageAvailable = Boolean(baseConfig && ((baseConfig.storage?.kind ?? "deeplake") !== "deeplake" || creds?.token));
   const dirRes = baseConfig ? resolveDirConfig(baseConfig, sessionCwd) : null;
   const collectHere = captureEnabled && (dirRes?.collect ?? true);
 
@@ -217,13 +219,13 @@ async function main(): Promise<void> {
   log(`autopull: pulled=${pullResult.pulled} skipped=${pullResult.skipped}`);
 
   let rulesBlock = "";
-  if (input.session_id && creds?.token) {
+  if (input.session_id && storageAvailable) {
     try {
       const config = dirRes?.config;
       if (config) {
         const table = config.tableName;
         const sessionsTable = config.sessionsTableName;
-        const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, table);
+        const api = createStorageBackend(config, table);
         if (collectHere) {
           await api.ensureTable();
           await api.ensureSessionsTable(sessionsTable);
@@ -319,20 +321,22 @@ async function main(): Promise<void> {
   // the worker is fully detached.
   // Gate on creds: pullSnapshot would early-return "skipped-no-auth"
   // anyway, so spawning a worker without auth is wasted process churn.
-  if (creds?.token) spawnGraphPullWorker(input.cwd ?? process.cwd(), __bundleDir);
+  if (storageAvailable) spawnGraphPullWorker(input.cwd ?? process.cwd(), __bundleDir);
   const graphLine = graphContextLine(input.cwd ?? process.cwd());
   const graphNote = graphLine ?? "";
+
+  // Effective provider/identity after any Deeplake-only directory routing.
+  const effConfig = dirRes?.config ?? baseConfig;
 
   // Docs wiki note — the agent has no other way to learn the wiki exists.
   // Gated on the same local consent registry as auto sync (no network),
   // and worded on-demand, never wiki-first (see docs-context.ts).
-  const docsNote = creds?.token
-    ? docsWikiContextNote(creds.orgId ?? "", deriveProjectKey(input.cwd ?? process.cwd()).key)
+  const docsNote = storageAvailable && effConfig
+    ? docsWikiContextNote(effConfig.orgId ?? "", deriveProjectKey(input.cwd ?? process.cwd()).key)
     : "";
 
   // Disclose the EFFECTIVE identity (after any `.hivemind` overlay), so a
   // directory that routes elsewhere (or opts out) is never silent.
-  const effConfig = dirRes?.config ?? baseConfig;
   // NOT gated on `dirRes.collect`: the identity overlay now applies to reads
   // whether or not capture is on, so a `collect:false` directory can still be
   // routed — and must say so.
@@ -343,10 +347,13 @@ async function main(): Promise<void> {
   // `routed` covers reads AND capture — both resolve through the same overlay —
   // so the disclosure must never imply one moved without the other.
   const routedNote = routed ? ` · routed by ${dirRes?.found?.path}` : "";
-  const identityLine = dirRes && !dirRes.collect
-    ? `Deeplake capture is disabled for this directory (${dirRes.found?.path}); memory search uses org: ${effOrg} (workspace: ${effWs})${routedNote}`
-    : `Logged in to Deeplake as org: ${effOrg} (workspace: ${effWs})${routedNote}`;
-  const baseContext = creds?.token
+  const provider = effConfig?.storage?.kind ?? "deeplake";
+  const identityLine = provider === "deeplake"
+    ? (dirRes && !dirRes.collect
+        ? `Deeplake capture is disabled for this directory (${dirRes.found?.path}); memory search uses org: ${effOrg} (workspace: ${effWs})${routedNote}`
+        : `Logged in to Deeplake as org: ${effOrg} (workspace: ${effWs})${routedNote}`)
+    : `Hivemind memory backend: ${provider}${dirRes && !dirRes.collect ? ` · capture disabled by ${dirRes.found?.path}` : ""}`;
+  const baseContext = storageAvailable && effConfig
     ? `${resolvedContext}\n\n${identityLine}${updateNotice}`
     : `${resolvedContext}\n\nNot logged in to Deeplake; memory search is unavailable this session.${localMinedNote}${updateNotice}`;
   // Append the rules block when there's something to show, then

--- a/src/hooks/shared/autoupdate.ts
+++ b/src/hooks/shared/autoupdate.ts
@@ -58,6 +58,7 @@ import { existsSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import type { Credentials } from "../../commands/auth-creds.js";
 import { log as _log } from "../../utils/debug.js";
+import { getAutoupdateEnabled, readUserConfig } from "../../user-config.js";
 
 const log = (msg: string) => _log("autoupdate", msg);
 
@@ -185,8 +186,11 @@ export async function autoUpdate(
     log(`agent=${opts.agent} skip: Codex-managed install (${opts.bundleDir}); updates come via marketplace snapshots (${Date.now() - t0}ms)`);
     return;
   }
-  if (!creds?.token) { log(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`); return; }
-  if (creds.autoupdate === false) { log(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`); return; }
+  const provider = process.env.HIVEMIND_BACKEND ?? readUserConfig().storage?.provider ?? "deeplake";
+  if (provider === "deeplake" && !creds?.token) { log(`agent=${opts.agent} skip: no creds.token (${Date.now() - t0}ms)`); return; }
+  const userPreference = readUserConfig().autoupdate;
+  const autoupdateEnabled = userPreference ?? creds?.autoupdate ?? getAutoupdateEnabled();
+  if (!autoupdateEnabled) { log(`agent=${opts.agent} skip: autoupdate=false (${Date.now() - t0}ms)`); return; }
 
   const binaryPath = opts.hivemindBinaryPath !== undefined
     ? opts.hivemindBinaryPath

--- a/src/hooks/shared/context-renderer.ts
+++ b/src/hooks/shared/context-renderer.ts
@@ -3,7 +3,7 @@
  *
  * Produces the "HIVEMIND RULES" + "HIVEMIND GOALS" + "HOW-TO" block
  * that every agent's SessionStart hook (claude-code, codex, cursor,
- * hermes) appends to its own DEEPLAKE MEMORY context. One source of
+ * hermes) appends to its own HIVEMIND MEMORY context. One source of
  * truth lives here so a wording fix lands in one place; the per-agent
  * forks just import and concatenate.
  *

--- a/src/hooks/shared/placeholder-summary.ts
+++ b/src/hooks/shared/placeholder-summary.ts
@@ -42,6 +42,8 @@
 
 import { sqlStr } from "../../utils/sql.js";
 import { projectNameFromCwd } from "../../utils/project-name.js";
+import type { StorageDialect } from "../../deeplake-schema.js";
+import { escapedStringPrefix } from "../../storage/sql-dialect.js";
 
 /** Minimal query surface — matches DeeplakeApi.query / the worker `query` fn. */
 export type PlaceholderQueryFn = (sql: string) => Promise<Array<Record<string, unknown>>>;
@@ -56,6 +58,7 @@ export interface PlaceholderParams {
   /** Agent literal stored in the `agent` column: claude_code | codex | cursor | hermes. */
   agent: string;
   pluginVersion: string;
+  dialect?: StorageDialect;
   /** Override for the timestamp (testing). Defaults to now. */
   ts?: string;
   /** Override for randomUUID (testing). */
@@ -103,6 +106,7 @@ export function buildPlaceholderInsertSql(params: PlaceholderParams): { sql: str
   ].join("\n");
   const filename = `${sessionId}.md`;
   const sizeBytes = Buffer.byteLength(content, "utf-8");
+  const stringPrefix = escapedStringPrefix(params.dialect ?? "deeplake");
 
   // Single atomic statement: the row is created only when no row exists at this
   // path. Closes the SELECT-then-INSERT race that produced duplicate stubs
@@ -110,7 +114,7 @@ export function buildPlaceholderInsertSql(params: PlaceholderParams): { sql: str
   // existing row (placeholder or finalized) suppresses the write.
   const sql =
     `INSERT INTO "${table}" (id, path, filename, summary, author, mime_type, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) ` +
-    `SELECT '${uuid}', '${sqlStr(summaryPath)}', '${sqlStr(filename)}', E'${sqlStr(content)}', '${sqlStr(userName)}', 'text/markdown', ` +
+    `SELECT '${uuid}', '${sqlStr(summaryPath)}', '${sqlStr(filename)}', ${stringPrefix}'${sqlStr(content)}', '${sqlStr(userName)}', 'text/markdown', ` +
     `${sizeBytes}, '${sqlStr(projectName)}', '${PLACEHOLDER_DESCRIPTION}', '${sqlStr(agent)}', '${sqlStr(pluginVersion)}', '${now}', '${now}' ` +
     `WHERE NOT EXISTS (SELECT 1 FROM "${table}" WHERE path = '${sqlStr(summaryPath)}')`;
 

--- a/src/hooks/shared/recall-query.ts
+++ b/src/hooks/shared/recall-query.ts
@@ -12,6 +12,7 @@
 import { serializeFloat4Array } from "../../shell/grep-core.js";
 import { sqlStr } from "../../utils/sql.js";
 import type { RecallHit } from "./recall-format.js";
+import { scoreVectorRows, vectorScanLimit } from "../../storage/vector-search.js";
 
 // `summary` is selected alongside `description` so recall can inject a
 // high-signal EXCERPT (the ## Key Facts / ## Entities sections carry the
@@ -64,7 +65,26 @@ export async function recallTopHit(
     `FROM "${memoryTable}" WHERE ${filters.join(" AND ")} ` +
     `ORDER BY score DESC, ${TIE_BREAK} LIMIT ${Math.max(1, opts.limit ?? 3)}`;
 
-  return mapTopRow(await query(sql), "semantic");
+  try {
+    return mapTopRow(await query(sql), "semantic");
+  } catch (error) {
+    // SQLite and vanilla PostgreSQL intentionally have no vector operator.
+    // Preserve Deeplake's server path, but fall back to a bounded candidate
+    // scan when the provider rejects `<#>`.
+    const localFilters = [`path LIKE '/summaries/%'`, `summary_embedding IS NOT NULL`];
+    if (opts.project) localFilters.push(`project = '${sqlStr(opts.project)}'`);
+    if (opts.excludePath) localFilters.push(`path <> '${sqlStr(opts.excludePath)}'`);
+    const rows = await query(
+      `SELECT ${SELECT_COLS}, summary_embedding FROM "${memoryTable}" ` +
+        `WHERE ${localFilters.join(" AND ")} LIMIT ${vectorScanLimit()}`,
+    ).catch(() => { throw error; });
+    const scored = scoreVectorRows(rows, "summary_embedding", queryEmbedding)
+      .sort((a, b) => b.score - a.score ||
+        String(b.row.last_update_date ?? "").localeCompare(String(a.row.last_update_date ?? "")) ||
+        String(a.row.path ?? "").localeCompare(String(b.row.path ?? "")));
+    if (scored.length === 0) return null;
+    return mapTopRow([{ ...scored[0].row, score: scored[0].score }], "semantic");
+  }
 }
 
 function mapTopRow(rows: Array<Record<string, unknown>>, mode: "semantic"): RecallHit | null {

--- a/src/hooks/shared/session-insert-sql.ts
+++ b/src/hooks/shared/session-insert-sql.ts
@@ -1,4 +1,6 @@
 import { sqlIdent, sqlStr } from "../../utils/sql.js";
+import type { StorageDialect } from "../../deeplake-schema.js";
+import { jsonLiteral } from "../../storage/sql-dialect.js";
 
 /**
  * Fields for one session-event row written by the capture hooks. All string
@@ -43,12 +45,16 @@ export interface DirectSessionInsertParams {
  * still recognised by isSessionInsertQuery() in deeplake-api.ts (which enables
  * the transient-403 retry path for session writes).
  */
-export function buildDirectSessionInsertSql(sessionsTable: string, p: DirectSessionInsertParams): string {
+export function buildDirectSessionInsertSql(
+  sessionsTable: string,
+  p: DirectSessionInsertParams,
+  dialect: StorageDialect = "deeplake",
+): string {
   const table = sqlIdent(sessionsTable);
   const id = sqlStr(p.id);
   return (
     `INSERT INTO "${table}" (id, path, filename, message, message_embedding, author, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) ` +
-    `SELECT '${id}', '${sqlStr(p.sessionPath)}', '${sqlStr(p.filename)}', '${p.jsonForSql}'::jsonb, ${p.embeddingSql}, '${sqlStr(p.userName)}', ` +
+    `SELECT '${id}', '${sqlStr(p.sessionPath)}', '${sqlStr(p.filename)}', ${jsonLiteral(p.jsonForSql, dialect)}, ${p.embeddingSql}, '${sqlStr(p.userName)}', ` +
     `${p.sizeBytes}, '${sqlStr(p.projectName)}', '${sqlStr(p.description)}', '${sqlStr(p.agent)}', '${sqlStr(p.pluginVersion)}', '${sqlStr(p.timestamp)}', '${sqlStr(p.timestamp)}' ` +
     `WHERE NOT EXISTS (SELECT 1 FROM "${table}" WHERE id = '${id}')`
   );

--- a/src/hooks/spawn-wiki-worker.ts
+++ b/src/hooks/spawn-wiki-worker.ts
@@ -104,10 +104,11 @@ export function spawnWikiWorker(opts: SpawnOptions): void {
 
   const configFile = join(tmpDir, "config.json");
   writeFileSync(configFile, JSON.stringify({
-    apiUrl: config.apiUrl,
-    token: config.token,
-    orgId: config.orgId,
-    workspaceId: config.workspaceId,
+    storage: {
+      kind: config.storage?.kind ?? "deeplake",
+      orgId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.orgId : undefined,
+      workspaceId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.workspaceId : undefined,
+    },
     memoryTable: config.tableName,
     sessionsTable: config.sessionsTableName,
     sessionId,

--- a/src/hooks/upload-summary.ts
+++ b/src/hooks/upload-summary.ts
@@ -11,6 +11,8 @@
 import { randomUUID } from "node:crypto";
 import { embeddingSqlLiteral } from "../embeddings/sql.js";
 import { redactSecrets } from "./shared/redact.js";
+import type { StorageDialect } from "../deeplake-schema.js";
+import { escapedStringPrefix } from "../storage/sql-dialect.js";
 
 export type QueryFn = (sql: string) => Promise<Array<Record<string, unknown>>>;
 
@@ -31,6 +33,8 @@ export interface UploadParams {
    * retrieval branch, it just won't show up in the semantic branch.
    */
   embedding?: number[] | null;
+  /** Dialect used by the detached worker's selected storage backend. */
+  dialect?: StorageDialect;
   /**
    * Hivemind plugin version that produced this summary.
    * - INSERT: omitted lands the column default (''), schema-compatible.
@@ -131,7 +135,9 @@ export async function uploadSummary(query: QueryFn, params: UploadParams): Promi
   const ts = params.ts ?? new Date().toISOString();
   const desc = extractDescription(text);
   const sizeBytes = Buffer.byteLength(text);
-  const embSql = embeddingSqlLiteral(params.embedding ?? null);
+  const dialect = params.dialect ?? "deeplake";
+  const embSql = embeddingSqlLiteral(params.embedding ?? null, dialect);
+  const stringPrefix = escapedStringPrefix(dialect);
   // Keep undefined sentinel for UPDATE conditional. INSERT still defaults to ''.
   const pluginVersion = params.pluginVersion;
 
@@ -166,10 +172,10 @@ export async function uploadSummary(query: QueryFn, params: UploadParams): Promi
       : `plugin_version = '${esc(pluginVersion)}', `;
     const sql =
       `UPDATE "${tableName}" SET ` +
-      `summary = E'${esc(text)}', ` +
+      `summary = ${stringPrefix}'${esc(text)}', ` +
       `summary_embedding = ${embSql}, ` +
       `size_bytes = ${sizeBytes}, ` +
-      `description = E'${esc(desc)}', ` +
+      `description = ${stringPrefix}'${esc(desc)}', ` +
       pluginVersionSet +
       `last_update_date = '${ts}' ` +
       `WHERE path = '${esc(vpath)}'`;
@@ -181,8 +187,8 @@ export async function uploadSummary(query: QueryFn, params: UploadParams): Promi
   const pluginVersionForInsert = pluginVersion ?? "";
   const sql =
     `INSERT INTO "${tableName}" (id, path, filename, summary, summary_embedding, author, mime_type, size_bytes, project, description, agent, plugin_version, creation_date, last_update_date) ` +
-    `VALUES ('${randomUUID()}', '${esc(vpath)}', '${esc(fname)}', E'${esc(text)}', ${embSql}, '${esc(userName)}', 'text/markdown', ` +
-    `${sizeBytes}, '${esc(project)}', E'${esc(desc)}', '${esc(agent)}', '${esc(pluginVersionForInsert)}', '${ts}', '${ts}')`;
+    `VALUES ('${randomUUID()}', '${esc(vpath)}', '${esc(fname)}', ${stringPrefix}'${esc(text)}', ${embSql}, '${esc(userName)}', 'text/markdown', ` +
+    `${sizeBytes}, '${esc(project)}', ${stringPrefix}'${esc(desc)}', '${esc(agent)}', '${esc(pluginVersionForInsert)}', '${ts}', '${ts}')`;
   await query(sql);
   return { path: "insert", sql, descLength: desc.length, summaryLength: text.length };
 }

--- a/src/hooks/virtual-table-query.ts
+++ b/src/hooks/virtual-table-query.ts
@@ -1,6 +1,7 @@
-import type { DeeplakeApi } from "../deeplake-api.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { sqlLike, sqlStr } from "../utils/sql.js";
 import { normalizeContent, emptySessionBodyNotice } from "../shell/grep-core.js";
+import { nullExpression, textExpression } from "../storage/sql-dialect.js";
 
 type Row = Record<string, unknown>;
 
@@ -121,7 +122,7 @@ function buildDirFilter(dirs: string[]): string {
 }
 
 async function queryUnionRows(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryQuery: string,
   sessionsQuery: string,
 ): Promise<Row[]> {
@@ -147,7 +148,7 @@ async function queryUnionRows(
 }
 
 export async function readVirtualPathContents(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryTable: string,
   sessionsTable: string,
   virtualPaths: string[],
@@ -157,10 +158,13 @@ export async function readVirtualPathContents(
   if (uniquePaths.length === 0) return result;
 
   const inList = buildInList(uniquePaths);
+  const textSummary = textExpression("summary", api.dialect);
+  const textMessage = textExpression("message", api.dialect);
+  const nullBigint = nullExpression("bigint", api.dialect);
   const rows = await queryUnionRows(
     api,
-    `SELECT path, summary::text AS content, NULL::bigint AS size_bytes, '' AS creation_date, 0 AS source_order FROM "${memoryTable}" WHERE path IN (${inList})`,
-    `SELECT path, message::text AS content, NULL::bigint AS size_bytes, COALESCE(creation_date::text, '') AS creation_date, 1 AS source_order FROM "${sessionsTable}" WHERE path IN (${inList})`,
+    `SELECT path, ${textSummary} AS content, ${nullBigint} AS size_bytes, '' AS creation_date, 0 AS source_order FROM "${memoryTable}" WHERE path IN (${inList})`,
+    `SELECT path, ${textMessage} AS content, ${nullBigint} AS size_bytes, COALESCE(${textExpression("creation_date", api.dialect)}, '') AS creation_date, 1 AS source_order FROM "${sessionsTable}" WHERE path IN (${inList})`,
   );
 
   const memoryHits = new Map<string, string>();
@@ -246,17 +250,18 @@ export async function readVirtualPathContents(
 }
 
 export async function listVirtualPathRowsForDirs(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryTable: string,
   sessionsTable: string,
   dirs: string[],
 ): Promise<Map<string, Row[]>> {
   const uniqueDirs = [...new Set(dirs.map(dir => dir.replace(/\/+$/, "") || "/"))];
   const filter = buildDirFilter(uniqueDirs);
+  const nullText = nullExpression("text", api.dialect);
   const rows = await queryUnionRows(
     api,
-    `SELECT path, NULL::text AS content, size_bytes, '' AS creation_date, 0 AS source_order FROM "${memoryTable}"${filter}`,
-    `SELECT path, NULL::text AS content, size_bytes, '' AS creation_date, 1 AS source_order FROM "${sessionsTable}"${filter}`,
+    `SELECT path, ${nullText} AS content, size_bytes, '' AS creation_date, 0 AS source_order FROM "${memoryTable}"${filter}`,
+    `SELECT path, ${nullText} AS content, size_bytes, '' AS creation_date, 1 AS source_order FROM "${sessionsTable}"${filter}`,
   );
 
   const deduped = dedupeRowsByPath(rows.map((row) => ({
@@ -280,7 +285,7 @@ export async function listVirtualPathRowsForDirs(
 }
 
 export async function readVirtualPathContent(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryTable: string,
   sessionsTable: string,
   virtualPath: string,
@@ -289,7 +294,7 @@ export async function readVirtualPathContent(
 }
 
 export async function listVirtualPathRows(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryTable: string,
   sessionsTable: string,
   dir: string,
@@ -298,7 +303,7 @@ export async function listVirtualPathRows(
 }
 
 export async function findVirtualPaths(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryTable: string,
   sessionsTable: string,
   dir: string,
@@ -306,10 +311,12 @@ export async function findVirtualPaths(
 ): Promise<string[]> {
   const normalizedDir = dir.replace(/\/+$/, "") || "/";
   const likePath = `${sqlLike(normalizedDir === "/" ? "" : normalizedDir)}/%`;
+  const nullText = nullExpression("text", api.dialect);
+  const nullBigint = nullExpression("bigint", api.dialect);
   const rows = await queryUnionRows(
     api,
-    `SELECT path, NULL::text AS content, NULL::bigint AS size_bytes, '' AS creation_date, 0 AS source_order FROM "${memoryTable}" WHERE path LIKE '${likePath}' ESCAPE '\\' AND filename LIKE '${filenamePattern}' ESCAPE '\\'`,
-    `SELECT path, NULL::text AS content, NULL::bigint AS size_bytes, '' AS creation_date, 1 AS source_order FROM "${sessionsTable}" WHERE path LIKE '${likePath}' ESCAPE '\\' AND filename LIKE '${filenamePattern}' ESCAPE '\\'`,
+    `SELECT path, ${nullText} AS content, ${nullBigint} AS size_bytes, '' AS creation_date, 0 AS source_order FROM "${memoryTable}" WHERE path LIKE '${likePath}' ESCAPE '\\' AND filename LIKE '${filenamePattern}' ESCAPE '\\'`,
+    `SELECT path, ${nullText} AS content, ${nullBigint} AS size_bytes, '' AS creation_date, 1 AS source_order FROM "${sessionsTable}" WHERE path LIKE '${likePath}' ESCAPE '\\' AND filename LIKE '${filenamePattern}' ESCAPE '\\'`,
   );
 
   return [...new Set(

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -13,7 +13,7 @@ import { buildClaudeInvocation } from "./wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { utcTimestamp, log as _log } from "../utils/debug.js";
-import { deeplakeClientHeader } from "../utils/client-header.js";
+import { createWorkerStorage, queryWorkerStorage } from "./worker-storage.js";
 
 const dlog = (msg: string) => _log("wiki-worker", msg);
 import { finalizeSummary, releaseLock, readState } from "./summary-state.js";
@@ -26,9 +26,10 @@ import { embedSummaryWithWarmup } from "../embeddings/embed-summary.js";
 import { embeddingsDisabled } from "../embeddings/disable.js";
 
 interface WorkerConfig {
-  apiUrl: string;
-  token: string;
-  orgId: string;
+  storage?: { kind: "deeplake" | "sqlite" | "postgres"; orgId?: string; workspaceId?: string };
+  apiUrl?: string;
+  token?: string;
+  orgId?: string;
   workspaceId: string;
   memoryTable: string;
   sessionsTable: string;
@@ -85,45 +86,8 @@ const EVENT_FETCH_RETRIES = parseNonNegativeInt(process.env.HIVEMIND_WIKI_EVENT_
 const EVENT_FETCH_BACKOFF_MS = parseNonNegativeInt(process.env.HIVEMIND_WIKI_EVENT_BACKOFF_MS, 1500);
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
-async function query(sql: string, retries = 4): Promise<Record<string, unknown>[]> {
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    const r = await fetch(`${cfg.apiUrl}/workspaces/${cfg.workspaceId}/tables/query`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${cfg.token}`,
-        "Content-Type": "application/json",
-        "X-Activeloop-Org-Id": cfg.orgId,
-        ...deeplakeClientHeader(),
-      },
-      body: JSON.stringify({ query: sql }),
-    });
-    if (r.ok) {
-      const j = await r.json() as { columns?: string[]; rows?: unknown[][] };
-      if (!j.columns || !j.rows) return [];
-      return j.rows.map(row =>
-        Object.fromEntries(j.columns!.map((col, i) => [col, row[i]]))
-      );
-    }
-    // 403 can arrive as a CloudFlare/nginx HTML page when the shared IP
-    // hits a transient rate limit (claude -p or codex exec bursts while
-    // the worker is running), and 401 shows up when the upstream auth
-    // cache expires. Treat both as retryable with exponential backoff.
-    const retryable = r.status === 401 || r.status === 403 ||
-      r.status === 429 || r.status === 500 || r.status === 502 || r.status === 503;
-    if (attempt < retries && retryable) {
-      // Exponential backoff with jitter — Cloudflare/nginx 403s from IP
-      // rate limiting (claude -p or codex exec bursts) can take 30-60 s
-      // to clear.
-      const base = Math.min(30_000, 2000 * Math.pow(2, attempt));
-      const delay = base + Math.floor(Math.random() * 1000);
-      wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise(resolve => setTimeout(resolve, delay));
-      continue;
-    }
-    throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
-  }
-  return [];
-}
+const storageBackend = createWorkerStorage(cfg, wlog);
+const query = (sql: string): Promise<Record<string, unknown>[]> => queryWorkerStorage(storageBackend, sql);
 
 function cleanup(): void {
   try {
@@ -382,6 +346,7 @@ async function main(): Promise<void> {
           sessionId: cfg.sessionId,
           text,
           embedding,
+          dialect: cfg.storage?.kind ?? "deeplake",
           pluginVersion: cfg.pluginVersion ?? "",
         });
         wlog(`uploaded ${vpath} (summary=${result.summaryLength}, desc=${result.descLength})`);
@@ -401,6 +366,7 @@ async function main(): Promise<void> {
   } catch (e: any) {
     wlog(`fatal: ${e.message}`);
   } finally {
+    await storageBackend.close().catch(() => undefined);
     cleanup();
     try {
       releaseLock(cfg.sessionId);

--- a/src/hooks/worker-storage.ts
+++ b/src/hooks/worker-storage.ts
@@ -1,0 +1,87 @@
+import {
+  configFromStorage,
+  loadConfig,
+  type Config,
+  type DeeplakeStorageConfig,
+  type StorageProvider,
+} from "../config.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
+import { DeeplakeApi } from "../deeplake-api.js";
+
+export interface WorkerStorageMetadata {
+  storage?: {
+    kind: StorageProvider;
+    orgId?: string;
+    workspaceId?: string;
+  };
+  memoryTable?: string;
+  sessionsTable: string;
+  /** Legacy handoff fields, accepted only for old installed bundles/tests. */
+  apiUrl?: string;
+  token?: string;
+  orgId?: string;
+  workspaceId?: string;
+  userName: string;
+}
+
+function legacyConfig(metadata: WorkerStorageMetadata): Config | null {
+  if (!metadata.token || !metadata.apiUrl || !metadata.orgId || !metadata.workspaceId) return null;
+  const storage: DeeplakeStorageConfig = {
+    kind: "deeplake",
+    token: metadata.token,
+    apiUrl: metadata.apiUrl,
+    orgId: metadata.orgId,
+    orgName: metadata.orgId,
+    userName: metadata.userName,
+    workspaceId: metadata.workspaceId,
+    tableName: metadata.memoryTable ?? "memory",
+    sessionsTableName: metadata.sessionsTable,
+    skillsTableName: "skills",
+    rulesTableName: "hivemind_rules",
+    goalsTableName: "hivemind_goals",
+    kpisTableName: "hivemind_kpis",
+    docsTableName: "hivemind_docs",
+    codebaseTableName: "codebase",
+    memoryPath: "",
+    vectorScanLimit: 2000,
+  };
+  return configFromStorage(storage);
+}
+
+/** Reload credentials/URLs in the detached process; handoffs contain metadata only. */
+export function createWorkerStorage(
+  metadata: WorkerStorageMetadata,
+  retryLogger?: (message: string) => void,
+): StorageBackend {
+  let config = legacyConfig(metadata) ?? loadConfig();
+  if (!config) throw new Error("Storage configuration is unavailable in worker");
+
+  if (config.storage?.kind === "deeplake" && metadata.storage?.kind === "deeplake") {
+    config = {
+      ...config,
+      orgId: metadata.storage.orgId ?? config.orgId,
+      workspaceId: metadata.storage.workspaceId ?? config.workspaceId,
+      storage: {
+        ...config.storage,
+        orgId: metadata.storage.orgId ?? config.storage.orgId,
+        workspaceId: metadata.storage.workspaceId ?? config.storage.workspaceId,
+      },
+    };
+  }
+  const backend = createStorageBackend(config, metadata.memoryTable ?? config.tableName);
+  if (backend instanceof DeeplakeApi && retryLogger) backend.configureWorkerRetries(retryLogger);
+  return backend;
+}
+
+export async function queryWorkerStorage(
+  backend: StorageBackend,
+  sql: string,
+): Promise<Record<string, unknown>[]> {
+  try {
+    return await backend.query(sql);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(message.replace(/^Query failed:\s*/, "API "));
+  }
+}

--- a/src/mcp/cowork-ingest.ts
+++ b/src/mcp/cowork-ingest.ts
@@ -35,7 +35,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { loadCredentials } from "../commands/auth.js";
 import { loadConfig, type Config } from "../config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { claudeDesktopConfigDir } from "../cli/util.js";
 import { getVersion } from "../cli/version.js";
 import {
@@ -68,7 +68,7 @@ const LOCK_HEARTBEAT_MS = 20_000;
 const SUMMARY_IDLE_MS = 5 * 60_000;
 
 const DATA_NOTICE =
-  "ℹ️ Hivemind data notice: this Cowork session is being saved to your team's shared Deeplake memory " +
+  "ℹ️ Hivemind data notice: this Cowork session is being saved to your team's shared Hivemind memory " +
   "(your prompts, the assistant's responses, and tool calls) so agents and teammates can recall it later. " +
   "Everyone in your Deeplake workspace can read it. To turn capture off, set HIVEMIND_CAPTURE=false. " +
   "(This notice is shown once.)";
@@ -354,9 +354,11 @@ export async function ingestCoworkSessions(): Promise<{ ingested: number } | { s
   if (!existsSync(root)) return { skipped: "no-cowork-sessions" };
 
   const creds = loadCredentials();
-  if (!creds?.token) return { skipped: "not-authenticated" };
   const config = loadConfig();
   if (!config) return { skipped: "no-config" };
+  if ((config.storage?.kind ?? "deeplake") === "deeplake" && !creds?.token) {
+    return { skipped: "not-authenticated" };
+  }
 
   const release = tryAcquireLock();
   if (!release) return { skipped: "busy" };
@@ -405,17 +407,15 @@ export async function ingestCoworkSessions(): Promise<{ ingested: number } | { s
     }
 
     if (appendedAny) {
-      const api = new DeeplakeApi(
-        config.token,
-        config.apiUrl,
-        config.orgId,
-        config.workspaceId,
-        config.sessionsTableName,
-      );
-      await drainSessionQueues(api, {
-        sessionsTable: config.sessionsTableName,
-        queueDir: COWORK_QUEUE_DIR,
-      });
+      const api = createStorageBackend(config, config.sessionsTableName);
+      try {
+        await drainSessionQueues(api, {
+          sessionsTable: config.sessionsTableName,
+          queueDir: COWORK_QUEUE_DIR,
+        });
+      } finally {
+        await api.close();
+      }
       // Persist the line watermark immediately after the upload, before the
       // slow summarize step below. Rows carry random ids, so a crash between
       // the insert and a later saveState would replay these lines under fresh

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,9 +17,11 @@
 import * as z from "zod/v3";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { loadCredentials } from "../commands/auth.js";
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { loadCredentials } from "../commands/auth.js";
+import { readUserConfig } from "../user-config.js";
+import { createStorageBackend } from "../storage/factory.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { isMissingTableError } from "../deeplake-schema.js";
 import { sqlStr, sqlLike } from "../utils/sql.js";
 import { searchDeeplakeTables, searchDocs, buildGrepSearchOptions, normalizeContent, TRUNCATION_NOTICE, type GrepMatchParams } from "../shell/grep-core.js";
@@ -27,25 +29,39 @@ import { deriveProjectKey } from "../utils/repo-identity.js";
 import { makeQueryEmbedder } from "../docs/embed.js";
 import { getVersion } from "../cli/version.js";
 import { startCoworkIngestLoop, coworkDataNoticeOnce } from "./cowork-ingest.js";
+import { textExpression } from "../storage/sql-dialect.js";
 
 interface ServerContext {
-  api: DeeplakeApi;
+  api: StorageBackend;
   memoryTable: string;
   sessionsTable: string;
   docsTable: string;
 }
 
+let cachedContext: ServerContext | null = null;
+
 function getContext(): ServerContext | { error: string } {
-  const creds = loadCredentials();
-  if (!creds?.token) {
-    return { error: "Not authenticated. Run `hivemind login` to sign in to Deeplake." };
-  }
+  if (cachedContext) return cachedContext;
   const config = loadRoutedConfig();
   if (!config) {
-    return { error: "Hivemind config could not be loaded — credentials present but invalid." };
+    const provider = process.env.HIVEMIND_BACKEND ?? readUserConfig().storage?.provider ?? "deeplake";
+    if (provider === "deeplake" && !loadCredentials()) {
+      return { error: "Not authenticated. Run `hivemind login` first." };
+    }
+    if (provider === "deeplake") {
+      return { error: "Hivemind config could not be loaded." };
+    }
+    return { error: "Hivemind storage is not configured. Run `hivemind backend status`." };
   }
-  const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
-  return { api, memoryTable: config.tableName, sessionsTable: config.sessionsTableName, docsTable: config.docsTableName };
+  // Legacy callers supplied a Deeplake-shaped Config after a separate
+  // credentials check. Preserve that contract while provider-aware configs
+  // can authenticate from either credentials or environment variables.
+  if (!config.storage && !loadCredentials()) {
+    return { error: "Not authenticated. Run `hivemind login` first." };
+  }
+  const api = createStorageBackend(config, config.tableName);
+  cachedContext = { api, memoryTable: config.tableName, sessionsTable: config.sessionsTableName, docsTable: config.docsTableName };
+  return cachedContext;
 }
 
 function errorResult(text: string): { content: Array<{ type: "text"; text: string }> } {
@@ -147,7 +163,7 @@ server.registerTool(
     opts.queryEmbedding = await makeQueryEmbedder()(query);
 
     try {
-      const rows = await searchDocs((sql) => ctx.api.query(sql), ctx.docsTable, opts);
+      const rows = await searchDocs((sql) => ctx.api.query(sql), ctx.docsTable, opts, ctx.api.dialect);
       if (rows.length === 0) return errorResult(`No docs match "${query}".`);
       const lines = rows.map(r => `[${r.path}]\n${r.content.slice(0, 600)}`);
       return { content: [{ type: "text", text: lines.join("\n\n---\n\n") }] };
@@ -177,7 +193,7 @@ server.registerTool(
 
     const isSession = path.startsWith("/sessions/");
     const table = isSession ? ctx.sessionsTable : ctx.memoryTable;
-    const column = isSession ? "message::text" : "summary::text";
+    const column = textExpression(isSession ? "message" : "summary", ctx.api.dialect);
 
     try {
       const sql = `SELECT path, ${column} AS content FROM "${table}" WHERE path = '${sqlStr(path)}' LIMIT 200`;

--- a/src/notifications/AGENT_CHANNELS.md
+++ b/src/notifications/AGENT_CHANNELS.md
@@ -69,7 +69,7 @@ Empirical evidence preserved in the session JSONL captured by the probe — see 
 ```
 • SessionStart hook (completed)
   warning: 💡 5 skills mined from your local sessions live in ~/.claude/skills/. Run 'hivemind login' to share them with your team.
-  hook context: DEEPLAKE MEMORY: ...
+  hook context: HIVEMIND MEMORY: ...
 ```
 
 **v1 implication:** Codex has the SAME systemMessage user-visible channel as Claude Code. `src/hooks/codex/session-start.ts` was migrated from plain-text stdout to JSON output mirroring CC's dual-channel shape. No shared `delivery/codex.ts` adapter needed — the hook itself emits the JSON.

--- a/src/rules/write.ts
+++ b/src/rules/write.ts
@@ -14,6 +14,8 @@ import { randomUUID } from "node:crypto";
 import { sqlIdent, sqlStr } from "../utils/sql.js";
 import type { RuleRow } from "./read.js";
 import { getRuleLatest } from "./read.js";
+import type { StorageDialect } from "../deeplake-schema.js";
+import { escapedStringPrefix } from "../storage/sql-dialect.js";
 
 export type QueryFn = (sql: string) => Promise<Array<Record<string, unknown>>>;
 
@@ -85,6 +87,7 @@ export async function insertRule(
   query: QueryFn,
   tableName: string,
   input: InsertRuleInput,
+  dialect: StorageDialect = "deeplake",
 ): Promise<WriteResult> {
   assertValidText(input.text);
   const safe = sqlIdent(tableName);
@@ -100,7 +103,7 @@ export async function insertRule(
     `VALUES (` +
     `'${sqlStr(rowId)}', ` +
     `'${sqlStr(ruleId)}', ` +
-    `E'${sqlStr(input.text)}', ` +
+    `${escapedStringPrefix(dialect)}'${sqlStr(input.text)}', ` +
     `'team', ` +
     `'active', ` +
     `'${sqlStr(input.assigned_by)}', ` +
@@ -122,6 +125,7 @@ export async function editRule(
   query: QueryFn,
   tableName: string,
   input: EditRuleInput,
+  dialect: StorageDialect = "deeplake",
 ): Promise<WriteResult> {
   const previous = await getRuleLatest(query, tableName, input.rule_id);
   if (!previous) {
@@ -133,7 +137,7 @@ export async function editRule(
     assigned_by: input.assigned_by,
     agent: input.agent,
     plugin_version: input.plugin_version,
-  });
+  }, dialect);
 }
 
 /**
@@ -146,8 +150,9 @@ export async function markRuleDone(
   query: QueryFn,
   tableName: string,
   input: { rule_id: string; assigned_by: string; agent?: string; plugin_version?: string },
+  dialect: StorageDialect = "deeplake",
 ): Promise<WriteResult> {
-  return editRule(query, tableName, { ...input, status: "done" });
+  return editRule(query, tableName, { ...input, status: "done" }, dialect);
 }
 
 interface AppendInput {
@@ -163,6 +168,7 @@ async function appendVersion(
   tableName: string,
   previous: RuleRow,
   next: AppendInput,
+  dialect: StorageDialect,
 ): Promise<WriteResult> {
   assertValidText(next.text);
   const safe = sqlIdent(tableName);
@@ -178,7 +184,7 @@ async function appendVersion(
     `VALUES (` +
     `'${sqlStr(rowId)}', ` +
     `'${sqlStr(previous.rule_id)}', ` +
-    `E'${sqlStr(next.text)}', ` +
+    `${escapedStringPrefix(dialect)}'${sqlStr(next.text)}', ` +
     `'team', ` +
     `'${sqlStr(next.status)}', ` +
     `'${sqlStr(next.assigned_by)}', ` +

--- a/src/shell/deeplake-fs.ts
+++ b/src/shell/deeplake-fs.ts
@@ -2,7 +2,7 @@ import { basename, posix } from "node:path";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { DeeplakeApi } from "../deeplake-api.js";
+import type { StorageBackend } from "../storage/backend.js";
 import type {
   IFileSystem, FsStat, MkdirOptions, RmOptions, CpOptions,
   FileContent, BufferEncoding,
@@ -11,6 +11,7 @@ import { normalizeContent, emptySessionBodyNotice } from "./grep-core.js";
 import { readSessionEventCache } from "../hooks/session-event-cache.js";
 import { EmbedClient } from "../embeddings/client.js";
 import { embeddingSqlLiteral } from "../embeddings/sql.js";
+import { escapedStringPrefix } from "../storage/sql-dialect.js";
 import { embeddingsDisabled } from "../embeddings/disable.js";
 import { buildVirtualIndexContent, INDEX_LIMIT_PER_SECTION } from "../hooks/virtual-table-query.js";
 import {
@@ -234,7 +235,7 @@ export class DeeplakeFs implements IFileSystem {
   private embedClient: EmbedClient | null = null;
 
   private constructor(
-    private readonly client: DeeplakeApi,
+    private readonly client: StorageBackend,
     private readonly table: string,
     readonly mountPoint: string,
   ) {
@@ -243,7 +244,7 @@ export class DeeplakeFs implements IFileSystem {
   }
 
   static async create(
-    client: DeeplakeApi,
+    client: StorageBackend,
     table: string,
     mount = "/memory",
     sessionsTable?: string,
@@ -441,7 +442,7 @@ export class DeeplakeFs implements IFileSystem {
 
     const embeddings = await this.computeEmbeddings(rows);
 
-    // Upsert in parallel — the semaphore in DeeplakeApi.query() handles concurrency.
+    // Upsert in parallel — each backend applies its own concurrency controls.
     // Re-queue any rows that failed so they are retried on the next flush.
     const results = await Promise.allSettled(rows.map((r, i) => this.upsertRow(r, embeddings[i])));
     let failures = 0;
@@ -497,9 +498,10 @@ export class DeeplakeFs implements IFileSystem {
     const ts = new Date().toISOString();
     const cd = r.creationDate ?? ts;
     const lud = r.lastUpdateDate ?? ts;
-    const embSql = embeddingSqlLiteral(embedding);
+    const embSql = embeddingSqlLiteral(embedding, this.client.dialect);
+    const stringPrefix = escapedStringPrefix(this.client.dialect);
     if (this.flushed.has(r.path)) {
-      let setClauses = `filename = '${fname}', summary = E'${text}', summary_embedding = ${embSql}, ` +
+      let setClauses = `filename = '${fname}', summary = ${stringPrefix}'${text}', summary_embedding = ${embSql}, ` +
         `mime_type = '${mime}', size_bytes = ${r.sizeBytes}, last_update_date = '${esc(lud)}'`;
       if (r.project !== undefined) setClauses += `, project = '${esc(r.project)}'`;
       if (r.description !== undefined) setClauses += `, description = '${esc(r.description)}'`;
@@ -511,7 +513,7 @@ export class DeeplakeFs implements IFileSystem {
       const cols = "id, path, filename, summary, summary_embedding, mime_type, size_bytes, creation_date, last_update_date" +
         (r.project !== undefined ? ", project" : "") +
         (r.description !== undefined ? ", description" : "");
-      const vals = `'${id}', '${p}', '${fname}', E'${text}', ${embSql}, '${mime}', ${r.sizeBytes}, '${esc(cd)}', '${esc(lud)}'` +
+      const vals = `'${id}', '${p}', '${fname}', ${stringPrefix}'${text}', ${embSql}, '${mime}', ${r.sizeBytes}, '${esc(cd)}', '${esc(lud)}'` +
         (r.project !== undefined ? `, '${esc(r.project)}'` : "") +
         (r.description !== undefined ? `, '${esc(r.description)}'` : "");
       await this.client.query(
@@ -555,7 +557,7 @@ export class DeeplakeFs implements IFileSystem {
         `UPDATE "${safe}" SET ` +
         `owner = '${esc(parts.owner)}', ` +
         `status = '${esc(parts.status)}', ` +
-        `content = E'${esc(r.contentText)}', ` +
+        `content = ${escapedStringPrefix(this.client.dialect)}'${esc(r.contentText)}', ` +
         `updated_at = '${esc(updatedAt)}' ` +
         `WHERE goal_id = '${esc(parts.goal_id)}'`
       );
@@ -567,7 +569,7 @@ export class DeeplakeFs implements IFileSystem {
         `'${esc(parts.goal_id)}', ` +
         `'${esc(parts.owner)}', ` +
         `'${esc(parts.status)}', ` +
-        `E'${esc(r.contentText)}', ` +
+        `${escapedStringPrefix(this.client.dialect)}'${esc(r.contentText)}', ` +
         `1, ` +
         `'${esc(createdAt)}', ` +
         `'${esc(updatedAt)}', ` +
@@ -602,7 +604,7 @@ export class DeeplakeFs implements IFileSystem {
       // (created_at ASC). Edit time goes to updated_at.
       await this.client.query(
         `UPDATE "${safe}" SET ` +
-        `content = E'${esc(r.contentText)}', ` +
+        `content = ${escapedStringPrefix(this.client.dialect)}'${esc(r.contentText)}', ` +
         `updated_at = '${esc(updatedAt)}' ` +
         `WHERE goal_id = '${esc(parts.goal_id)}' AND kpi_id = '${esc(parts.kpi_id)}'`
       );
@@ -613,7 +615,7 @@ export class DeeplakeFs implements IFileSystem {
         `'${id}', ` +
         `'${esc(parts.goal_id)}', ` +
         `'${esc(parts.kpi_id)}', ` +
-        `E'${esc(r.contentText)}', ` +
+        `${escapedStringPrefix(this.client.dialect)}'${esc(r.contentText)}', ` +
         `1, ` +
         `'${esc(createdAt)}', ` +
         `'${esc(updatedAt)}', ` +
@@ -797,7 +799,7 @@ export class DeeplakeFs implements IFileSystem {
     // cursor / hermes / interactive), not just the pre-tool-use hook (Claude).
     if (isDocsPath(p) && this.docsTable) {
       if (isDocsDir(p)) throw fsErr("EISDIR", "illegal operation on a directory", p);
-      const r = await handleDocsVfs(docsSubpathOf(p), (sql) => this.client.query(sql), this.docsTable, { embedQuery: makeQueryEmbedder(), project: this.docsProject ?? undefined });
+      const r = await handleDocsVfs(docsSubpathOf(p), (sql) => this.client.query(sql), this.docsTable, { embedQuery: makeQueryEmbedder(), project: this.docsProject ?? undefined, dialect: this.client.dialect });
       if (r.kind === "ok") return r.body;
       throw fsErr("ENOENT", `${r.message}`, p);
     }
@@ -912,7 +914,7 @@ export class DeeplakeFs implements IFileSystem {
       const ts = new Date().toISOString();
       await this.client.query(
         `UPDATE "${this.table}" SET ` +
-        `summary = summary || E'${esc(add)}', ` +
+        `summary = summary || ${escapedStringPrefix(this.client.dialect)}'${esc(add)}', ` +
         `size_bytes = size_bytes + ${Buffer.byteLength(add, "utf-8")}, ` +
         `last_update_date = '${ts}' ` +
         `WHERE path = '${esc(p)}'`

--- a/src/shell/deeplake-shell.ts
+++ b/src/shell/deeplake-shell.ts
@@ -26,7 +26,7 @@ import { deriveProjectKey } from "../utils/repo-identity.js";
 import { Bash } from "just-bash";
 import { loadConfig } from "../config.js";
 import { resolveDirConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { DeeplakeFs } from "./deeplake-fs.js";
 import { createGrepCommand } from "./grep-interceptor.js";
 
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
 
   // One-shot mode is what the pre-tool-use hook invokes via `node shell-bundle -c "..."`
   // to execute compound bash commands. Claude Code's Bash tool merges the child's
-  // stderr into the tool_result string Claude sees, so any `[deeplake-sql]` trace
+  // stderr into the tool_result string Claude sees, so any `[hivemind-sql]` trace
   // written to stderr here pollutes the model's view of the command output.
   // Silence trace env vars regardless of how the caller set them.
   if (isOneShot) {
@@ -63,12 +63,10 @@ async function main(): Promise<void> {
   const docsTable = process.env["HIVEMIND_DOCS_TABLE"] ?? config.docsTableName;
   const mount = process.env["HIVEMIND_MOUNT"] ?? "/";
 
-  const client = new DeeplakeApi(
-    config.token, config.apiUrl, config.orgId, config.workspaceId, table
-  );
+  const client = createStorageBackend(config, table);
 
   if (!isOneShot) {
-    process.stderr.write(`Connecting to deeplake://${config.workspaceId}/${table} ...\n`);
+    process.stderr.write(`Connecting to Hivemind ${config.storage?.kind ?? "deeplake"} storage ...\n`);
   }
 
   const fs = await DeeplakeFs.create(client, table, mount, sessionsTable, { goalsTable, kpisTable, docsTable, docsProject: deriveProjectKey(process.cwd()).key });

--- a/src/shell/grep-core.ts
+++ b/src/shell/grep-core.ts
@@ -14,8 +14,11 @@
  *   3. refineGrepMatches: line-by-line regex match with the usual grep flags.
  */
 
-import type { DeeplakeApi } from "../deeplake-api.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { sqlStr, sqlLike, sqlIdent } from "../utils/sql.js";
+import { scoreVectorRows, vectorScanLimit } from "../storage/vector-search.js";
+import type { StorageDialect } from "../deeplake-schema.js";
+import { likeOperator, textExpression } from "../storage/sql-dialect.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -306,7 +309,7 @@ function buildPathCondition(targetPath: string): string {
  * maps to one round-trip.
  */
 export async function searchDeeplakeTables(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryTable: string,
   sessionsTable: string,
   opts: SearchOptions,
@@ -320,6 +323,59 @@ export async function searchDeeplakeTables(
 ): Promise<ContentRow[]> {
   const { pathFilter, contentScanOnly, likeOp, escapedPattern, prefilterPattern, prefilterPatterns, queryEmbedding, multiWordPatterns } = opts;
   const limit = opts.limit ?? 100;
+
+  // SQLite and vanilla PostgreSQL have no vector operator. Query each source
+  // independently (also avoiding SQLite's compound-select limitations), then
+  // score the bounded embedded candidate set in application code.
+  if (api.capabilities && !api.capabilities.serverVectorSearch) {
+    const textSummary = textExpression("summary", api.dialect);
+    const textMessage = textExpression("message", api.dialect);
+    const localLike = likeOperator(likeOp, api.dialect);
+    const filterPatterns = contentScanOnly
+      ? (prefilterPatterns && prefilterPatterns.length > 0 ? prefilterPatterns : (prefilterPattern ? [prefilterPattern] : []))
+      : (multiWordPatterns && multiWordPatterns.length > 1 ? multiWordPatterns : [escapedPattern]);
+    const memFilter = buildContentFilter(textSummary, localLike, filterPatterns);
+    const sessFilter = buildContentFilter(textMessage, localLike, filterPatterns);
+    const lexicalLimit = Math.min(limit, Number(process.env.HIVEMIND_HYBRID_LEXICAL_LIMIT ?? "20"));
+    const lexicalRows = (await Promise.all([
+      api.query(`SELECT path, ${textSummary} AS content FROM "${memoryTable}" WHERE 1=1${pathFilter}${memFilter} LIMIT ${queryEmbedding ? lexicalLimit : limit}`),
+      api.query(`SELECT path, ${textMessage} AS content FROM "${sessionsTable}" WHERE 1=1${pathFilter}${sessFilter} LIMIT ${queryEmbedding ? lexicalLimit : limit}`),
+    ])).flat();
+
+    const ranked: Array<{ path: string; content: string; score: number }> = lexicalRows.map(row => ({
+      path: String(row.path ?? ""),
+      content: typeof row.content === "string" ? row.content : JSON.stringify(row.content ?? ""),
+      score: 2,
+    }));
+    if (queryEmbedding && queryEmbedding.length > 0) {
+      const scanLimit = vectorScanLimit();
+      const [memoryRows, sessionRows] = await Promise.all([
+        api.query(`SELECT path, ${textSummary} AS content, summary_embedding FROM "${memoryTable}" WHERE 1=1${pathFilter} AND summary_embedding IS NOT NULL LIMIT ${scanLimit}`),
+        api.query(`SELECT path, ${textMessage} AS content, message_embedding FROM "${sessionsTable}" WHERE 1=1${pathFilter} AND message_embedding IS NOT NULL LIMIT ${scanLimit}`),
+      ]);
+      for (const { row, score } of scoreVectorRows(memoryRows, "summary_embedding", queryEmbedding)) {
+        ranked.push({ path: String(row.path ?? ""), content: String(row.content ?? ""), score });
+      }
+      for (const { row, score } of scoreVectorRows(sessionRows, "message_embedding", queryEmbedding)) {
+        ranked.push({
+          path: String(row.path ?? ""),
+          content: typeof row.content === "string" ? row.content : JSON.stringify(row.content ?? ""),
+          score,
+        });
+      }
+    }
+    ranked.sort((a, b) => b.score - a.score);
+    const seen = new Set<string>();
+    const result: ContentRow[] = [];
+    for (const row of ranked) {
+      if (!row.path || seen.has(row.path)) continue;
+      seen.add(row.path);
+      result.push({ path: row.path, content: row.content });
+      if (result.length >= limit) break;
+    }
+    if (meta && (lexicalRows.length >= limit || ranked.length > result.length)) meta.truncated = true;
+    return result;
+  }
 
   // ── Hybrid (lexical + semantic) branch ───────────────────────────────────
   // Runs both halves in a single UNION ALL query so each grep = one round-
@@ -461,6 +517,7 @@ export async function searchDocs(
   query: (sql: string) => Promise<Record<string, unknown>[]>,
   docsTable: string,
   opts: SearchOptions,
+  dialect: StorageDialect = "deeplake",
 ): Promise<ContentRow[]> {
   const { pathFilter, contentScanOnly, likeOp, escapedPattern, prefilterPattern, prefilterPatterns, queryEmbedding, multiWordPatterns } = opts;
   const safeDocsTable = sqlIdent(docsTable);
@@ -468,6 +525,8 @@ export async function searchDocs(
   // Legacy rows carry project '' and stay visible to every project.
   const projFilter = opts.project !== undefined ? ` AND (project = '${sqlStr(opts.project)}' OR project = '')` : "";
   const active = ` AND status = 'active'${projFilter}`;
+  const textContent = textExpression("content", dialect);
+  const localLike = likeOperator(likeOp, dialect);
   const dedup = (rows: Record<string, unknown>[]): ContentRow[] => {
     const seen = new Set<string>();
     const out: ContentRow[] = [];
@@ -487,31 +546,63 @@ export async function searchDocs(
     const filterPatternsForLex = contentScanOnly
       ? (prefilterPatterns && prefilterPatterns.length > 0 ? prefilterPatterns : (prefilterPattern ? [prefilterPattern] : []))
       : [escapedPattern];
-    const lexFilter = buildContentFilter("content::text", likeOp, filterPatternsForLex);
+    const lexFilter = buildContentFilter(textContent, localLike, filterPatternsForLex);
     const lexQuery = lexFilter
-      ? `SELECT doc_id AS path, content::text AS content, 1.0 AS score ` +
+      ? `SELECT doc_id AS path, ${textContent} AS content, 1.0 AS score ` +
         `FROM "${safeDocsTable}" WHERE 1=1${pathFilter}${active}${lexFilter} LIMIT ${lexicalLimit}`
       : null;
+    if (dialect !== "deeplake") {
+      const lexicalRows = lexQuery ? await query(lexQuery) : [];
+      const candidates = await query(
+        `SELECT doc_id AS path, ${textContent} AS content, content_embedding ` +
+        `FROM "${safeDocsTable}" WHERE content_embedding IS NOT NULL${pathFilter}${active} ` +
+        `LIMIT ${vectorScanLimit()}`,
+      );
+      const semanticRows = scoreVectorRows(candidates, "content_embedding", queryEmbedding)
+        .slice(0, semanticLimit)
+        .map(({ row, score }) => ({ ...row, score }));
+      return dedup([
+        ...lexicalRows.map(row => ({ ...row, score: 2 })),
+        ...semanticRows,
+      ].sort((a, b) => Number(b.score ?? 0) - Number(a.score ?? 0)));
+    }
     const semQuery =
-      `SELECT doc_id AS path, content::text AS content, (content_embedding <#> ${vecLit}) AS score ` +
+      `SELECT doc_id AS path, ${textContent} AS content, (content_embedding <#> ${vecLit}) AS score ` +
       `FROM "${safeDocsTable}" WHERE ARRAY_LENGTH(content_embedding, 1) > 0${pathFilter}${active} ` +
       `ORDER BY score DESC LIMIT ${semanticLimit}`;
     const parts = [semQuery];
     if (lexQuery) parts.push(lexQuery);
     const unionSql = parts.map(q => `(${q})`).join(" UNION ALL ");
-    const rows = await query(
-      `SELECT path, content, score FROM (${unionSql}) AS combined ORDER BY score DESC LIMIT ${semanticLimit + lexicalLimit}`,
-    );
-    return dedup(rows);
+    try {
+      const rows = await query(
+        `SELECT path, content, score FROM (${unionSql}) AS combined ORDER BY score DESC LIMIT ${semanticLimit + lexicalLimit}`,
+      );
+      return dedup(rows);
+    } catch (serverError) {
+      // Local providers score a bounded vector candidate set in-process.
+      const lexicalRows = lexQuery ? await query(lexQuery) : [];
+      const candidates = await query(
+        `SELECT doc_id AS path, ${textContent} AS content, content_embedding ` +
+        `FROM "${safeDocsTable}" WHERE content_embedding IS NOT NULL${pathFilter}${active} ` +
+        `LIMIT ${vectorScanLimit()}`,
+      ).catch(() => { throw serverError; });
+      const semanticRows = scoreVectorRows(candidates, "content_embedding", queryEmbedding)
+        .slice(0, semanticLimit)
+        .map(({ row, score }) => ({ ...row, score }));
+      return dedup([
+        ...lexicalRows.map(row => ({ ...row, score: 2 })),
+        ...semanticRows,
+      ].sort((a, b) => Number(b.score ?? 0) - Number(a.score ?? 0)));
+    }
   }
 
   // Lexical-only (no query embedding available — daemon off / disabled).
   const filterPatterns = contentScanOnly
     ? (prefilterPatterns && prefilterPatterns.length > 0 ? prefilterPatterns : (prefilterPattern ? [prefilterPattern] : []))
     : (multiWordPatterns && multiWordPatterns.length > 1 ? multiWordPatterns : [escapedPattern]);
-  const filter = buildContentFilter("content::text", likeOp, filterPatterns);
+  const filter = buildContentFilter(textContent, localLike, filterPatterns);
   const rows = await query(
-    `SELECT doc_id AS path, content::text AS content ` +
+    `SELECT doc_id AS path, ${textContent} AS content ` +
     `FROM "${safeDocsTable}" WHERE 1=1${pathFilter}${active}${filter} LIMIT ${limit}`,
   );
   return dedup(rows);
@@ -716,7 +807,7 @@ export function refineGrepMatches(
 
 /** Convenience: search both tables, normalize session JSON, then refine. */
 export async function grepBothTables(
-  api: DeeplakeApi,
+  api: StorageBackend,
   memoryTable: string,
   sessionsTable: string,
   params: GrepMatchParams,

--- a/src/shell/grep-interceptor.ts
+++ b/src/shell/grep-interceptor.ts
@@ -1,4 +1,4 @@
-import type { DeeplakeApi } from "../deeplake-api.js";
+import type { StorageBackend } from "../storage/backend.js";
 import { defineCommand } from "just-bash";
 import yargsParser from "yargs-parser";
 import type { DeeplakeFs } from "./deeplake-fs.js";
@@ -63,7 +63,7 @@ const MAX_FALLBACK_CANDIDATES = 500;
  * use its own built-in grep.
  */
 export function createGrepCommand(
-  client: DeeplakeApi,
+  client: StorageBackend,
   fs: DeeplakeFs,
   table: string,
   sessionsTable?: string,

--- a/src/skillify/auto-pull.ts
+++ b/src/skillify/auto-pull.ts
@@ -27,7 +27,7 @@
 
 import { type Config } from "../config.js";
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { runPull, type QueryFn } from "./pull.js";
 import { migrateLegacyCappedInstalls } from "./legacy-cap-migration.js";
 import { log as _log } from "../utils/debug.js";
@@ -116,13 +116,7 @@ export async function autoPullSkills(deps: AutoPullDeps = {}): Promise<AutoPullR
   if (deps.queryFn) {
     query = deps.queryFn;
   } else {
-    const api = new DeeplakeApi(
-      config.token,
-      config.apiUrl,
-      config.orgId,
-      config.workspaceId,
-      config.skillsTableName,
-    );
+    const api = createStorageBackend(config, config.skillsTableName);
     query = (sql: string) => api.query(sql) as Promise<Record<string, unknown>[]>;
     discoverTableExists = async () => {
       const known = await api.knownTablesOrNull();

--- a/src/skillify/skillify-worker.ts
+++ b/src/skillify/skillify-worker.ts
@@ -14,7 +14,7 @@
 import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { utcTimestamp } from "../utils/debug.js";
-import { deeplakeClientHeader } from "../utils/client-header.js";
+import { createWorkerStorage, queryWorkerStorage } from "../hooks/worker-storage.js";
 import { extractPairs, SessionRow, Pair } from "./extractors/index.js";
 import {
   resolveSkillsRoot,
@@ -35,9 +35,10 @@ import {
 } from "./state.js";
 
 interface WorkerConfig {
-  apiUrl: string;
-  token: string;
-  orgId: string;
+  storage?: { kind: "deeplake" | "sqlite" | "postgres"; orgId?: string; workspaceId?: string };
+  apiUrl?: string;
+  token?: string;
+  orgId?: string;
   workspaceId: string;
   sessionsTable: string;
   userName: string;
@@ -120,61 +121,8 @@ function esc(s: string): string {
 // keep the worker process alive past the wall-clock at which the parent
 // already considers the run abandoned. 30s matches the per-attempt budget
 // in src/deeplake-api.ts (QUERY_TIMEOUT_MS).
-const QUERY_TIMEOUT_MS = 30_000;
-
-async function query(sql: string, retries = 4): Promise<Record<string, unknown>[]> {
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    let r: Response;
-    try {
-      r = await fetch(`${cfg.apiUrl}/workspaces/${cfg.workspaceId}/tables/query`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${cfg.token}`,
-          "Content-Type": "application/json",
-          "X-Activeloop-Org-Id": cfg.orgId,
-          ...deeplakeClientHeader(),
-        },
-        signal: AbortSignal.timeout(QUERY_TIMEOUT_MS),
-        body: JSON.stringify({ query: sql }),
-      });
-    } catch (e: any) {
-      // Network-level failure: AbortSignal timeout, DNS lookup error,
-      // ECONNRESET, etc. The original loop only checked HTTP statuses,
-      // so a fetch rejection would propagate past the retry path and
-      // out of main(); the per-project worker lock would still be
-      // released by main()'s finally, but we'd lose the retry budget
-      // for transient network blips that the HTTP-status path already
-      // handles. Match the exponential-backoff schedule used below for
-      // 5xx responses.
-      if (attempt < retries) {
-        const base = Math.min(30_000, 2000 * Math.pow(2, attempt));
-        const delay = base + Math.floor(Math.random() * 1000);
-        wlog(`fetch failed (${e?.name ?? e?.code ?? e?.message}), retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-        await new Promise(resolve => setTimeout(resolve, delay));
-        continue;
-      }
-      throw e;
-    }
-    if (r.ok) {
-      const j = await r.json() as { columns?: string[]; rows?: unknown[][] };
-      if (!j.columns || !j.rows) return [];
-      return j.rows.map(row =>
-        Object.fromEntries(j.columns!.map((col, i) => [col, row[i]]))
-      );
-    }
-    const retryable = r.status === 401 || r.status === 403 ||
-      r.status === 429 || r.status === 500 || r.status === 502 || r.status === 503;
-    if (attempt < retries && retryable) {
-      const base = Math.min(30_000, 2000 * Math.pow(2, attempt));
-      const delay = base + Math.floor(Math.random() * 1000);
-      wlog(`API ${r.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`);
-      await new Promise(resolve => setTimeout(resolve, delay));
-      continue;
-    }
-    throw new Error(`API ${r.status}: ${(await r.text()).slice(0, 200)}`);
-  }
-  return [];
-}
+const storageBackend = createWorkerStorage({ ...cfg, memoryTable: cfg.skillsTable }, wlog);
+const query = (sql: string): Promise<Record<string, unknown>[]> => queryWorkerStorage(storageBackend, sql);
 
 function authorClause(): string {
   // scope=team with a populated team list mines sessions authored by
@@ -603,6 +551,7 @@ async function main(): Promise<void> {
   } catch (e: any) {
     wlog(`fatal: ${e.message}`);
   } finally {
+    await storageBackend.close().catch(() => undefined);
     // Counter was already reset by the hook before spawn, so we don't touch it here.
     cleanup(keepTmpForInspection);
     try { releaseWorkerLock(cfg.projectKey); }

--- a/src/skillify/skillopt-trigger.ts
+++ b/src/skillify/skillopt-trigger.ts
@@ -31,7 +31,10 @@ const log = (m: string) => _log("skillopt-trigger", m);
 
 /** Creds check — same as the worker (loadConfig accepts file OR env creds). */
 function defaultHasCreds(): boolean {
-  try { return Boolean(loadConfig()?.token); } catch { return false; }
+  try {
+    const config = loadConfig();
+    return Boolean(config && ((config.storage?.kind ?? "deeplake") !== "deeplake" || config.token));
+  } catch { return false; }
 }
 
 /** How many user messages after a skill call to keep judging it (the reaction may not be

--- a/src/skillify/skillopt-worker.ts
+++ b/src/skillify/skillopt-worker.ts
@@ -14,7 +14,7 @@ import path from "node:path";
 import { accessSync, constants as fsConstants } from "node:fs";
 import { log as _log } from "../utils/debug.js";
 import { loadRoutedConfig } from "../dir-config.js";
-import { DeeplakeApi } from "../deeplake-api.js";
+import { createStorageBackend } from "../storage/factory.js";
 import { getStateDir } from "./state-dir.js";
 import { agentModel, detectScorerAgent } from "./agent-model.js";
 import { improveSkillIfFailed } from "./skillopt-improve.js";
@@ -55,9 +55,9 @@ async function main(): Promise<void> {
   if (!sessionId || !skillRef) { log("no session/skill in env — nothing to do"); return; }
 
   const config = loadRoutedConfig();
-  if (!config?.token) { log("no config/credentials — exiting"); return; }
+  if (!config) { log("no storage config — exiting"); return; }
 
-  const api = new DeeplakeApi(config.token, config.apiUrl, config.orgId, config.workspaceId, config.tableName);
+  const api = createStorageBackend(config, config.tableName);
   const query = (sql: string) => api.query(sql) as Promise<Array<Record<string, unknown>>>;
   const now = new Date().toISOString();
 

--- a/src/skillify/spawn-skillify-worker.ts
+++ b/src/skillify/spawn-skillify-worker.ts
@@ -47,10 +47,7 @@ export function spawnSkillifyWorker(opts: SkillifySpawnOptions): void {
   const { config, cwd, projectKey, project, bundleDir, agent, scopeConfig, currentSessionId, reason } = opts;
 
   const tmpDir = join(tmpdir(), `deeplake-skillify-${projectKey}-${Date.now()}`);
-  // mode 0o700: tmpDir holds config.json with the user's full-org Deeplake API token.
-  // The file itself is written 0o600 below, but a world-readable directory still
-  // leaks the file's existence + name to other users on the host. Mirror of the
-  // Pi extension's spawnPiSkillifyWorker which already uses 0o700.
+  // Worker handoffs contain provider metadata, but no credentials or database URL.
   mkdirSync(tmpDir, { recursive: true, mode: 0o700 });
 
   // Resolve the gate CLI for this agent up front (faster cold-start in the
@@ -58,14 +55,13 @@ export function spawnSkillifyWorker(opts: SkillifySpawnOptions): void {
   const gateBin = findAgentBin(agent as Agent);
 
   const configFile = join(tmpDir, "config.json");
-  // The config file embeds the user's Deeplake API token (full org scope).
-  // Write with mode 0o600 so other users on the same host can't read it
-  // during the worker's lifetime (typically 30-60s before cleanup).
+  // Keep the file private because it still carries local paths and project data.
   writeFileSync(configFile, JSON.stringify({
-    apiUrl: config.apiUrl,
-    token: config.token,
-    orgId: config.orgId,
-    workspaceId: config.workspaceId,
+    storage: {
+      kind: config.storage?.kind ?? "deeplake",
+      orgId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.orgId : undefined,
+      workspaceId: (config.storage?.kind ?? "deeplake") === "deeplake" ? config.workspaceId : undefined,
+    },
     sessionsTable: config.sessionsTableName,
     skillsTable: config.skillsTableName,
     userName: config.userName,

--- a/src/storage/backend.ts
+++ b/src/storage/backend.ts
@@ -1,0 +1,222 @@
+import { randomUUID } from "node:crypto";
+import type { WriteRow } from "../deeplake-api.js";
+import {
+  CODEBASE_COLUMNS,
+  DOCS_COLUMNS,
+  GOALS_COLUMNS,
+  KPIS_COLUMNS,
+  MEMORY_COLUMNS,
+  RULES_COLUMNS,
+  SESSIONS_COLUMNS,
+  SKILLS_COLUMNS,
+  type ColumnDef,
+  type StorageDialect,
+  buildCreateTableSql,
+  renderColumnSql,
+} from "../deeplake-schema.js";
+import { SUMMARY_EMBEDDING_COL } from "../embeddings/columns.js";
+import { sqlIdent } from "../utils/sql.js";
+
+export type StorageKind = "deeplake" | "sqlite" | "postgres";
+export type SqlValue = string | number | boolean | null | Date | readonly number[] | Record<string, unknown>;
+export type QueryRow = Record<string, unknown>;
+
+export interface StorageCapabilities {
+  serverVectorSearch: boolean;
+  transactions: boolean;
+  json: "native" | "text";
+  vectors: "server" | "array" | "json-text";
+}
+
+export interface ExecuteResult {
+  rowCount: number;
+}
+
+export interface StorageBackend {
+  readonly kind: StorageKind;
+  readonly dialect: StorageDialect;
+  readonly capabilities: StorageCapabilities;
+  readonly tableName: string;
+
+  query(sql: string, paramsOrSignal?: readonly SqlValue[] | AbortSignal, signal?: AbortSignal): Promise<QueryRow[]>;
+  execute(sql: string, params?: readonly SqlValue[]): Promise<ExecuteResult>;
+  transaction<T>(fn: (tx: StorageBackend) => Promise<T>): Promise<T>;
+  listTables(forceRefresh?: boolean): Promise<string[]>;
+  knownTablesOrNull(): Promise<string[] | null>;
+  getColumns(table: string): Promise<string[]>;
+  initializeSchema(): Promise<void>;
+  close(): Promise<void>;
+
+  appendRows(rows: WriteRow[]): void;
+  commit(): Promise<void>;
+  updateColumns(path: string, columns: Record<string, string | number>): Promise<void>;
+  createIndex(column: string): Promise<void>;
+  ensureTable(name?: string): Promise<void>;
+  ensureSessionsTable(name: string): Promise<void>;
+  ensureSkillsTable(name: string): Promise<void>;
+  ensureRulesTable(name: string): Promise<void>;
+  ensureGoalsTable(name: string): Promise<void>;
+  ensureKpisTable(name: string): Promise<void>;
+  ensureDocsTable(name: string): Promise<void>;
+  ensureCodebaseTable(name: string): Promise<void>;
+}
+
+export interface BackendTableNames {
+  memory: string;
+  sessions: string;
+  skills: string;
+  rules: string;
+  goals: string;
+  kpis: string;
+  docs: string;
+  codebase: string;
+}
+
+const INDEXES: Partial<Record<keyof BackendTableNames, Array<{ suffix: string; columns: string[] }>>> = {
+  sessions: [{ suffix: "path_creation_date", columns: ["path", "creation_date"] }],
+  skills: [{ suffix: "project_key_name", columns: ["project_key", "name"] }],
+  rules: [{ suffix: "rule_id_version", columns: ["rule_id", "version"] }],
+  goals: [
+    { suffix: "goal_id_version", columns: ["goal_id", "version"] },
+    { suffix: "owner_status", columns: ["owner", "status"] },
+  ],
+  kpis: [{ suffix: "goal_id_kpi_id", columns: ["goal_id", "kpi_id"] }],
+  docs: [{ suffix: "doc_id_version", columns: ["doc_id", "version"] }],
+  codebase: [{
+    suffix: "codebase_identity",
+    columns: ["org_id", "workspace_id", "repo_slug", "user_id", "worktree_id", "commit_sha"],
+  }],
+};
+
+const SCHEMAS: Record<keyof BackendTableNames, readonly ColumnDef[]> = {
+  memory: MEMORY_COLUMNS,
+  sessions: SESSIONS_COLUMNS,
+  skills: SKILLS_COLUMNS,
+  rules: RULES_COLUMNS,
+  goals: GOALS_COLUMNS,
+  kpis: KPIS_COLUMNS,
+  docs: DOCS_COLUMNS,
+  codebase: CODEBASE_COLUMNS,
+};
+
+/** Shared schema/upsert behavior for local SQL providers. */
+export abstract class SqlStorageBackend implements StorageBackend {
+  abstract readonly kind: StorageKind;
+  abstract readonly dialect: StorageDialect;
+  abstract readonly capabilities: StorageCapabilities;
+  private pendingRows: WriteRow[] = [];
+
+  constructor(
+    readonly tableName: string,
+    protected readonly tableNames: BackendTableNames,
+  ) {}
+
+  abstract query(
+    sql: string,
+    paramsOrSignal?: readonly SqlValue[] | AbortSignal,
+    signal?: AbortSignal,
+  ): Promise<QueryRow[]>;
+  abstract execute(sql: string, params?: readonly SqlValue[]): Promise<ExecuteResult>;
+  abstract transaction<T>(fn: (tx: StorageBackend) => Promise<T>): Promise<T>;
+  abstract listTables(forceRefresh?: boolean): Promise<string[]>;
+  abstract getColumns(table: string): Promise<string[]>;
+  abstract close(): Promise<void>;
+
+  async knownTablesOrNull(): Promise<string[] | null> {
+    return this.listTables();
+  }
+
+  async initializeSchema(): Promise<void> {
+    await this.ensureTable(this.tableNames.memory);
+    await this.ensureSessionsTable(this.tableNames.sessions);
+    await this.ensureSkillsTable(this.tableNames.skills);
+    await this.ensureRulesTable(this.tableNames.rules);
+    await this.ensureGoalsTable(this.tableNames.goals);
+    await this.ensureKpisTable(this.tableNames.kpis);
+    await this.ensureDocsTable(this.tableNames.docs);
+    await this.ensureCodebaseTable(this.tableNames.codebase);
+  }
+
+  appendRows(rows: WriteRow[]): void {
+    this.pendingRows.push(...rows);
+  }
+
+  async commit(): Promise<void> {
+    if (this.pendingRows.length === 0) return;
+    const rows = this.pendingRows;
+    this.pendingRows = [];
+    await this.transaction(async tx => {
+      for (const row of rows) await this.upsertRow(tx, row);
+    });
+  }
+
+  private async upsertRow(tx: StorageBackend, row: WriteRow): Promise<void> {
+    const now = new Date().toISOString();
+    const found = await tx.query(
+      `SELECT path FROM "${sqlIdent(this.tableName)}" WHERE path = $1 LIMIT 1`,
+      [row.path],
+    );
+    if (found.length > 0) {
+      await tx.execute(
+        `UPDATE "${sqlIdent(this.tableName)}" SET summary = $1, ${SUMMARY_EMBEDDING_COL} = NULL, ` +
+          `mime_type = $2, size_bytes = $3, project = COALESCE($4, project), ` +
+          `description = COALESCE($5, description), last_update_date = $6 WHERE path = $7`,
+        [row.contentText, row.mimeType, row.sizeBytes, row.project ?? null, row.description ?? null, now, row.path],
+      );
+      return;
+    }
+    await tx.execute(
+      `INSERT INTO "${sqlIdent(this.tableName)}" ` +
+        `(id, path, filename, summary, ${SUMMARY_EMBEDDING_COL}, mime_type, size_bytes, project, description, creation_date, last_update_date) ` +
+        `VALUES ($1, $2, $3, $4, NULL, $5, $6, $7, $8, $9, $10)`,
+      [randomUUID(), row.path, row.filename, row.contentText, row.mimeType, row.sizeBytes,
+        row.project ?? "", row.description ?? "", row.creationDate ?? now, row.lastUpdateDate ?? now],
+    );
+  }
+
+  async updateColumns(path: string, columns: Record<string, string | number>): Promise<void> {
+    const entries = Object.entries(columns);
+    if (entries.length === 0) return;
+    const sets = entries.map(([name], i) => `${sqlIdent(name)} = $${i + 1}`).join(", ");
+    await this.execute(
+      `UPDATE "${sqlIdent(this.tableName)}" SET ${sets} WHERE path = $${entries.length + 1}`,
+      [...entries.map(([, value]) => value), path],
+    );
+  }
+
+  async createIndex(columnName: string): Promise<void> {
+    const column = sqlIdent(columnName);
+    await this.execute(
+      `CREATE INDEX IF NOT EXISTS "idx_${sqlIdent(this.tableName)}_${column}" ` +
+        `ON "${sqlIdent(this.tableName)}" ("${column}")`,
+    );
+  }
+
+  async ensureTable(name = this.tableName): Promise<void> {
+    await this.ensureSchema("memory", name);
+  }
+  async ensureSessionsTable(name: string): Promise<void> { await this.ensureSchema("sessions", name); }
+  async ensureSkillsTable(name: string): Promise<void> { await this.ensureSchema("skills", name); }
+  async ensureRulesTable(name: string): Promise<void> { await this.ensureSchema("rules", name); }
+  async ensureGoalsTable(name: string): Promise<void> { await this.ensureSchema("goals", name); }
+  async ensureKpisTable(name: string): Promise<void> { await this.ensureSchema("kpis", name); }
+  async ensureDocsTable(name: string): Promise<void> { await this.ensureSchema("docs", name); }
+  async ensureCodebaseTable(name: string): Promise<void> { await this.ensureSchema("codebase", name); }
+
+  private async ensureSchema(key: keyof BackendTableNames, tableName: string): Promise<void> {
+    const table = sqlIdent(tableName);
+    await this.execute(buildCreateTableSql(table, SCHEMAS[key], this.dialect));
+    const present = new Set((await this.getColumns(table)).map(name => name.toLowerCase()));
+    for (const col of SCHEMAS[key]) {
+      if (present.has(col.name.toLowerCase())) continue;
+      await this.execute(
+        `ALTER TABLE "${table}" ADD COLUMN ${sqlIdent(col.name)} ${renderColumnSql(col, this.dialect)}`,
+      );
+    }
+    for (const index of INDEXES[key] ?? []) {
+      const indexName = `idx_${table}_${index.suffix}`.replace(/[^A-Za-z0-9_]/g, "_");
+      const columns = index.columns.map(name => `"${sqlIdent(name)}"`).join(", ");
+      await this.execute(`CREATE INDEX IF NOT EXISTS "${indexName}" ON "${table}" (${columns})`);
+    }
+  }
+}

--- a/src/storage/factory.ts
+++ b/src/storage/factory.ts
@@ -1,0 +1,199 @@
+import type { Config, StorageConfig } from "../config.js";
+import { DeeplakeApi, type WriteRow } from "../deeplake-api.js";
+import type {
+  BackendTableNames,
+  ExecuteResult,
+  QueryRow,
+  SqlValue,
+  StorageBackend,
+} from "./backend.js";
+
+function tableNames(config: StorageConfig): BackendTableNames {
+  return {
+    memory: config.tableName,
+    sessions: config.sessionsTableName,
+    skills: config.skillsTableName,
+    rules: config.rulesTableName,
+    goals: config.goalsTableName,
+    kpis: config.kpisTableName,
+    docs: config.docsTableName,
+    codebase: config.codebaseTableName,
+  };
+}
+
+function asStorageConfig(config: Config | StorageConfig): StorageConfig {
+  if ("kind" in config) return config;
+  if (config.storage) return config.storage;
+  // Keep accepting the original Deeplake-shaped Config. Besides preserving the
+  // public API, this avoids forcing integrations that mock Config to learn
+  // about the new storage helpers.
+  return {
+    kind: "deeplake",
+    token: config.token,
+    apiUrl: config.apiUrl,
+    orgId: config.orgId,
+    orgName: config.orgName,
+    userName: config.userName,
+    workspaceId: config.workspaceId,
+    tableName: config.tableName,
+    sessionsTableName: config.sessionsTableName,
+    skillsTableName: config.skillsTableName,
+    rulesTableName: config.rulesTableName,
+    goalsTableName: config.goalsTableName,
+    kpisTableName: config.kpisTableName,
+    docsTableName: config.docsTableName,
+    codebaseTableName: config.codebaseTableName,
+    memoryPath: config.memoryPath,
+    vectorScanLimit: config.vectorScanLimit ?? 2000,
+  };
+}
+
+class LazySqliteBackend implements StorageBackend {
+  readonly kind = "sqlite" as const;
+  readonly dialect = "sqlite" as const;
+  readonly capabilities = {
+    serverVectorSearch: false,
+    transactions: true,
+    json: "text",
+    vectors: "json-text",
+  } as const;
+  private backendPromise: Promise<StorageBackend> | null = null;
+  private pendingRows: WriteRow[] = [];
+
+  constructor(
+    private readonly config: Extract<StorageConfig, { kind: "sqlite" }>,
+    readonly tableName: string,
+  ) {}
+
+  private backend(): Promise<StorageBackend> {
+    if (!this.backendPromise) {
+      this.backendPromise = import("./sqlite.js").then(({ SqliteBackend }) =>
+        new SqliteBackend(this.config.path, this.tableName, tableNames(this.config)),
+      );
+    }
+    return this.backendPromise;
+  }
+
+  async query(sql: string, paramsOrSignal?: readonly SqlValue[] | AbortSignal, signal?: AbortSignal): Promise<QueryRow[]> {
+    return (await this.backend()).query(sql, paramsOrSignal, signal);
+  }
+  async execute(sql: string, params?: readonly SqlValue[]): Promise<ExecuteResult> {
+    return (await this.backend()).execute(sql, params);
+  }
+  async transaction<T>(fn: (tx: StorageBackend) => Promise<T>): Promise<T> {
+    return (await this.backend()).transaction(fn);
+  }
+  async listTables(forceRefresh?: boolean): Promise<string[]> { return (await this.backend()).listTables(forceRefresh); }
+  async knownTablesOrNull(): Promise<string[] | null> { return (await this.backend()).knownTablesOrNull(); }
+  async getColumns(table: string): Promise<string[]> { return (await this.backend()).getColumns(table); }
+  async initializeSchema(): Promise<void> { await (await this.backend()).initializeSchema(); }
+  async close(): Promise<void> { if (this.backendPromise) await (await this.backendPromise).close(); }
+  appendRows(rows: WriteRow[]): void { this.pendingRows.push(...rows); }
+  async commit(): Promise<void> {
+    const backend = await this.backend();
+    if (this.pendingRows.length > 0) {
+      backend.appendRows(this.pendingRows);
+      this.pendingRows = [];
+    }
+    await backend.commit();
+  }
+  async updateColumns(path: string, columns: Record<string, string | number>): Promise<void> {
+    await (await this.backend()).updateColumns(path, columns);
+  }
+  async createIndex(column: string): Promise<void> { await (await this.backend()).createIndex(column); }
+  async ensureTable(name?: string): Promise<void> { await (await this.backend()).ensureTable(name); }
+  async ensureSessionsTable(name: string): Promise<void> { await (await this.backend()).ensureSessionsTable(name); }
+  async ensureSkillsTable(name: string): Promise<void> { await (await this.backend()).ensureSkillsTable(name); }
+  async ensureRulesTable(name: string): Promise<void> { await (await this.backend()).ensureRulesTable(name); }
+  async ensureGoalsTable(name: string): Promise<void> { await (await this.backend()).ensureGoalsTable(name); }
+  async ensureKpisTable(name: string): Promise<void> { await (await this.backend()).ensureKpisTable(name); }
+  async ensureDocsTable(name: string): Promise<void> { await (await this.backend()).ensureDocsTable(name); }
+  async ensureCodebaseTable(name: string): Promise<void> { await (await this.backend()).ensureCodebaseTable(name); }
+}
+
+class LazyPostgresBackend implements StorageBackend {
+  readonly kind = "postgres" as const;
+  readonly dialect = "postgres" as const;
+  readonly capabilities = {
+    serverVectorSearch: false,
+    transactions: true,
+    json: "native",
+    vectors: "array",
+  } as const;
+  private backendPromise: Promise<StorageBackend> | null = null;
+  private pendingRows: WriteRow[] = [];
+
+  constructor(
+    private readonly config: Extract<StorageConfig, { kind: "postgres" }>,
+    readonly tableName: string,
+  ) {}
+
+  private backend(): Promise<StorageBackend> {
+    if (!this.backendPromise) {
+      this.backendPromise = import("./postgres.js").then(({ PostgresBackend }) =>
+        new PostgresBackend(
+          this.config.connectionUrl,
+          this.config.schema,
+          this.tableName,
+          tableNames(this.config),
+        ),
+      );
+    }
+    return this.backendPromise;
+  }
+
+  async query(sql: string, paramsOrSignal?: readonly SqlValue[] | AbortSignal, signal?: AbortSignal): Promise<QueryRow[]> {
+    return (await this.backend()).query(sql, paramsOrSignal, signal);
+  }
+  async execute(sql: string, params?: readonly SqlValue[]): Promise<ExecuteResult> {
+    return (await this.backend()).execute(sql, params);
+  }
+  async transaction<T>(fn: (tx: StorageBackend) => Promise<T>): Promise<T> {
+    return (await this.backend()).transaction(fn);
+  }
+  async listTables(forceRefresh?: boolean): Promise<string[]> { return (await this.backend()).listTables(forceRefresh); }
+  async knownTablesOrNull(): Promise<string[] | null> { return (await this.backend()).knownTablesOrNull(); }
+  async getColumns(table: string): Promise<string[]> { return (await this.backend()).getColumns(table); }
+  async initializeSchema(): Promise<void> { await (await this.backend()).initializeSchema(); }
+  async close(): Promise<void> { if (this.backendPromise) await (await this.backendPromise).close(); }
+
+  appendRows(rows: WriteRow[]): void { this.pendingRows.push(...rows); }
+  async commit(): Promise<void> {
+    const backend = await this.backend();
+    if (this.pendingRows.length > 0) {
+      backend.appendRows(this.pendingRows);
+      this.pendingRows = [];
+    }
+    await backend.commit();
+  }
+  async updateColumns(path: string, columns: Record<string, string | number>): Promise<void> {
+    await (await this.backend()).updateColumns(path, columns);
+  }
+  async createIndex(column: string): Promise<void> { await (await this.backend()).createIndex(column); }
+  async ensureTable(name?: string): Promise<void> { await (await this.backend()).ensureTable(name); }
+  async ensureSessionsTable(name: string): Promise<void> { await (await this.backend()).ensureSessionsTable(name); }
+  async ensureSkillsTable(name: string): Promise<void> { await (await this.backend()).ensureSkillsTable(name); }
+  async ensureRulesTable(name: string): Promise<void> { await (await this.backend()).ensureRulesTable(name); }
+  async ensureGoalsTable(name: string): Promise<void> { await (await this.backend()).ensureGoalsTable(name); }
+  async ensureKpisTable(name: string): Promise<void> { await (await this.backend()).ensureKpisTable(name); }
+  async ensureDocsTable(name: string): Promise<void> { await (await this.backend()).ensureDocsTable(name); }
+  async ensureCodebaseTable(name: string): Promise<void> { await (await this.backend()).ensureCodebaseTable(name); }
+}
+
+/** Create the configured provider without eagerly loading PostgreSQL. */
+export function createStorageBackend(config: Config | StorageConfig, tableOverride?: string): StorageBackend {
+  const storage = asStorageConfig(config);
+  const activeTable = tableOverride ?? storage.tableName;
+  const names = tableNames(storage);
+
+  if (storage.kind === "sqlite") return new LazySqliteBackend(storage, activeTable);
+  if (storage.kind === "postgres") return new LazyPostgresBackend(storage, activeTable);
+  return new DeeplakeApi(
+    storage.token,
+    storage.apiUrl,
+    storage.orgId,
+    storage.workspaceId,
+    activeTable,
+    names,
+  );
+}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,0 +1,2 @@
+export * from "./backend.js";
+export * from "./factory.js";

--- a/src/storage/postgres.ts
+++ b/src/storage/postgres.ts
@@ -1,0 +1,129 @@
+import { Pool, type PoolClient } from "pg";
+import type { BackendTableNames, ExecuteResult, QueryRow, SqlValue, StorageBackend } from "./backend.js";
+import { SqlStorageBackend } from "./backend.js";
+
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function pgValue(value: SqlValue): unknown {
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}
+
+export class PostgresBackend extends SqlStorageBackend {
+  readonly kind = "postgres" as const;
+  readonly dialect = "postgres" as const;
+  readonly capabilities = {
+    serverVectorSearch: false,
+    transactions: true,
+    json: "native",
+    vectors: "array",
+  } as const;
+
+  private readonly pool: Pool;
+  private readonly ready: Promise<void>;
+
+  constructor(
+    connectionUrl: string,
+    readonly schema: string,
+    tableName: string,
+    tableNames: BackendTableNames,
+  ) {
+    super(tableName, tableNames);
+    if (!IDENTIFIER.test(schema)) throw new Error(`Invalid PostgreSQL schema: ${schema}`);
+    this.pool = new Pool({
+      connectionString: connectionUrl,
+      max: 5,
+      connectionTimeoutMillis: 5000,
+      idleTimeoutMillis: 10_000,
+      statement_timeout: 10_000,
+      allowExitOnIdle: true,
+      options: `-c search_path=${schema} -c statement_timeout=10000`,
+    });
+    this.ready = this.pool.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`).then(() => undefined);
+  }
+
+  async query(
+    sql: string,
+    paramsOrSignal: readonly SqlValue[] | AbortSignal = [],
+    signal?: AbortSignal,
+  ): Promise<QueryRow[]> {
+    await this.ready;
+    const params = paramsOrSignal instanceof AbortSignal ? [] : paramsOrSignal;
+    const activeSignal = paramsOrSignal instanceof AbortSignal ? paramsOrSignal : signal;
+    if (activeSignal?.aborted) throw new Error("Query aborted");
+    const result = await this.pool.query({
+      text: sql,
+      values: params.map(pgValue),
+      signal: activeSignal,
+    } as any);
+    return result.rows as QueryRow[];
+  }
+
+  async execute(sql: string, params: readonly SqlValue[] = []): Promise<ExecuteResult> {
+    await this.ready;
+    const result = await this.pool.query(sql, params.map(pgValue));
+    return { rowCount: result.rowCount ?? 0 };
+  }
+
+  async transaction<T>(fn: (tx: StorageBackend) => Promise<T>): Promise<T> {
+    await this.ready;
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await fn(this.transactionView(client));
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch { /* preserve original error */ }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listTables(): Promise<string[]> {
+    const rows = await this.query(
+      "SELECT table_name FROM information_schema.tables WHERE table_schema = $1 ORDER BY table_name",
+      [this.schema],
+    );
+    return rows.map(row => String(row.table_name));
+  }
+
+  async getColumns(table: string): Promise<string[]> {
+    const rows = await this.query(
+      "SELECT column_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 ORDER BY ordinal_position",
+      [this.schema, table],
+    );
+    return rows.map(row => String(row.column_name));
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
+  private transactionView(client: PoolClient): StorageBackend {
+    const self = this;
+    return new Proxy(this, {
+      get(target, property, receiver) {
+        if (property === "query") {
+          return async (sql: string, paramsOrSignal: readonly SqlValue[] | AbortSignal = [], signal?: AbortSignal) => {
+            const params = paramsOrSignal instanceof AbortSignal ? [] : paramsOrSignal;
+            const activeSignal = paramsOrSignal instanceof AbortSignal ? paramsOrSignal : signal;
+            if (activeSignal?.aborted) throw new Error("Query aborted");
+            const result = await client.query({ text: sql, values: params.map(pgValue), signal: activeSignal } as any);
+            return result.rows as QueryRow[];
+          };
+        }
+        if (property === "execute") {
+          return async (sql: string, params: readonly SqlValue[] = []) => {
+            const result = await client.query(sql, params.map(pgValue));
+            return { rowCount: result.rowCount ?? 0 };
+          };
+        }
+        if (property === "transaction") return <T>(fn: (tx: StorageBackend) => Promise<T>) => fn(receiver as StorageBackend);
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+  }
+}

--- a/src/storage/sql-dialect.ts
+++ b/src/storage/sql-dialect.ts
@@ -1,0 +1,30 @@
+import type { StorageDialect } from "../deeplake-schema.js";
+
+/** Render an expression as text without relying on backend-side SQL rewriting. */
+export function textExpression(expression: string, dialect: StorageDialect): string {
+  return dialect === "sqlite" ? expression : `${expression}::text`;
+}
+
+/** Render a typed NULL where PostgreSQL-style UNION inference needs one. */
+export function nullExpression(type: "text" | "bigint", dialect: StorageDialect): string {
+  return dialect === "sqlite" ? "NULL" : `NULL::${type}`;
+}
+
+/** SQLite LIKE is case-insensitive for ASCII unless case_sensitive_like is enabled. */
+export function likeOperator(
+  requested: "LIKE" | "ILIKE",
+  dialect: StorageDialect,
+): "LIKE" | "ILIKE" {
+  return dialect === "sqlite" && requested === "ILIKE" ? "LIKE" : requested;
+}
+
+/** Prefix a string literal with E only on providers that support it. */
+export function escapedStringPrefix(dialect: StorageDialect): "" | "E" {
+  return dialect === "sqlite" ? "" : "E";
+}
+
+/** Render a pre-escaped JSON literal for the provider's logical JSON type. */
+export function jsonLiteral(escapedJson: string, dialect: StorageDialect): string {
+  const literal = `'${escapedJson}'`;
+  return dialect === "sqlite" ? literal : `${literal}::jsonb`;
+}

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -1,0 +1,207 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import type { WriteRow } from "../deeplake-api.js";
+import type { BackendTableNames, ExecuteResult, QueryRow, SqlValue, StorageBackend } from "./backend.js";
+import { SqlStorageBackend } from "./backend.js";
+
+const BUSY_RETRIES = 6;
+const BUSY_BASE_DELAY_MS = 25;
+
+function isBusy(error: unknown): boolean {
+  const code = (error as { code?: string })?.code;
+  const message = error instanceof Error ? error.message : String(error);
+  return code === "SQLITE_BUSY" || /database is (?:locked|busy)|SQLITE_BUSY/i.test(message);
+}
+
+function bindValue(value: SqlValue): string | number | bigint | null {
+  if (value === null) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "boolean") return value ? 1 : 0;
+  if (Array.isArray(value) || typeof value === "object") return JSON.stringify(value);
+  return value;
+}
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try { return JSON.parse(value); } catch { return value; }
+}
+
+function decodeRow(row: QueryRow): QueryRow {
+  const out = { ...row };
+  for (const [key, value] of Object.entries(out)) {
+    if (key === "message" || key.endsWith("_embedding")) out[key] = parseJson(value);
+  }
+  return out;
+}
+
+function compileParameters(sql: string, params: readonly SqlValue[]): { sql: string; values: Array<string | number | bigint | null> } {
+  const values: Array<string | number | bigint | null> = [];
+  const compiled = sql.replace(/\$(\d+)/g, (_all, index: string) => {
+    const value = params[Number(index) - 1];
+    if (value === undefined && Number(index) > params.length) {
+      throw new Error(`Missing SQL parameter $${index}`);
+    }
+    values.push(bindValue(value));
+    return "?";
+  });
+  return { sql: compiled, values };
+}
+
+export class SqliteBackend extends SqlStorageBackend {
+  readonly kind = "sqlite" as const;
+  readonly dialect = "sqlite" as const;
+  readonly capabilities = {
+    serverVectorSearch: false,
+    transactions: true,
+    json: "text",
+    vectors: "json-text",
+  } as const;
+
+  private readonly dbPromise: Promise<DatabaseSync>;
+  private tail: Promise<void> = Promise.resolve();
+  private closed = false;
+
+  constructor(
+    readonly path: string,
+    tableName: string,
+    tableNames: BackendTableNames,
+  ) {
+    super(tableName, tableNames);
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    // Keep node:sqlite out of non-SQLite startup. In bundled runtimes this
+    // remains a native dynamic import, so Deeplake/PostgreSQL users do not
+    // load the experimental SQLite module or see its warning.
+    this.dbPromise = import("node:sqlite").then(async ({ DatabaseSync }) => {
+      const db = new DatabaseSync(path, { timeout: 5000 });
+      db["exec"]("PRAGMA busy_timeout=5000");
+      await this.runBusy(() => db["exec"]("PRAGMA journal_mode=WAL"));
+      await this.runBusy(() => db["exec"]("PRAGMA foreign_keys=ON"));
+      await this.runBusy(() => db["exec"]("PRAGMA synchronous=NORMAL"));
+      db.function("ARRAY_LENGTH", (raw: unknown) => {
+        const parsed = parseJson(raw);
+        return Array.isArray(parsed) ? parsed.length : null;
+      });
+      db.function("GREATEST", (...values: unknown[]) => Math.max(...values.map(Number)));
+      db.function("NOW", () => new Date().toISOString());
+      return db;
+    });
+  }
+
+  async query(
+    sql: string,
+    paramsOrSignal: readonly SqlValue[] | AbortSignal = [],
+    signal?: AbortSignal,
+  ): Promise<QueryRow[]> {
+    const params = paramsOrSignal instanceof AbortSignal ? [] : paramsOrSignal;
+    const activeSignal = paramsOrSignal instanceof AbortSignal ? paramsOrSignal : signal;
+    if (activeSignal?.aborted) throw new Error("Query aborted");
+    return this.withLock(() => this.queryDirect(sql, params, activeSignal));
+  }
+
+  async execute(sql: string, params: readonly SqlValue[] = []): Promise<ExecuteResult> {
+    return this.withLock(() => this.executeDirect(sql, params));
+  }
+
+  async transaction<T>(fn: (tx: StorageBackend) => Promise<T>): Promise<T> {
+    return this.withLock(async () => {
+      const db = await this.dbPromise;
+      await this.runBusy(() => db["exec"]("BEGIN IMMEDIATE"));
+      const tx = this.transactionView();
+      try {
+        const result = await fn(tx);
+        db["exec"]("COMMIT");
+        return result;
+      } catch (error) {
+        try { db["exec"]("ROLLBACK"); } catch { /* preserve original error */ }
+        throw error;
+      }
+    });
+  }
+
+  async listTables(): Promise<string[]> {
+    const rows = await this.query(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    );
+    return rows.map(row => String(row.name));
+  }
+
+  async getColumns(table: string): Promise<string[]> {
+    // The identifier is validated by schema callers before reaching here.
+    const rows = await this.query(`PRAGMA table_info("${table}")`);
+    return rows.map(row => String(row.name));
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    await this.tail;
+    (await this.dbPromise).close();
+    this.closed = true;
+  }
+
+  private transactionView(): StorageBackend {
+    const self = this;
+    return new Proxy(this, {
+      get(target, property, receiver) {
+        if (property === "query") {
+          return (sql: string, paramsOrSignal: readonly SqlValue[] | AbortSignal = [], signal?: AbortSignal) => {
+            const params = paramsOrSignal instanceof AbortSignal ? [] : paramsOrSignal;
+            const activeSignal = paramsOrSignal instanceof AbortSignal ? paramsOrSignal : signal;
+            return self.queryDirect(sql, params, activeSignal);
+          };
+        }
+        if (property === "execute") return (sql: string, params: readonly SqlValue[] = []) => self.executeDirect(sql, params);
+        if (property === "transaction") return <T>(fn: (tx: StorageBackend) => Promise<T>) => fn(receiver as StorageBackend);
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+  }
+
+  private async queryDirect(sql: string, params: readonly SqlValue[], signal?: AbortSignal): Promise<QueryRow[]> {
+    if (signal?.aborted) throw new Error("Query aborted");
+    const compiled = compileParameters(sql, params);
+    const db = await this.dbPromise;
+    return this.runBusy(() => {
+      const statement = db.prepare(compiled.sql);
+      const readsRows = /^\s*(?:SELECT|WITH|PRAGMA|EXPLAIN)\b/i.test(compiled.sql) || /\bRETURNING\b/i.test(compiled.sql);
+      if (!readsRows) {
+        statement.run(...compiled.values);
+        return [];
+      }
+      return statement.all(...compiled.values).map(row => decodeRow(row as QueryRow));
+    });
+  }
+
+  private async executeDirect(sql: string, params: readonly SqlValue[]): Promise<ExecuteResult> {
+    const compiled = compileParameters(sql, params);
+    const db = await this.dbPromise;
+    return this.runBusy(() => {
+      const result = db.prepare(compiled.sql).run(...compiled.values);
+      return { rowCount: Number(result.changes) };
+    });
+  }
+
+  private async runBusy<T>(fn: () => T): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= BUSY_RETRIES; attempt++) {
+      try { return fn(); } catch (error) {
+        lastError = error;
+        if (!isBusy(error) || attempt === BUSY_RETRIES) throw error;
+        await new Promise(resolve => setTimeout(resolve, BUSY_BASE_DELAY_MS * (attempt + 1)));
+      }
+    }
+    throw lastError;
+  }
+
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.closed) throw new Error("SQLite backend is closed");
+    const previous = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>(resolve => { release = resolve; });
+    await previous;
+    try { return await fn(); } finally { release(); }
+  }
+}
+
+export type { WriteRow };

--- a/src/storage/vector-search.ts
+++ b/src/storage/vector-search.ts
@@ -1,0 +1,52 @@
+export interface ScoredVectorRow {
+  row: Record<string, unknown>;
+  score: number;
+}
+
+export function parseStoredVector(value: unknown): number[] | null {
+  let candidate = value;
+  if (typeof candidate === "string") {
+    try { candidate = JSON.parse(candidate); } catch { return null; }
+  }
+  if (!Array.isArray(candidate) || candidate.length === 0) return null;
+  const vector = candidate.map(Number);
+  return vector.every(Number.isFinite) ? vector : null;
+}
+
+export function cosineSimilarity(left: readonly number[], right: readonly number[]): number | null {
+  if (left.length === 0 || left.length !== right.length) return null;
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let i = 0; i < left.length; i++) {
+    const a = left[i];
+    const b = right[i];
+    if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+    dot += a * b;
+    leftNorm += a * a;
+    rightNorm += b * b;
+  }
+  if (leftNorm === 0 || rightNorm === 0) return null;
+  return dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
+}
+
+export function scoreVectorRows(
+  rows: Record<string, unknown>[],
+  embeddingColumn: string,
+  queryEmbedding: readonly number[],
+): ScoredVectorRow[] {
+  const scored: ScoredVectorRow[] = [];
+  for (const row of rows) {
+    const vector = parseStoredVector(row[embeddingColumn]);
+    if (!vector) continue;
+    const score = cosineSimilarity(vector, queryEmbedding);
+    if (score === null) continue;
+    scored.push({ row, score });
+  }
+  return scored.sort((a, b) => b.score - a.score);
+}
+
+export function vectorScanLimit(): number {
+  const raw = Number.parseInt(process.env.HIVEMIND_VECTOR_SCAN_LIMIT ?? "2000", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 2000;
+}

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -14,6 +14,12 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 export interface UserConfig {
+  storage?: {
+    provider?: "deeplake" | "sqlite" | "postgres";
+    sqlitePath?: string;
+    postgresSchema?: string;
+  };
+  autoupdate?: boolean;
   embeddings?: {
     enabled?: boolean;
   };
@@ -107,6 +113,14 @@ function migrationValueFromEnv(): boolean {
 
 export function setEmbeddingsEnabled(enabled: boolean): void {
   writeUserConfig({ embeddings: { enabled } });
+}
+
+export function getAutoupdateEnabled(): boolean {
+  return readUserConfig().autoupdate !== false;
+}
+
+export function setAutoupdateEnabled(enabled: boolean): void {
+  writeUserConfig({ autoupdate: enabled });
 }
 
 /**

--- a/src/utils/direct-run.ts
+++ b/src/utils/direct-run.ts
@@ -1,12 +1,18 @@
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
+
+function canonical(path: string): string {
+  const resolved = resolve(path);
+  try { return realpathSync.native(resolved); } catch { return resolved; }
+}
 
 export function isDirectRun(metaUrl: string): boolean {
   const entry = process.argv[1];
   if (!entry) return false;
 
   try {
-    return resolve(fileURLToPath(metaUrl)) === resolve(entry);
+    return canonical(fileURLToPath(metaUrl)) === canonical(entry);
   } catch {
     return false;
   }

--- a/src/utils/plugin-cache.ts
+++ b/src/utils/plugin-cache.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, readdirSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
+import { cpSync, existsSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { homedir, platform } from "node:os";
 
@@ -36,9 +36,13 @@ export function resolveVersionedPluginDir(bundleDir: string): {
   const version = basename(pluginDir);
   if (!isSemver(version)) return null;
   if (basename(versionsRoot) !== "hivemind") return null;
-  const expectedPrefix = resolve(homedir(), ".claude", "plugins", "cache") + sep;
-  if (!resolve(versionsRoot).startsWith(expectedPrefix)) return null;
-  return { pluginDir, versionsRoot, version };
+  const cacheRoot = resolve(homedir(), ".claude", "plugins", "cache");
+  let canonicalRoot = resolve(versionsRoot);
+  let canonicalCache = cacheRoot;
+  try { canonicalRoot = realpathSync.native(canonicalRoot); } catch { /* keep resolved path */ }
+  try { canonicalCache = realpathSync.native(canonicalCache); } catch { /* keep resolved path */ }
+  if (!canonicalRoot.startsWith(canonicalCache + sep)) return null;
+  return { pluginDir: join(canonicalRoot, version), versionsRoot: canonicalRoot, version };
 }
 
 function snapshotPath(pluginDir: string, pid: number): string {

--- a/src/utils/repo-identity.ts
+++ b/src/utils/repo-identity.ts
@@ -12,6 +12,7 @@
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { basename, resolve } from "node:path";
+import { realpathSync } from "node:fs";
 
 /**
  * Default port per scheme. If the URL carries `:<defaultPort>` explicitly,
@@ -82,7 +83,7 @@ export function normalizeGitRemoteUrl(url: string): string {
  * `git config` from inside the repo). CodeRabbit P1 fix.
  */
 export function deriveProjectKey(cwd: string): { key: string; project: string } {
-  const absCwd = resolve(cwd);
+  const absCwd = canonicalPath(cwd);
   const project = basename(absCwd) || "unknown";
   let signature: string | null = null;
   try {
@@ -98,4 +99,9 @@ export function deriveProjectKey(cwd: string): { key: string; project: string } 
   const input = signature ?? absCwd;
   const key = createHash("sha1").update(input).digest("hex").slice(0, 16);
   return { key, project };
+}
+
+export function canonicalPath(path: string): string {
+  const resolvedPath = resolve(path);
+  try { return realpathSync.native(resolvedPath); } catch { return resolvedPath; }
 }

--- a/tests/claude-code/auth-login-dispatch.test.ts
+++ b/tests/claude-code/auth-login-dispatch.test.ts
@@ -24,6 +24,8 @@ const removeMemberMock = vi.fn();
 const sessionPruneMock = vi.fn();
 const consoleLogMock = vi.fn();
 const exitSpy = vi.fn();
+const getAutoupdateEnabledMock = vi.fn();
+const setAutoupdateEnabledMock = vi.fn();
 
 vi.mock("../../src/commands/auth.js", () => ({
   loadCredentials: (...a: unknown[]) => loadCredentialsMock(...a),
@@ -47,6 +49,10 @@ vi.mock("../../src/commands/session-prune.js", () => ({
 // ~/.deeplake/credentials.json and make these assertions machine-dependent.
 vi.mock("../../src/config.js", () => ({
   loadConfig: (...a: unknown[]) => loadConfigMock(...a),
+}));
+vi.mock("../../src/user-config.js", () => ({
+  getAutoupdateEnabled: () => getAutoupdateEnabledMock(),
+  setAutoupdateEnabled: (enabled: boolean) => setAutoupdateEnabledMock(enabled),
 }));
 
 const validCreds = {
@@ -86,6 +92,8 @@ beforeEach(() => {
   sessionPruneMock.mockReset().mockResolvedValue(undefined);
   consoleLogMock.mockReset();
   exitSpy.mockReset();
+  getAutoupdateEnabledMock.mockReset().mockReturnValue(true);
+  setAutoupdateEnabledMock.mockReset();
   vi.spyOn(console, "log").mockImplementation(((...a: unknown[]) => { consoleLogMock(...a); }) as any);
   vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
     exitSpy(code);
@@ -487,25 +495,25 @@ describe("runAuthCommand — sessions prune", () => {
 });
 
 describe("runAuthCommand — autoupdate", () => {
-  it("'autoupdate on' calls saveCredentials with autoupdate:true", async () => {
+  it("'autoupdate on' stores the user preference without rewriting credentials", async () => {
     await run(["autoupdate", "on"]);
-    expect(saveCredentialsMock).toHaveBeenCalledTimes(1);
-    expect(saveCredentialsMock.mock.calls[0][0]).toMatchObject({ ...validCreds, autoupdate: true });
+    expect(setAutoupdateEnabledMock).toHaveBeenCalledWith(true);
+    expect(saveCredentialsMock).not.toHaveBeenCalled();
     expect(consoleText()).toContain("Autoupdate enabled");
   });
 
-  it("'autoupdate off' calls saveCredentials with autoupdate:false", async () => {
+  it("'autoupdate off' stores autoupdate:false", async () => {
     await run(["autoupdate", "off"]);
-    expect(saveCredentialsMock.mock.calls[0][0]).toMatchObject({ autoupdate: false });
+    expect(setAutoupdateEnabledMock).toHaveBeenCalledWith(false);
     expect(consoleText()).toContain("Autoupdate disabled");
   });
 
   it("'autoupdate true/false' aliases work too", async () => {
     await run(["autoupdate", "true"]);
-    expect(saveCredentialsMock.mock.calls[0][0]).toMatchObject({ autoupdate: true });
-    saveCredentialsMock.mockClear();
+    expect(setAutoupdateEnabledMock).toHaveBeenCalledWith(true);
+    setAutoupdateEnabledMock.mockClear();
     await run(["autoupdate", "false"]);
-    expect(saveCredentialsMock.mock.calls[0][0]).toMatchObject({ autoupdate: false });
+    expect(setAutoupdateEnabledMock).toHaveBeenCalledWith(false);
   });
 
   it("'autoupdate' (no arg) prints the current value with 'on' default for missing field", async () => {
@@ -515,15 +523,16 @@ describe("runAuthCommand — autoupdate", () => {
   });
 
   it("'autoupdate' (no arg) prints 'off' when the stored value is explicitly false", async () => {
-    loadCredentialsMock.mockReturnValue({ ...validCreds, autoupdate: false });
+    getAutoupdateEnabledMock.mockReturnValue(false);
     await run(["autoupdate"]);
     expect(consoleText()).toContain("Autoupdate is currently: off");
   });
 
-  it("'autoupdate' without credentials exits 1", async () => {
+  it("'autoupdate' without credentials still reads the user preference", async () => {
     loadCredentialsMock.mockReturnValue(null);
     await run(["autoupdate"]);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(consoleText()).toContain("Autoupdate is currently: on");
   });
 });
 

--- a/tests/claude-code/session-start.test.ts
+++ b/tests/claude-code/session-start.test.ts
@@ -128,10 +128,10 @@ describe("claude-code integration: session-start.js (sync hook)", () => {
     expect(typeof parsed.hookSpecificOutput.additionalContext).toBe("string");
   });
 
-  it("additionalContext contains DEEPLAKE MEMORY", () => {
+  it("additionalContext contains HIVEMIND MEMORY", () => {
     const raw = runHook("session-start.js", baseInput);
     const parsed = JSON.parse(raw);
-    expect(parsed.hookSpecificOutput.additionalContext).toContain("DEEPLAKE MEMORY");
+    expect(parsed.hookSpecificOutput.additionalContext).toContain("HIVEMIND MEMORY");
   });
 
   it("contains login status text", () => {

--- a/tests/cli/cli-bundle-runtime.test.ts
+++ b/tests/cli/cli-bundle-runtime.test.ts
@@ -74,17 +74,13 @@ describe.skipIf(!bundleBuilt)(
         expect(r.status).toBe(0);
       });
 
-      it("graph exits 1 with a friendly user message, not an uncaught exception", () => {
+      it("graph help remains available without the optional parser stack", () => {
         const r = runCli(["graph"]);
-        // Must be a handled exit — process.exit(1), not an unhandled crash.
-        expect(r.status).toBe(1);
-        // The error message must mention tree-sitter so the user knows why.
-        expect(r.stderr).toContain("tree-sitter");
-        // Must NOT be Node.js's raw ERR_MODULE_NOT_FOUND (which would print a
-        // full stack trace and exit(1) via uncaughtException — a crash, not a
-        // graceful degradation).
+        // Only `graph build` needs tree-sitter. Help, diff, and history stay
+        // usable because the parser module is imported inside the build path.
+        expect(r.status).toBe(0);
+        expect(r.stdout).toContain("hivemind graph");
         expect(r.stderr).not.toContain("ERR_MODULE_NOT_FOUND");
-        expect(r.stderr).not.toContain("at node:internal");
       });
     });
   },

--- a/tests/cli/install-cowork.test.ts
+++ b/tests/cli/install-cowork.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { setFakeHome, clearFakeHome } from "../shared/fake-home.js";
 
@@ -33,9 +33,12 @@ beforeEach(() => {
   writeFileSync(join(tmpPkg, "package.json"), JSON.stringify({ version: "5.5.5" }));
 
   setFakeHome(tmpHome);
-  // Linux/macOS test runners: config dir is ~/.config/Claude. (On Windows CI
-  // os.homedir() + the helper keep this under tmpHome too.)
-  configPath = join(tmpHome, ".config", "Claude", "claude_desktop_config.json");
+  const configDir = process.platform === "darwin"
+    ? join(tmpHome, "Library", "Application Support", "Claude")
+    : process.platform === "win32"
+      ? join(tmpHome, "AppData", "Roaming", "Claude")
+      : join(tmpHome, ".config", "Claude");
+  configPath = join(configDir, "claude_desktop_config.json");
   vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 });
@@ -81,7 +84,7 @@ describe("installCowork", () => {
 
   it("merges non-destructively — preserves other servers and top-level keys", async () => {
     if (process.platform === "win32") return;
-    mkdirSync(join(tmpHome, ".config", "Claude"), { recursive: true });
+    mkdirSync(dirname(configPath), { recursive: true });
     writeFileSync(
       configPath,
       JSON.stringify({
@@ -112,7 +115,7 @@ describe("installCowork", () => {
 
   it("refuses to clobber a malformed config and surfaces a clear error", async () => {
     if (process.platform === "win32") return;
-    mkdirSync(join(tmpHome, ".config", "Claude"), { recursive: true });
+    mkdirSync(dirname(configPath), { recursive: true });
     writeFileSync(configPath, "{ not valid json ");
 
     const { installCowork } = await importCowork();
@@ -129,7 +132,7 @@ describe("installCowork", () => {
 describe("uninstallCowork", () => {
   it("removes only the hivemind entry, preserving other servers", async () => {
     if (process.platform === "win32") return;
-    mkdirSync(join(tmpHome, ".config", "Claude"), { recursive: true });
+    mkdirSync(dirname(configPath), { recursive: true });
     writeFileSync(
       configPath,
       JSON.stringify({
@@ -152,7 +155,7 @@ describe("uninstallCowork", () => {
 
   it("deletes the file when hivemind was its only content", async () => {
     if (process.platform === "win32") return;
-    mkdirSync(join(tmpHome, ".config", "Claude"), { recursive: true });
+    mkdirSync(dirname(configPath), { recursive: true });
     writeFileSync(
       configPath,
       JSON.stringify({ mcpServers: { hivemind: { command: "node", args: ["/x"] } } }),

--- a/tests/cursor/cursor-session-start-hook.test.ts
+++ b/tests/cursor/cursor-session-start-hook.test.ts
@@ -162,7 +162,7 @@ describe("cursor session-start hook — additional_context payload", () => {
     await runHook();
     const json = consoleLogMock.mock.calls[0][0] as string;
     const payload = JSON.parse(json);
-    expect(payload.additional_context).toContain("DEEPLAKE MEMORY");
+    expect(payload.additional_context).toContain("HIVEMIND MEMORY");
     expect(payload.additional_context).toContain("Logged in to Deeplake as org: acme");
     expect(payload.additional_context).toContain("Hivemind v0.7.0");
   });

--- a/tests/fixtures/sqlite-writer.ts
+++ b/tests/fixtures/sqlite-writer.ts
@@ -1,0 +1,27 @@
+import { SqliteBackend } from "../../src/storage/sqlite.js";
+
+const [databasePath, writerId, countRaw] = process.argv.slice(2);
+const count = Number.parseInt(countRaw, 10);
+const names = {
+  memory: "memory",
+  sessions: "sessions",
+  skills: "skills",
+  rules: "hivemind_rules",
+  goals: "hivemind_goals",
+  kpis: "hivemind_kpis",
+  docs: "hivemind_docs",
+  codebase: "codebase",
+};
+
+const backend = new SqliteBackend(databasePath, "sessions", names);
+try {
+  await backend.ensureSessionsTable("sessions");
+  for (let index = 0; index < count; index++) {
+    await backend.execute(
+      `INSERT INTO "sessions" (id, path, filename, message, author) VALUES ($1, $2, $3, $4, $5)`,
+      [`${writerId}-${index}`, `/sessions/${writerId}-${index}.jsonl`, `${writerId}-${index}.jsonl`, { writerId, index }, writerId],
+    );
+  }
+} finally {
+  await backend.close();
+}

--- a/tests/hermes/hermes-session-start-hook.test.ts
+++ b/tests/hermes/hermes-session-start-hook.test.ts
@@ -162,7 +162,7 @@ describe("hermes session-start hook — context payload", () => {
   it("logged-in branch: emits {context: ...} with the org line + version notice", async () => {
     await runHook();
     const payload = JSON.parse(consoleLogMock.mock.calls[0][0] as string);
-    expect(payload.context).toContain("DEEPLAKE MEMORY");
+    expect(payload.context).toContain("HIVEMIND MEMORY");
     expect(payload.context).toContain("Logged in to Deeplake as org: acme");
     expect(payload.context).toContain("Hivemind v0.7.0");
     // Hermes uses 'context' not 'additional_context' (Cursor's key).

--- a/tests/shared/deeplake-api.test.ts
+++ b/tests/shared/deeplake-api.test.ts
@@ -1188,18 +1188,18 @@ describe("traceSql (indirect, via query() with trace env set)", () => {
     delete process.env.HIVEMIND_DEBUG;
   });
 
-  it("writes [deeplake-sql] to stderr when HIVEMIND_TRACE_SQL=1", async () => {
+  it("writes [hivemind-sql] to stderr when HIVEMIND_TRACE_SQL=1", async () => {
     process.env.HIVEMIND_TRACE_SQL = "1";
     mockFetch.mockResolvedValueOnce(jsonResponse({ columns: ["a"], rows: [["x"]] }));
     await makeApi().query("SELECT a FROM t");
-    const wrote = stderrSpy.mock.calls.some(c => String(c[0]).includes("[deeplake-sql]"));
+    const wrote = stderrSpy.mock.calls.some(c => String(c[0]).includes("[hivemind-sql]"));
     expect(wrote).toBe(true);
   });
 
-  it("does not write [deeplake-sql] to stderr when trace env vars are unset", async () => {
+  it("does not write [hivemind-sql] to stderr when trace env vars are unset", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ columns: ["a"], rows: [["x"]] }));
     await makeApi().query("SELECT a FROM t");
-    const wrote = stderrSpy.mock.calls.some(c => String(c[0]).includes("[deeplake-sql]"));
+    const wrote = stderrSpy.mock.calls.some(c => String(c[0]).includes("[hivemind-sql]"));
     expect(wrote).toBe(false);
   });
 });

--- a/tests/shared/dir-config-single-source.test.ts
+++ b/tests/shared/dir-config-single-source.test.ts
@@ -7,17 +7,17 @@ import { fileURLToPath } from "node:url";
  * SINGLE-SOURCE-OF-TRUTH GUARD for per-directory workspace routing.
  *
  * `.hivemind` routing broke repeatedly because it was wired writer-by-writer:
- * each new code path that built a DeeplakeApi from a raw `loadConfig()` silently
+ * each new code path that built a storage backend from a raw `loadConfig()` silently
  * wrote/read the GLOBAL workspace instead of the directory's routed one (the
  * skillify/goals/rules/other-agent bugs). This test makes that class of
  * regression impossible to merge.
  *
- * The invariant: every module that constructs a `DeeplakeApi` MUST obtain its
+ * The invariant: every module that constructs a storage backend MUST obtain its
  * config through a router — `loadRoutedConfig` (the single entry point) or
  * `resolveDirConfig`/`resolveCaptureConfig` (when it also needs the `collect`
  * flag) — UNLESS it is explicitly allow-listed below with a reason.
  *
- * Adding a new DeeplakeApi call site therefore forces a choice: route it, or
+ * Adding a new storage call site therefore forces a choice: route it, or
  * justify why it doesn't (account-level op, creds-based, no directory context).
  * A silent unrouted writer can no longer slip in.
  */
@@ -26,10 +26,14 @@ const __dir = fileURLToPath(new URL(".", import.meta.url));
 const SRC = join(__dir, "..", "..", "src");
 
 /**
- * Files that build a DeeplakeApi but intentionally do NOT route through
+ * Files that build a storage backend but intentionally do NOT route through
  * `.hivemind`. Each MUST carry a reason — this list is the audit trail.
  */
 const ALLOWLIST: Record<string, string> = {
+  "commands/backend.ts":
+    "Global provider selection and connectivity checks are user-level configuration, not directory workspace operations.",
+  "hooks/worker-storage.ts":
+    "Detached workers receive already-routed provider metadata from their parent and have no independent directory context.",
   "commands/session-prune.ts":
     "Account-level cleanup of the user's own sessions; not scoped to a directory's workspace.",
   "commands/docs.ts":
@@ -61,11 +65,13 @@ function rel(abs: string): string {
 
 describe("dir-config single source of truth", () => {
   const files = walk(SRC);
-  const apiSites = files.filter((f) => readFileSync(f, "utf-8").includes("new DeeplakeApi("));
+  const isBackendSite = (src: string) => src.includes("createStorageBackend(") || src.includes("new DeeplakeApi(");
+  const providerInfrastructure = new Set(["storage/factory.ts", "deeplake-api.ts"]);
+  const apiSites = files.filter((f) => !providerInfrastructure.has(rel(f)) && isBackendSite(readFileSync(f, "utf-8")));
 
   it("finds DeeplakeApi construction sites to guard (sanity)", () => {
     // If this ever hits 0 the glob/walk broke and the guard is silently vacuous.
-    expect(apiSites.length).toBeGreaterThan(10);
+    expect(apiSites.length).toBeGreaterThan(20);
   });
 
   it("every DeeplakeApi site routes through .hivemind or is allow-listed with a reason", () => {
@@ -77,7 +83,7 @@ describe("dir-config single source of truth", () => {
       const allowed = key in ALLOWLIST;
       if (!routes && !allowed) {
         offenders.push(
-          `${key}: builds a DeeplakeApi from an unrouted config. ` +
+            `${key}: builds a storage backend from an unrouted config. ` +
             `Use loadRoutedConfig() (src/dir-config.ts), or add an ALLOWLIST entry with a reason.`,
         );
       }
@@ -85,7 +91,7 @@ describe("dir-config single source of truth", () => {
     expect(offenders, offenders.join("\n")).toEqual([]);
   });
 
-  it("the allow-list has no stale entries (each still builds a DeeplakeApi and still does not route)", () => {
+  it("the allow-list has no stale entries (each still builds a backend and still does not route)", () => {
     const stale: string[] = [];
     for (const key of Object.keys(ALLOWLIST)) {
       const abs = join(SRC, key);
@@ -96,8 +102,8 @@ describe("dir-config single source of truth", () => {
         stale.push(`${key}: allow-listed but no longer exists — remove it.`);
         continue;
       }
-      if (!src.includes("new DeeplakeApi(")) {
-        stale.push(`${key}: allow-listed but no longer builds a DeeplakeApi — remove it.`);
+      if (!isBackendSite(src)) {
+        stale.push(`${key}: allow-listed but no longer builds a storage backend — remove it.`);
       } else if (ROUTER_TOKENS.some((t) => src.includes(t))) {
         stale.push(`${key}: now routes — remove it from the allow-list so the guard covers it.`);
       }

--- a/tests/shared/embeddings-schema.test.ts
+++ b/tests/shared/embeddings-schema.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { MEMORY_COLUMNS, SESSIONS_COLUMNS, renderColumnSql } from "../../src/deeplake-schema.js";
 
 const BUNDLE_DIRS = [
   "harnesses/claude-code/bundle",
@@ -40,21 +41,20 @@ describe("src-level schema includes new embedding columns", () => {
   // Schemas moved from inline strings in deeplake-api.ts to structured
   // arrays in deeplake-schema.ts. The bundles still need to inline these
   // columns, but the source of truth is now the new module.
-  const schemaSrc = read("src/deeplake-schema.ts");
-
-  // Scope each regex to a single object literal (`[^}]*`) so a later
-  // entry's SQL can't accidentally satisfy the match.
-
   it("MEMORY_COLUMNS includes summary_embedding FLOAT4[]", () => {
-    expect(schemaSrc).toMatch(/name:\s*"summary_embedding"[^}]*FLOAT4\[\]/);
+    const column = MEMORY_COLUMNS.find(item => item.name === "summary_embedding");
+    expect(column?.type).toBe("vector");
+    expect(renderColumnSql(column!, "deeplake")).toBe("FLOAT4[]");
   });
 
   it("SESSIONS_COLUMNS includes message_embedding FLOAT4[]", () => {
-    expect(schemaSrc).toMatch(/name:\s*"message_embedding"[^}]*FLOAT4\[\]/);
+    const column = SESSIONS_COLUMNS.find(item => item.name === "message_embedding");
+    expect(column?.type).toBe("vector");
+    expect(renderColumnSql(column!, "deeplake")).toBe("FLOAT4[]");
   });
 
   it("embedding columns do NOT use TEXT (regression guard)", () => {
-    expect(schemaSrc).not.toMatch(/name:\s*"summary_embedding"[^}]*TEXT/);
-    expect(schemaSrc).not.toMatch(/name:\s*"message_embedding"[^}]*TEXT/);
+    expect(renderColumnSql(MEMORY_COLUMNS.find(item => item.name === "summary_embedding")!, "deeplake")).not.toBe("TEXT");
+    expect(renderColumnSql(SESSIONS_COLUMNS.find(item => item.name === "message_embedding")!, "deeplake")).not.toBe("TEXT");
   });
 });

--- a/tests/shared/graph/deeplake-fs-graph.test.ts
+++ b/tests/shared/graph/deeplake-fs-graph.test.ts
@@ -61,7 +61,7 @@ describe("DeeplakeFs graph bridge — branch coverage", () => {
 
   function seedWorktreeSnapshot(): void {
     const { createHash } = require("node:crypto") as typeof import("node:crypto");
-    const wt = createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+    const wt = createHash("sha256").update(process.cwd()).digest("hex").slice(0, 16);
     mkdirSync(snapshotsDir, { recursive: true });
     const commit = "c".repeat(40);
     const snap = {

--- a/tests/shared/helpers/sql-storage-feature-parity.ts
+++ b/tests/shared/helpers/sql-storage-feature-parity.ts
@@ -1,0 +1,424 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { describe, expect, it } from "vitest";
+import type { Config } from "../../../src/config.js";
+import { computeSnapshotSha256 } from "../../../src/graph/snapshot.js";
+import { pullSnapshot } from "../../../src/graph/deeplake-pull.js";
+import { pushSnapshot } from "../../../src/graph/deeplake-push.js";
+import type { GraphSnapshot } from "../../../src/graph/types.js";
+import { listOpenGoals } from "../../../src/hooks/shared/context-renderer.js";
+import { DeeplakeFs } from "../../../src/shell/deeplake-fs.js";
+import { searchDeeplakeTables, searchDocs } from "../../../src/shell/grep-core.js";
+import { runPull } from "../../../src/skillify/pull.js";
+import { runPush } from "../../../src/skillify/push.js";
+import type { StorageBackend } from "../../../src/storage/backend.js";
+import { deriveProjectKey } from "../../../src/utils/repo-identity.js";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = resolve(import.meta.dirname, "../../..");
+const tsxLoader = join(repoRoot, "node_modules", "tsx", "dist", "loader.mjs");
+
+export interface SqlStorageHarness {
+  backend: StorageBackend;
+  config: Config;
+  root: string;
+  childEnv: NodeJS.ProcessEnv;
+  malformedVector: string | number[];
+  cleanup(): Promise<void>;
+}
+
+export type SqlStorageHarnessFactory = () => Promise<SqlStorageHarness>;
+
+async function withHarness(
+  createHarness: SqlStorageHarnessFactory,
+  scenario: (harness: SqlStorageHarness) => Promise<void>,
+): Promise<void> {
+  const harness = await createHarness();
+  try {
+    await harness.backend.initializeSchema();
+    await scenario(harness);
+  } finally {
+    await harness.cleanup();
+  }
+}
+
+function queryFor(backend: StorageBackend): (sql: string) => Promise<Array<Record<string, unknown>>> {
+  return sql => backend.query(sql);
+}
+
+function writeSkill(root: string, body: string): void {
+  const dir = join(root, ".claude", "skills", "sql-parity");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), [
+    "---",
+    "name: sql-parity",
+    'description: "Verify SQL storage"',
+    'trigger: "when checking SQL storage"',
+    "author: alice",
+    "contributors:",
+    "  - alice",
+    "source_sessions:",
+    "  - session-1",
+    "version: 1",
+    "created_by_agent: codex",
+    "created_at: 2026-01-01T00:00:00.000Z",
+    "---",
+    "",
+    body,
+    "",
+  ].join("\n"));
+}
+
+function snapshotFor(root: string): GraphSnapshot {
+  return {
+    directed: true,
+    multigraph: true,
+    graph: {
+      schema_version: 1,
+      generator: "hivemind-graph",
+      commit_sha: "abc123",
+      repo_key: deriveProjectKey(root).key,
+    },
+    observation: {
+      ts: "2026-01-02T03:04:05.000Z",
+      branch: "main",
+      worktree_path: root,
+      repo_project: "sql-parity",
+      generator_version: "test",
+      source_files_extracted: 1,
+      source_files_skipped: 0,
+    },
+    nodes: [{
+      id: "src/index.ts:main:function",
+      label: "main",
+      kind: "function",
+      source_file: "src/index.ts",
+      source_location: "L1",
+      language: "typescript",
+      exported: true,
+    }],
+    links: [],
+  };
+}
+
+async function runCli(harness: SqlStorageHarness, args: string[]): Promise<string> {
+  const result = await execFileAsync(
+    process.execPath,
+    ["--import", tsxLoader, join(repoRoot, "src", "cli", "index.ts"), ...args],
+    {
+      cwd: harness.root,
+      env: harness.childEnv,
+      timeout: 20_000,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  return result.stdout;
+}
+
+async function callMcpTools(harness: SqlStorageHarness): Promise<void> {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--import", tsxLoader, join(repoRoot, "src", "mcp", "server.ts")],
+    cwd: harness.root,
+    env: harness.childEnv as Record<string, string>,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "sql-storage-parity", version: "1.0.0" });
+  try {
+    await client.connect(transport);
+    const listed = await client.listTools();
+    expect(listed.tools.map(tool => tool.name).sort()).toEqual([
+      "hivemind_docs_search",
+      "hivemind_index",
+      "hivemind_read",
+      "hivemind_search",
+    ]);
+
+    const index = await client.callTool({ name: "hivemind_index", arguments: {} });
+    expect(JSON.stringify(index)).toContain("/summaries/alice/mcp.md");
+
+    const read = await client.callTool({
+      name: "hivemind_read",
+      arguments: { path: "/summaries/alice/mcp.md" },
+    });
+    expect(JSON.stringify(read)).toContain("MCP lexical needle");
+
+    const search = await client.callTool({
+      name: "hivemind_search",
+      arguments: { query: "lexical needle", limit: 10 },
+    });
+    expect(JSON.stringify(search)).toContain("/summaries/alice/mcp.md");
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+export function registerSqlStorageFeatureParity(
+  label: string,
+  enabled: boolean,
+  createHarness: SqlStorageHarnessFactory,
+): void {
+  const suite = enabled ? describe.sequential : describe.skip;
+
+  suite(`${label} real-backend feature parity`, () => {
+    it("round-trips goals and KPIs, transitions status, and isolates latest-version reads", async () => {
+      await withHarness(createHarness, async ({ backend }) => {
+        const fs = await DeeplakeFs.create(backend, "memory", "/", "sessions", {
+          goalsTable: "hivemind_goals",
+          kpisTable: "hivemind_kpis",
+        });
+        await fs.writeFile("/goal/alice/opened/goal-1.md", "Ship SQL storage");
+        await fs.writeFile(
+          "/kpi/goal-1/k-tests.md",
+          "Passing scenarios\n\n- target: 8\n- current: 1\n- unit: tests",
+        );
+        await fs.flush();
+        await fs.mv(
+          "/goal/alice/opened/goal-1.md",
+          "/goal/alice/in_progress/goal-1.md",
+        );
+        await fs.writeFile(
+          "/kpi/goal-1/k-tests.md",
+          "Passing scenarios\n\n- target: 8\n- current: 2\n- unit: tests",
+        );
+        await fs.flush();
+
+        expect(await fs.readFile("/goal/alice/in_progress/goal-1.md")).toBe("Ship SQL storage");
+        expect(await fs.readFile("/kpi/goal-1/k-tests.md")).toContain("current: 2");
+        expect(await backend.query(
+          `SELECT status, content, version FROM "hivemind_goals" WHERE goal_id = $1`,
+          ["goal-1"],
+        )).toEqual([{ status: "in_progress", content: "Ship SQL storage", version: 1 }]);
+
+        await backend.execute(
+          `INSERT INTO "hivemind_goals" (id, goal_id, owner, status, content, version, created_at) VALUES ` +
+          `($1, $2, $3, $4, $5, $6, $7), ($8, $9, $10, $11, $12, $13, $14), ` +
+          `($15, $16, $17, $18, $19, $20, $21)`,
+          [
+            randomUUID(), "versioned", "alice", "closed", "old version", 1, "2026-01-01T00:00:00Z",
+            randomUUID(), "versioned", "alice", "opened", "latest version", 2, "2026-01-02T00:00:00Z",
+            randomUUID(), "private", "bob", "opened", "must not leak", 1, "2026-01-03T00:00:00Z",
+          ],
+        );
+        const goals = await listOpenGoals(queryFor(backend), "hivemind_goals", "alice");
+        expect(goals).toEqual(expect.arrayContaining([
+          { goal_id: "goal-1", status: "in_progress", content: "Ship SQL storage" },
+          { goal_id: "versioned", status: "opened", content: "latest version" },
+        ]));
+        expect(goals.some(goal => goal.content === "old version" || goal.content === "must not leak")).toBe(false);
+      });
+    });
+
+    it("pushes, discovers, and idempotently updates versioned skills", async () => {
+      await withHarness(createHarness, async ({ backend, config, root }) => {
+        const previousState = process.env.HIVEMIND_STATE_DIR;
+        process.env.HIVEMIND_STATE_DIR = join(root, "state");
+        try {
+          writeSkill(root, "## Workflow\n\nVersion one.");
+          const base = {
+            query: queryFor(backend),
+            tableName: config.skillsTableName,
+            workspaceId: config.workspaceId,
+            from: "project" as const,
+            cwd: root,
+            skillName: "sql-parity",
+            pusher: "alice",
+            scope: "team" as const,
+            agent: "codex",
+          };
+          const first = await runPush({ ...base, now: "2026-01-02T00:00:00.000Z" });
+          expect(first.version).toBe(1);
+          writeSkill(root, "## Workflow\n\nVersion two.");
+          const second = await runPush({ ...base, now: "2026-01-03T00:00:00.000Z" });
+          expect(second).toMatchObject({ previousVersion: 1, version: 2 });
+
+          const pullRoot = join(root, "consumer");
+          const pulled = await runPull({
+            query: queryFor(backend),
+            tableName: config.skillsTableName,
+            install: "project",
+            cwd: pullRoot,
+            users: ["alice"],
+            skillName: "sql-parity",
+          });
+          expect(pulled).toMatchObject({ scanned: 1, wrote: 1, skipped: 0 });
+          const skillPath = join(pullRoot, ".claude", "skills", "sql-parity--alice", "SKILL.md");
+          expect(readFileSync(skillPath, "utf-8")).toContain("Version two.");
+          expect(readFileSync(skillPath, "utf-8")).toContain("version: 2");
+
+          const repeated = await runPull({
+            query: queryFor(backend),
+            tableName: config.skillsTableName,
+            install: "project",
+            cwd: pullRoot,
+            users: ["alice"],
+            skillName: "sql-parity",
+          });
+          expect(repeated).toMatchObject({ scanned: 1, wrote: 0, skipped: 1 });
+          expect(await backend.query(
+            `SELECT version FROM "skills" WHERE name = $1 AND author = $2 ORDER BY version`,
+            ["sql-parity", "alice"],
+          )).toEqual([{ version: 1 }, { version: 2 }]);
+        } finally {
+          if (previousState === undefined) delete process.env.HIVEMIND_STATE_DIR;
+          else process.env.HIVEMIND_STATE_DIR = previousState;
+        }
+      });
+    });
+
+    it("pushes and pulls graph snapshots through the codebase table", async () => {
+      await withHarness(createHarness, async ({ backend, config, root }) => {
+        const previousGraphsHome = process.env.HIVEMIND_GRAPHS_HOME;
+        process.env.HIVEMIND_GRAPHS_HOME = join(root, "graphs");
+        try {
+          const snapshot = snapshotFor(root);
+          const pushed = await pushSnapshot(snapshot, "worktree-a", {
+            loadConfig: () => config,
+            makeApi: () => backend,
+            cwd: root,
+          });
+          expect(pushed).toEqual({ kind: "inserted", commitSha: "abc123" });
+          expect(await pushSnapshot(snapshot, "worktree-a", {
+            loadConfig: () => config,
+            makeApi: () => backend,
+            cwd: root,
+          })).toEqual({ kind: "already-current", commitSha: "abc123" });
+
+          const rows = await backend.query(
+            `SELECT snapshot_sha256, node_count, edge_count FROM "codebase" WHERE commit_sha = $1`,
+            ["abc123"],
+          );
+          expect(rows).toEqual([{
+            snapshot_sha256: computeSnapshotSha256(snapshot),
+            node_count: 1,
+            edge_count: 0,
+          }]);
+
+          const pulled = await pullSnapshot(root, {
+            loadConfig: () => config,
+            makeApi: () => backend,
+            readHead: () => "abc123",
+          });
+          expect(pulled.kind).toBe("pulled");
+          expect(existsSync(join(
+            process.env.HIVEMIND_GRAPHS_HOME,
+            snapshot.graph.repo_key,
+            "snapshots",
+            "abc123.json",
+          ))).toBe(true);
+        } finally {
+          if (previousGraphsHome === undefined) delete process.env.HIVEMIND_GRAPHS_HOME;
+          else process.env.HIVEMIND_GRAPHS_HOME = previousGraphsHome;
+        }
+      });
+    });
+
+    it("serves MCP list, read, and lexical search operations", async () => {
+      await withHarness(createHarness, async (harness) => {
+        harness.backend.appendRows([{
+          path: "/summaries/alice/mcp.md",
+          filename: "mcp.md",
+          contentText: "MCP lexical needle",
+          mimeType: "text/markdown",
+          sizeBytes: 18,
+          project: deriveProjectKey(harness.root).key,
+          description: "MCP parity",
+        }]);
+        await harness.backend.commit();
+        await harness.backend.execute(
+          `INSERT INTO "sessions" (id, path, filename, message, author, creation_date, project) ` +
+          `VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+          [randomUUID(), "/sessions/alice/mcp.jsonl", "mcp.jsonl", { type: "user_message", content: "secondary needle" }, "alice", "2026-01-01T00:00:00Z", "parity"],
+        );
+        await callMcpTools(harness);
+      });
+    }, 30_000);
+
+    it("prunes only matching sessions and their summaries", async () => {
+      await withHarness(createHarness, async (harness) => {
+        const rows = [
+          ["old-a", "/sessions/alice/alice_local_default_old.jsonl", "alice", "2024-01-01T00:00:00Z"],
+          ["new-a", "/sessions/alice/alice_local_default_new.jsonl", "alice", "2026-01-01T00:00:00Z"],
+          ["old-b", "/sessions/bob/bob_local_default_bobold.jsonl", "bob", "2024-01-01T00:00:00Z"],
+        ];
+        for (const [id, path, author, created] of rows) {
+          await harness.backend.execute(
+            `INSERT INTO "sessions" (id, path, filename, message, author, creation_date, project) ` +
+            `VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            [id, path, `${id}.jsonl`, { type: "user_message", content: id }, author, created, "parity"],
+          );
+        }
+        harness.backend.appendRows([
+          { path: "/summaries/alice/old.md", filename: "old.md", contentText: "old", mimeType: "text/markdown", sizeBytes: 3 },
+          { path: "/summaries/alice/new.md", filename: "new.md", contentText: "new", mimeType: "text/markdown", sizeBytes: 3 },
+          { path: "/summaries/alice/bobold.md", filename: "bobold.md", contentText: "bob", mimeType: "text/markdown", sizeBytes: 3 },
+        ]);
+        await harness.backend.commit();
+
+        const output = await runCli(harness, ["sessions", "prune", "--before", "2025-01-01", "--yes"]);
+        expect(output).toContain("Deleted 1 session(s) and 1 summary file(s).");
+        expect(await harness.backend.query(`SELECT id FROM "sessions" ORDER BY id`)).toEqual([
+          { id: "new-a" },
+          { id: "old-b" },
+        ]);
+        expect(await harness.backend.query(`SELECT path FROM "memory" ORDER BY path`)).toEqual([
+          { path: "/summaries/alice/bobold.md" },
+          { path: "/summaries/alice/new.md" },
+        ]);
+      });
+    }, 30_000);
+
+    it("keeps lexical results when embeddings are disabled or stored vectors are malformed", async () => {
+      await withHarness(createHarness, async ({ backend, malformedVector }) => {
+        backend.appendRows([{
+          path: "/summaries/alice/fallback.md",
+          filename: "fallback.md",
+          contentText: "lexical fallback survives",
+          mimeType: "text/markdown",
+          sizeBytes: 25,
+        }]);
+        await backend.commit();
+        await backend.execute(
+          `UPDATE "memory" SET summary_embedding = $1 WHERE path = $2`,
+          [malformedVector, "/summaries/alice/fallback.md"],
+        );
+
+        const base = {
+          pathFilter: "",
+          contentScanOnly: false,
+          likeOp: "ILIKE" as const,
+          escapedPattern: "%FALLBACK%",
+          limit: 10,
+        };
+        const disabled = await searchDeeplakeTables(backend, "memory", "sessions", {
+          ...base,
+          queryEmbedding: null,
+        });
+        expect(disabled.map(row => row.path)).toContain("/summaries/alice/fallback.md");
+        const malformed = await searchDeeplakeTables(backend, "memory", "sessions", {
+          ...base,
+          queryEmbedding: [1, 0],
+        });
+        expect(malformed.map(row => row.path)).toContain("/summaries/alice/fallback.md");
+
+        await backend.execute(
+          `INSERT INTO "hivemind_docs" (id, doc_id, path, content, content_embedding, project, status) ` +
+          `VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+          [randomUUID(), "src/fallback.ts", "/docs/src/fallback.ts.md", "docs lexical fallback", malformedVector, "parity", "active"],
+        );
+        const docs = await searchDocs(queryFor(backend), "hivemind_docs", {
+          ...base,
+          escapedPattern: "%LEXICAL%",
+          queryEmbedding: [1, 0],
+          project: "parity",
+        }, backend.dialect);
+        expect(docs.map(row => row.path)).toContain("src/fallback.ts");
+      });
+    });
+  });
+}

--- a/tests/shared/storage-config.test.ts
+++ b/tests/shared/storage-config.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadStorageConfig } from "../../src/config.js";
+import { renderBackendStatus, runBackendCommand, selectedBackend } from "../../src/commands/backend.js";
+import { _resetUserConfigForTesting, _setConfigPathForTesting, readUserConfig, writeUserConfig } from "../../src/user-config.js";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "hivemind-storage-config-"));
+  _setConfigPathForTesting(() => join(root, "config.json"));
+  for (const key of ["HIVEMIND_BACKEND", "HIVEMIND_SQLITE_PATH", "HIVEMIND_POSTGRES_URL", "HIVEMIND_POSTGRES_SCHEMA", "HIVEMIND_VECTOR_SCAN_LIMIT"]) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  _resetUserConfigForTesting();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("storage configuration", () => {
+  it("loads SQLite without Deeplake credentials", () => {
+    const dbPath = join(root, "local.sqlite3");
+    writeUserConfig({ storage: { provider: "sqlite", sqlitePath: dbPath } });
+    const config = loadStorageConfig();
+    expect(config).toMatchObject({ kind: "sqlite", path: dbPath, vectorScanLimit: 2000 });
+  });
+
+  it("applies environment precedence and validates scan limits", () => {
+    writeUserConfig({ storage: { provider: "sqlite", sqlitePath: join(root, "stored.sqlite3") } });
+    process.env.HIVEMIND_SQLITE_PATH = join(root, "env.sqlite3");
+    process.env.HIVEMIND_VECTOR_SCAN_LIMIT = "37";
+    expect(loadStorageConfig()).toMatchObject({ kind: "sqlite", path: join(root, "env.sqlite3"), vectorScanLimit: 37 });
+  });
+
+  it("requires the PostgreSQL URL and never renders it", () => {
+    writeUserConfig({ storage: { provider: "postgres", postgresSchema: "team_memory" } });
+    expect(loadStorageConfig()).toBeNull();
+    process.env.HIVEMIND_POSTGRES_URL = "postgres://secret-user:secret-pass@example.test/db";
+    expect(loadStorageConfig()).toMatchObject({ kind: "postgres", schema: "team_memory" });
+    const status = renderBackendStatus();
+    expect(status).toContain("configured via environment");
+    expect(status).not.toContain("secret-user");
+    expect(status).not.toContain("secret-pass");
+  });
+
+  it("rejects invalid provider and schema identifiers", () => {
+    process.env.HIVEMIND_BACKEND = "unknown";
+    expect(() => loadStorageConfig()).toThrow(/Invalid HIVEMIND_BACKEND/);
+    process.env.HIVEMIND_BACKEND = "postgres";
+    process.env.HIVEMIND_POSTGRES_URL = "postgres://example/db";
+    process.env.HIVEMIND_POSTGRES_SCHEMA = "bad;drop";
+    expect(() => loadStorageConfig()).toThrow(/Invalid PostgreSQL schema/);
+  });
+
+  it("switches to SQLite only after a successful connectivity check", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const dbPath = join(root, "selected.sqlite3");
+    await expect(runBackendCommand(["use", "sqlite", "--path", dbPath])).resolves.toBe(0);
+    expect(selectedBackend()).toBe("sqlite");
+    expect(readUserConfig().storage).toEqual({ provider: "sqlite", sqlitePath: dbPath });
+    await expect(runBackendCommand(["check"])).resolves.toBe(0);
+    expect(log.mock.calls.flat().join(" ")).toContain("sqlite backend: ok");
+  });
+
+  it("does not select PostgreSQL when the environment URL is missing", async () => {
+    await expect(runBackendCommand(["use", "postgres", "--schema", "team_memory"]))
+      .rejects.toThrow(/HIVEMIND_POSTGRES_URL/);
+    expect(readUserConfig().storage).toBeUndefined();
+  });
+});

--- a/tests/shared/storage-config.test.ts
+++ b/tests/shared/storage-config.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { loadStorageConfig } from "../../src/config.js";
 import { renderBackendStatus, runBackendCommand, selectedBackend } from "../../src/commands/backend.js";
+import { createStorageBackend } from "../../src/storage/factory.js";
 import { _resetUserConfigForTesting, _setConfigPathForTesting, readUserConfig, writeUserConfig } from "../../src/user-config.js";
 
 let root: string;
@@ -65,11 +66,111 @@ describe("storage configuration", () => {
     expect(readUserConfig().storage).toEqual({ provider: "sqlite", sqlitePath: dbPath });
     await expect(runBackendCommand(["check"])).resolves.toBe(0);
     expect(log.mock.calls.flat().join(" ")).toContain("sqlite backend: ok");
+    const config = loadStorageConfig();
+    expect(config?.kind).toBe("sqlite");
+    const backend = createStorageBackend(config!);
+    expect(await backend.listTables()).toEqual([
+      "codebase", "hivemind_docs", "hivemind_goals", "hivemind_kpis",
+      "hivemind_rules", "memory", "sessions", "skills",
+    ]);
+    await backend.close();
   });
 
   it("does not select PostgreSQL when the environment URL is missing", async () => {
     await expect(runBackendCommand(["use", "postgres", "--schema", "team_memory"]))
       .rejects.toThrow(/HIVEMIND_POSTGRES_URL/);
     expect(readUserConfig().storage).toBeUndefined();
+  });
+
+  it("renders default, SQLite, and PostgreSQL status without secrets", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(renderBackendStatus()).toContain("Backend: deeplake\nSelected by: default");
+    await expect(runBackendCommand(["status"])).resolves.toBe(0);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Connection: Deeplake credentials"));
+
+    process.env.HIVEMIND_BACKEND = "sqlite";
+    process.env.HIVEMIND_SQLITE_PATH = join(homedir(), ".deeplake", "status.sqlite3");
+    expect(renderBackendStatus()).toContain("Database: ~/.deeplake/status.sqlite3");
+    expect(renderBackendStatus()).toContain("Selected by: environment");
+
+    process.env.HIVEMIND_BACKEND = "postgres";
+    delete process.env.HIVEMIND_POSTGRES_URL;
+    process.env.HIVEMIND_POSTGRES_SCHEMA = "status_schema";
+    expect(renderBackendStatus()).toContain("Schema: status_schema");
+    expect(renderBackendStatus()).toContain("Connection: not configured");
+  });
+
+  it("persists Deeplake selection and accepts equals-style SQLite paths", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    writeUserConfig({ storage: { provider: "sqlite", sqlitePath: join(root, "old.sqlite3") } });
+    await expect(runBackendCommand(["use", "deeplake"])).resolves.toBe(0);
+    expect(readUserConfig().storage).toEqual({ provider: "deeplake", sqlitePath: join(root, "old.sqlite3") });
+
+    const path = join(root, "equals.sqlite3");
+    await expect(runBackendCommand(["use", "sqlite", `--path=${path}`])).resolves.toBe(0);
+    expect(readUserConfig().storage).toEqual({ provider: "sqlite", sqlitePath: path });
+  });
+
+  it("rejects invalid backend command shapes and PostgreSQL schemas", async () => {
+    await expect(runBackendCommand(["wat"])).rejects.toThrow("Usage: hivemind backend status");
+    await expect(runBackendCommand(["use"])).rejects.toThrow("Usage: hivemind backend use");
+    await expect(runBackendCommand(["use", "unknown"])).rejects.toThrow("Usage: hivemind backend use");
+    process.env.HIVEMIND_POSTGRES_URL = "postgresql://secret:password@example.invalid/db";
+    await expect(runBackendCommand(["use", "postgres", "--schema", "bad;drop"]))
+      .rejects.toThrow("Invalid PostgreSQL schema");
+    expect(readUserConfig().storage).toBeUndefined();
+  });
+
+  it("reports missing configuration from backend check", async () => {
+    process.env.HIVEMIND_BACKEND = "postgres";
+    await expect(runBackendCommand(["check"])).rejects.toThrow("PostgreSQL backend requires HIVEMIND_POSTGRES_URL");
+  });
+
+  it("uses persisted status values when environment overrides are absent", () => {
+    const sqlitePath = join(root, "persisted.sqlite3");
+    writeUserConfig({ storage: { provider: "sqlite", sqlitePath } });
+    expect(renderBackendStatus()).toContain("Selected by: user config");
+    expect(renderBackendStatus()).toContain(`Database: ${sqlitePath}`);
+
+    writeUserConfig({ storage: { provider: "postgres", postgresSchema: "persisted_schema" } });
+    expect(renderBackendStatus()).toContain("Schema: persisted_schema");
+  });
+
+  it("uses the default SQLite path and restores pre-existing provider environment", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    process.env.HIVEMIND_BACKEND = "deeplake";
+    process.env.HIVEMIND_SQLITE_PATH = join(root, "previous.sqlite3");
+    try {
+      await expect(runBackendCommand(["use", "sqlite"])).resolves.toBe(0);
+      expect(readUserConfig().storage).toEqual({
+        provider: "sqlite",
+        sqlitePath: join(root, ".deeplake", "hivemind.sqlite3"),
+      });
+      expect(process.env.HIVEMIND_BACKEND).toBe("deeplake");
+      expect(process.env.HIVEMIND_SQLITE_PATH).toBe(join(root, "previous.sqlite3"));
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+  });
+
+  it("surfaces provider query failures and still closes the backend", async () => {
+    process.env.HIVEMIND_BACKEND = "sqlite";
+    process.env.HIVEMIND_SQLITE_PATH = root;
+    await expect(runBackendCommand(["check"])).rejects.toThrow();
+  });
+
+  it("reports missing Deeplake credentials during check", async () => {
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    process.env.HIVEMIND_BACKEND = "deeplake";
+    try {
+      await expect(runBackendCommand(["check"])).rejects.toThrow("Deeplake backend requires login credentials");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
   });
 });

--- a/tests/shared/storage-factory.test.ts
+++ b/tests/shared/storage-factory.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StorageBackend, StorageKind } from "../../src/storage/backend.js";
+import type { StorageConfig } from "../../src/config.js";
+
+const state = vi.hoisted(() => ({
+  constructorCalls: [] as Array<{ kind: StorageKind; args: unknown[] }>,
+  backends: [] as StorageBackend[],
+}));
+
+function fakeBackend(kind: StorageKind, tableName: string): StorageBackend {
+  const backend = {
+    kind,
+    dialect: kind === "sqlite" ? "sqlite" : kind === "postgres" ? "postgres" : "deeplake",
+    capabilities: {
+      serverVectorSearch: kind === "deeplake",
+      transactions: kind !== "deeplake",
+      json: kind === "sqlite" ? "text" : "native",
+      vectors: kind === "sqlite" ? "json-text" : kind === "postgres" ? "array" : "server",
+    },
+    tableName,
+    query: vi.fn().mockResolvedValue([{ ok: 1 }]),
+    execute: vi.fn().mockResolvedValue({ rowCount: 1 }),
+    transaction: vi.fn(async (fn: (tx: StorageBackend) => Promise<unknown>) => fn(backend as StorageBackend)),
+    listTables: vi.fn().mockResolvedValue(["memory"]),
+    knownTablesOrNull: vi.fn().mockResolvedValue(["memory"]),
+    getColumns: vi.fn().mockResolvedValue(["id"]),
+    initializeSchema: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    appendRows: vi.fn(),
+    commit: vi.fn().mockResolvedValue(undefined),
+    updateColumns: vi.fn().mockResolvedValue(undefined),
+    createIndex: vi.fn().mockResolvedValue(undefined),
+    ensureTable: vi.fn().mockResolvedValue(undefined),
+    ensureSessionsTable: vi.fn().mockResolvedValue(undefined),
+    ensureSkillsTable: vi.fn().mockResolvedValue(undefined),
+    ensureRulesTable: vi.fn().mockResolvedValue(undefined),
+    ensureGoalsTable: vi.fn().mockResolvedValue(undefined),
+    ensureKpisTable: vi.fn().mockResolvedValue(undefined),
+    ensureDocsTable: vi.fn().mockResolvedValue(undefined),
+    ensureCodebaseTable: vi.fn().mockResolvedValue(undefined),
+  } as unknown as StorageBackend;
+  state.backends.push(backend);
+  return backend;
+}
+
+vi.mock("../../src/storage/sqlite.js", () => ({
+  SqliteBackend: class {
+    constructor(...args: unknown[]) {
+      state.constructorCalls.push({ kind: "sqlite", args });
+      return fakeBackend("sqlite", String(args[1]));
+    }
+  },
+}));
+
+vi.mock("../../src/storage/postgres.js", () => ({
+  PostgresBackend: class {
+    constructor(...args: unknown[]) {
+      state.constructorCalls.push({ kind: "postgres", args });
+      return fakeBackend("postgres", String(args[2]));
+    }
+  },
+}));
+
+vi.mock("../../src/deeplake-api.js", () => ({
+  DeeplakeApi: class {
+    constructor(...args: unknown[]) {
+      state.constructorCalls.push({ kind: "deeplake", args });
+      return fakeBackend("deeplake", String(args[4]));
+    }
+  },
+}));
+
+import { createStorageBackend } from "../../src/storage/factory.js";
+
+function config(kind: "sqlite" | "postgres"): StorageConfig {
+  const common = {
+    userName: "alice",
+    workspaceId: "default",
+    tableName: "memory",
+    sessionsTableName: "sessions",
+    skillsTableName: "skills",
+    rulesTableName: "rules",
+    goalsTableName: "goals",
+    kpisTableName: "kpis",
+    docsTableName: "docs",
+    codebaseTableName: "codebase",
+    memoryPath: "/tmp/memory",
+    vectorScanLimit: 100,
+    orgId: "local" as const,
+    orgName: "local" as const,
+  };
+  return kind === "sqlite"
+    ? { ...common, kind, path: "/tmp/test.sqlite3" }
+    : { ...common, kind, connectionUrl: "postgresql://example/test", schema: "test_schema" };
+}
+
+beforeEach(() => {
+  state.constructorCalls.length = 0;
+  state.backends.length = 0;
+});
+
+describe.each(["sqlite", "postgres"] as const)("lazy %s storage factory", kind => {
+  it("loads on demand, flushes queued rows, and delegates the complete backend contract", async () => {
+    const wrapper = createStorageBackend(config(kind), "alternate");
+    expect(state.constructorCalls).toEqual([]);
+    wrapper.appendRows([{ path: "/a", filename: "a", contentText: "a", mimeType: "text/plain", sizeBytes: 1 }]);
+    await wrapper.commit();
+
+    const concrete = state.backends[0];
+    expect(state.constructorCalls[0]?.kind).toBe(kind);
+    expect(concrete.tableName).toBe("alternate");
+    expect(concrete.appendRows).toHaveBeenCalledTimes(1);
+    expect(concrete.commit).toHaveBeenCalledTimes(1);
+
+    const signal = new AbortController().signal;
+    await expect(wrapper.query("SELECT 1", [], signal)).resolves.toEqual([{ ok: 1 }]);
+    await expect(wrapper.execute("UPDATE x", [1])).resolves.toEqual({ rowCount: 1 });
+    await expect(wrapper.transaction(async tx => tx.query("SELECT 2"))).resolves.toEqual([{ ok: 1 }]);
+    await expect(wrapper.listTables(true)).resolves.toEqual(["memory"]);
+    await expect(wrapper.knownTablesOrNull()).resolves.toEqual(["memory"]);
+    await expect(wrapper.getColumns("memory")).resolves.toEqual(["id"]);
+    await wrapper.initializeSchema();
+    await wrapper.updateColumns("/a", { size_bytes: 2 });
+    await wrapper.createIndex("path");
+    await wrapper.ensureTable("memory");
+    await wrapper.ensureSessionsTable("sessions");
+    await wrapper.ensureSkillsTable("skills");
+    await wrapper.ensureRulesTable("rules");
+    await wrapper.ensureGoalsTable("goals");
+    await wrapper.ensureKpisTable("kpis");
+    await wrapper.ensureDocsTable("docs");
+    await wrapper.ensureCodebaseTable("codebase");
+    await wrapper.close();
+
+    expect(concrete.close).toHaveBeenCalledTimes(1);
+    expect(concrete.ensureCodebaseTable).toHaveBeenCalledWith("codebase");
+  });
+
+  it("does not load the provider merely to close an unused wrapper", async () => {
+    const wrapper = createStorageBackend(config(kind));
+    await wrapper.close();
+    expect(state.constructorCalls).toEqual([]);
+  });
+});
+
+describe("Deeplake compatibility factory", () => {
+  it("constructs Deeplake directly from a legacy Config shape", () => {
+    const legacy = {
+      token: "token",
+      apiUrl: "https://api.example",
+      orgId: "org",
+      orgName: "Org",
+      userName: "alice",
+      workspaceId: "ws",
+      tableName: "memory",
+      sessionsTableName: "sessions",
+      skillsTableName: "skills",
+      rulesTableName: "rules",
+      goalsTableName: "goals",
+      kpisTableName: "kpis",
+      docsTableName: "docs",
+      codebaseTableName: "codebase",
+      memoryPath: "/tmp/memory",
+    };
+    const backend = createStorageBackend(legacy, "sessions");
+    expect(backend.kind).toBe("deeplake");
+    expect(state.constructorCalls[0]?.kind).toBe("deeplake");
+    expect(state.constructorCalls[0]?.args.slice(0, 5)).toEqual([
+      "token", "https://api.example", "org", "ws", "sessions",
+    ]);
+  });
+
+  it("uses the nested storage config when one is present", () => {
+    const storage = config("sqlite");
+    const backend = createStorageBackend({ storage } as never);
+    expect(backend.kind).toBe("sqlite");
+  });
+});

--- a/tests/shared/storage-postgres.integration.test.ts
+++ b/tests/shared/storage-postgres.integration.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { PostgresBackend } from "../../src/storage/postgres.js";
+
+const connectionUrl = process.env.HIVEMIND_TEST_POSTGRES_URL;
+const run = connectionUrl ? describe : describe.skip;
+
+run("PostgreSQL storage contract", () => {
+  it("creates, heals, transacts, and round-trips native JSON and vectors", async () => {
+    const schema = `hivemind_test_${process.pid}_${Date.now()}`;
+    const names = {
+      memory: "memory", sessions: "sessions", skills: "skills", rules: "hivemind_rules",
+      goals: "hivemind_goals", kpis: "hivemind_kpis", docs: "hivemind_docs", codebase: "codebase",
+    };
+    const backend = new PostgresBackend(connectionUrl!, schema, "memory", names);
+    try {
+      await backend.initializeSchema();
+      await backend.initializeSchema();
+      expect(await backend.listTables()).toContain("memory");
+      expect(await backend.getColumns("memory")).toContain("summary_embedding");
+
+      await backend.execute(
+        `INSERT INTO "sessions" (id, path, filename, message, message_embedding, author) VALUES ($1, $2, $3, $4, $5, $6)`,
+        ["quote'1", "/sessions/quote.jsonl", "quote.jsonl", { text: "it's valid" }, [0.25, 0.75], "o'hara"],
+      );
+      expect(await backend.query(`SELECT id, message, message_embedding, author FROM "sessions"`)).toEqual([{
+        id: "quote'1", message: { text: "it's valid" }, message_embedding: [0.25, 0.75], author: "o'hara",
+      }]);
+
+      await expect(backend.transaction(async tx => {
+        await tx.execute(`INSERT INTO "memory" (id, path) VALUES ($1, $2)`, ["rollback", "/rollback"]);
+        throw new Error("rollback");
+      })).rejects.toThrow("rollback");
+      expect(await backend.query(`SELECT id FROM "memory" WHERE id = $1`, ["rollback"])).toEqual([]);
+    } finally {
+      await backend.execute(`DROP SCHEMA "${schema}" CASCADE`);
+      await backend.close();
+    }
+  }, 30_000);
+});

--- a/tests/shared/storage-postgres.integration.test.ts
+++ b/tests/shared/storage-postgres.integration.test.ts
@@ -1,5 +1,11 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { configFromStorage, type PostgresStorageConfig } from "../../src/config.js";
+import { createStorageBackend } from "../../src/storage/factory.js";
 import { PostgresBackend } from "../../src/storage/postgres.js";
+import { registerSqlStorageFeatureParity } from "./helpers/sql-storage-feature-parity.js";
 
 const connectionUrl = process.env.HIVEMIND_TEST_POSTGRES_URL;
 const run = connectionUrl ? describe : describe.skip;
@@ -36,4 +42,62 @@ run("PostgreSQL storage contract", () => {
       await backend.close();
     }
   }, 30_000);
+});
+
+registerSqlStorageFeatureParity("PostgreSQL", Boolean(connectionUrl), async () => {
+  const root = mkdtempSync(join(tmpdir(), "hivemind-postgres-parity-"));
+  const schema = `hivemind_parity_${process.pid}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  const configPath = join(root, "config.json");
+  mkdirSync(join(root, ".deeplake"), { recursive: true });
+  writeFileSync(join(root, ".deeplake", "credentials.json"), JSON.stringify({
+    token: "unused-local-token",
+    orgId: "local",
+    userName: "alice",
+    workspaceId: "default",
+  }));
+  const storage: PostgresStorageConfig = {
+    kind: "postgres",
+    connectionUrl: connectionUrl!,
+    schema,
+    orgId: "local",
+    orgName: "local",
+    userName: "alice",
+    workspaceId: "default",
+    tableName: "memory",
+    sessionsTableName: "sessions",
+    skillsTableName: "skills",
+    rulesTableName: "hivemind_rules",
+    goalsTableName: "hivemind_goals",
+    kpisTableName: "hivemind_kpis",
+    docsTableName: "hivemind_docs",
+    codebaseTableName: "codebase",
+    memoryPath: join(root, "memory"),
+    vectorScanLimit: 100,
+  };
+  const backend = createStorageBackend(storage);
+  return {
+    backend,
+    config: configFromStorage(storage),
+    root,
+    childEnv: {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      HIVEMIND_BACKEND: "postgres",
+      HIVEMIND_POSTGRES_URL: connectionUrl!,
+      HIVEMIND_POSTGRES_SCHEMA: schema,
+      HIVEMIND_CONFIG_PATH: configPath,
+      HIVEMIND_EMBEDDINGS: "false",
+      HIVEMIND_MEMORY_PATH: storage.memoryPath,
+    },
+    malformedVector: [1],
+    cleanup: async () => {
+      try {
+        await backend.execute(`DROP SCHEMA "${schema}" CASCADE`);
+      } finally {
+        await backend.close();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  };
 });

--- a/tests/shared/storage-postgres.test.ts
+++ b/tests/shared/storage-postgres.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  poolOptions: null as Record<string, unknown> | null,
+  poolQueries: [] as Array<{ text: string; values: unknown[] }>,
+  clientQueries: [] as Array<{ text: string; values: unknown[] }>,
+  released: 0,
+  ended: 0,
+}));
+
+function normalize(query: unknown, values: unknown[] = []): { text: string; values: unknown[] } {
+  if (typeof query === "string") return { text: query, values };
+  const cfg = query as { text: string; values?: unknown[] };
+  return { text: cfg.text, values: cfg.values ?? [] };
+}
+
+vi.mock("pg", () => ({
+  Pool: class {
+    constructor(options: Record<string, unknown>) {
+      state.poolOptions = options;
+    }
+
+    async query(query: unknown, values: unknown[] = []) {
+      const normalized = normalize(query, values);
+      state.poolQueries.push(normalized);
+      if (normalized.text.includes("information_schema.tables")) {
+        return { rows: [{ table_name: "memory" }, { table_name: "sessions" }], rowCount: 2 };
+      }
+      if (normalized.text.includes("information_schema.columns")) {
+        return { rows: [{ column_name: "id" }, { column_name: "path" }], rowCount: 2 };
+      }
+      if (/^SELECT/i.test(normalized.text)) return { rows: [{ ok: 1 }], rowCount: 1 };
+      return { rows: [], rowCount: 3 };
+    }
+
+    async connect() {
+      return {
+        query: async (query: unknown, values: unknown[] = []) => {
+          const normalized = normalize(query, values);
+          state.clientQueries.push(normalized);
+          if (/^SELECT/i.test(normalized.text)) return { rows: [{ tx: true }], rowCount: 1 };
+          return { rows: [], rowCount: 2 };
+        },
+        release: () => { state.released++; },
+      };
+    }
+
+    async end() { state.ended++; }
+  },
+}));
+
+import { PostgresBackend } from "../../src/storage/postgres.js";
+
+const names = {
+  memory: "memory",
+  sessions: "sessions",
+  skills: "skills",
+  rules: "rules",
+  goals: "goals",
+  kpis: "kpis",
+  docs: "docs",
+  codebase: "codebase",
+};
+
+beforeEach(() => {
+  state.poolOptions = null;
+  state.poolQueries.length = 0;
+  state.clientQueries.length = 0;
+  state.released = 0;
+  state.ended = 0;
+});
+
+describe("PostgreSQL backend pool wrapper", () => {
+  it("validates schemas and configures a schema-scoped pool", () => {
+    expect(() => new PostgresBackend("postgresql://example/db", "bad;drop", "memory", names))
+      .toThrow("Invalid PostgreSQL schema");
+    new PostgresBackend("postgresql://example/db", "valid_schema", "memory", names);
+    expect(state.poolOptions).toMatchObject({
+      connectionString: "postgresql://example/db",
+      max: 5,
+      options: "-c search_path=valid_schema -c statement_timeout=10000",
+    });
+  });
+
+  it("queries, executes, introspects, converts dates, and closes", async () => {
+    const backend = new PostgresBackend("postgresql://example/db", "test_schema", "memory", names);
+    const when = new Date("2026-01-01T00:00:00.000Z");
+    await expect(backend.query("SELECT $1 AS value", [when])).resolves.toEqual([{ ok: 1 }]);
+    expect(state.poolQueries.at(-1)?.values).toEqual(["2026-01-01T00:00:00.000Z"]);
+    await expect(backend.execute("UPDATE memory SET path = $1", ["/a"])).resolves.toEqual({ rowCount: 3 });
+    await expect(backend.listTables()).resolves.toEqual(["memory", "sessions"]);
+    await expect(backend.getColumns("memory")).resolves.toEqual(["id", "path"]);
+    expect(state.poolQueries.at(-1)?.values).toEqual(["test_schema", "memory"]);
+    await backend.close();
+    expect(state.ended).toBe(1);
+  });
+
+  it("honors already-aborted query signals", async () => {
+    const backend = new PostgresBackend("postgresql://example/db", "test_schema", "memory", names);
+    await expect(backend.query("SELECT 1", AbortSignal.abort())).rejects.toThrow("Query aborted");
+  });
+
+  it("commits transactions and delegates query, execute, and nested transactions", async () => {
+    const backend = new PostgresBackend("postgresql://example/db", "test_schema", "memory", names);
+    const result = await backend.transaction(async tx => {
+      await expect(tx.query("SELECT $1", [new Date("2026-02-01T00:00:00.000Z")]))
+        .resolves.toEqual([{ tx: true }]);
+      await expect(tx.execute("UPDATE memory SET path = $1", ["/tx"]))
+        .resolves.toEqual({ rowCount: 2 });
+      return tx.transaction(async nested => nested.query("SELECT 2"));
+    });
+    expect(result).toEqual([{ tx: true }]);
+    expect(state.clientQueries.map(call => call.text)).toEqual([
+      "BEGIN",
+      "SELECT $1",
+      "UPDATE memory SET path = $1",
+      "SELECT 2",
+      "COMMIT",
+    ]);
+    expect(state.clientQueries[1]?.values).toEqual(["2026-02-01T00:00:00.000Z"]);
+    expect(state.released).toBe(1);
+  });
+
+  it("rolls back and releases the client when a transaction fails", async () => {
+    const backend = new PostgresBackend("postgresql://example/db", "test_schema", "memory", names);
+    await expect(backend.transaction(async () => {
+      throw new Error("boom");
+    })).rejects.toThrow("boom");
+    expect(state.clientQueries.map(call => call.text)).toEqual(["BEGIN", "ROLLBACK"]);
+    expect(state.released).toBe(1);
+  });
+
+  it("rejects aborted transaction queries", async () => {
+    const backend = new PostgresBackend("postgresql://example/db", "test_schema", "memory", names);
+    await expect(backend.transaction(tx => tx.query("SELECT 1", AbortSignal.abort())))
+      .rejects.toThrow("Query aborted");
+    expect(state.clientQueries.map(call => call.text)).toEqual(["BEGIN", "ROLLBACK"]);
+  });
+});

--- a/tests/shared/storage-sqlite-feature-parity.test.ts
+++ b/tests/shared/storage-sqlite-feature-parity.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -12,6 +12,9 @@ import { storageQuery } from "../../src/docs/read.js";
 import { upsertDoc } from "../../src/docs/write.js";
 import { insertRule } from "../../src/rules/write.js";
 import { buildPlaceholderInsertSql } from "../../src/hooks/shared/placeholder-summary.js";
+import { configFromStorage, type SqliteStorageConfig } from "../../src/config.js";
+import { createStorageBackend } from "../../src/storage/factory.js";
+import { registerSqlStorageFeatureParity } from "./helpers/sql-storage-feature-parity.js";
 
 const names = {
   memory: "memory",
@@ -150,4 +153,56 @@ describe("SQLite feature parity smoke", () => {
     expect(await backend.query(`SELECT text FROM "hivemind_rules" WHERE rule_id = $1`, [rule.rule_id]))
       .toEqual([{ text: "Use the local backend" }]);
   });
+});
+
+registerSqlStorageFeatureParity("SQLite", true, async () => {
+  const parityRoot = mkdtempSync(join(tmpdir(), "hivemind-sqlite-parity-"));
+  const databasePath = join(parityRoot, "memory.sqlite3");
+  const configPath = join(parityRoot, "config.json");
+  mkdirSync(join(parityRoot, ".deeplake"), { recursive: true });
+  writeFileSync(join(parityRoot, ".deeplake", "credentials.json"), JSON.stringify({
+    token: "unused-local-token",
+    orgId: "local",
+    userName: "alice",
+    workspaceId: "default",
+  }));
+  const storage: SqliteStorageConfig = {
+    kind: "sqlite",
+    path: databasePath,
+    orgId: "local",
+    orgName: "local",
+    userName: "alice",
+    workspaceId: "default",
+    tableName: "memory",
+    sessionsTableName: "sessions",
+    skillsTableName: "skills",
+    rulesTableName: "hivemind_rules",
+    goalsTableName: "hivemind_goals",
+    kpisTableName: "hivemind_kpis",
+    docsTableName: "hivemind_docs",
+    codebaseTableName: "codebase",
+    memoryPath: join(parityRoot, "memory"),
+    vectorScanLimit: 100,
+  };
+  const parityBackend = createStorageBackend(storage);
+  return {
+    backend: parityBackend,
+    config: configFromStorage(storage),
+    root: parityRoot,
+    childEnv: {
+      ...process.env,
+      HOME: parityRoot,
+      USERPROFILE: parityRoot,
+      HIVEMIND_BACKEND: "sqlite",
+      HIVEMIND_SQLITE_PATH: databasePath,
+      HIVEMIND_CONFIG_PATH: configPath,
+      HIVEMIND_EMBEDDINGS: "false",
+      HIVEMIND_MEMORY_PATH: storage.memoryPath,
+    },
+    malformedVector: "not-json",
+    cleanup: async () => {
+      await parityBackend.close();
+      rmSync(parityRoot, { recursive: true, force: true });
+    },
+  };
 });

--- a/tests/shared/storage-sqlite-feature-parity.test.ts
+++ b/tests/shared/storage-sqlite-feature-parity.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { SqliteBackend } from "../../src/storage/sqlite.js";
+import { embeddingSqlLiteral } from "../../src/embeddings/sql.js";
+import { buildDirectSessionInsertSql } from "../../src/hooks/shared/session-insert-sql.js";
+import { readVirtualPathContent } from "../../src/hooks/virtual-table-query.js";
+import { searchDeeplakeTables, searchDocs } from "../../src/shell/grep-core.js";
+import { storageQuery } from "../../src/docs/read.js";
+import { upsertDoc } from "../../src/docs/write.js";
+import { insertRule } from "../../src/rules/write.js";
+import { buildPlaceholderInsertSql } from "../../src/hooks/shared/placeholder-summary.js";
+
+const names = {
+  memory: "memory",
+  sessions: "sessions",
+  skills: "skills",
+  rules: "hivemind_rules",
+  goals: "hivemind_goals",
+  kpis: "hivemind_kpis",
+  docs: "hivemind_docs",
+  codebase: "codebase",
+};
+
+let root: string;
+let backend: SqliteBackend;
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), "hivemind-sqlite-feature-"));
+  backend = new SqliteBackend(join(root, "memory.sqlite3"), "memory", names);
+  await backend.initializeSchema();
+});
+
+afterEach(async () => {
+  await backend.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("SQLite feature parity smoke", () => {
+  it("captures, reads, and searches memory without SQL translation", async () => {
+    const sessionPath = "/sessions/alice/example.jsonl";
+    const message = JSON.stringify({ type: "user", content: "Find the blue widget" });
+    const insert = buildDirectSessionInsertSql("sessions", {
+      id: randomUUID(),
+      sessionPath,
+      filename: "example.jsonl",
+      jsonForSql: message.replace(/'/g, "''"),
+      embeddingSql: embeddingSqlLiteral([1, 0], "sqlite"),
+      userName: "alice",
+      sizeBytes: message.length,
+      projectName: "demo",
+      description: "Prompt",
+      agent: "codex",
+      pluginVersion: "test",
+      timestamp: new Date().toISOString(),
+    }, "sqlite");
+    await backend.query(insert);
+
+    backend.appendRows([{
+      path: "/summaries/alice/one.md",
+      filename: "one.md",
+      contentText: "A blue widget summary",
+      mimeType: "text/markdown",
+      sizeBytes: 21,
+    }]);
+    await backend.commit();
+    await backend.execute(
+      `UPDATE "memory" SET summary_embedding = $1 WHERE path = $2`,
+      [[1, 0], "/summaries/alice/one.md"],
+    );
+
+    expect(await readVirtualPathContent(backend, "memory", "sessions", sessionPath))
+      .toContain("Find the blue widget");
+
+    const lexical = await searchDeeplakeTables(backend, "memory", "sessions", {
+      pathFilter: "",
+      contentScanOnly: false,
+      likeOp: "ILIKE",
+      escapedPattern: "%BLUE%",
+      queryEmbedding: null,
+      limit: 10,
+    });
+    expect(lexical.map(row => row.path)).toContain("/summaries/alice/one.md");
+
+    const semantic = await searchDeeplakeTables(backend, "memory", "sessions", {
+      pathFilter: "",
+      contentScanOnly: false,
+      likeOp: "ILIKE",
+      escapedPattern: "%missing lexical term%",
+      queryEmbedding: [1, 0],
+      limit: 10,
+    });
+    expect(semantic[0]?.path).toBe("/summaries/alice/one.md");
+  });
+
+  it("searches docs lexically and with application-side cosine scoring", async () => {
+    const query = storageQuery(backend);
+    await upsertDoc(query, "hivemind_docs", {
+      doc_id: "src/auth.ts",
+      path: "/docs/src/auth.ts.md",
+      content: "Token minting happens here",
+      project: "demo",
+      content_embedding: [1, 0],
+    });
+
+    const lexical = await searchDocs(query, "hivemind_docs", {
+      pathFilter: "",
+      contentScanOnly: false,
+      likeOp: "ILIKE",
+      escapedPattern: "%TOKEN%",
+      queryEmbedding: null,
+      project: "demo",
+    }, "sqlite");
+    expect(lexical.map(row => row.path)).toEqual(["src/auth.ts"]);
+
+    const semantic = await searchDocs(query, "hivemind_docs", {
+      pathFilter: "",
+      contentScanOnly: false,
+      likeOp: "ILIKE",
+      escapedPattern: "%unrelated%",
+      queryEmbedding: [1, 0],
+      project: "demo",
+    }, "sqlite");
+    expect(semantic.map(row => row.path)).toEqual(["src/auth.ts"]);
+  });
+
+  it("writes placeholder summaries and rules using SQLite literals", async () => {
+    const placeholder = buildPlaceholderInsertSql({
+      table: "memory",
+      sessionId: "session-1",
+      cwd: "/tmp/demo",
+      userName: "alice",
+      orgName: "local",
+      workspaceId: "local",
+      agent: "codex",
+      pluginVersion: "test",
+      dialect: "sqlite",
+    });
+    await backend.query(placeholder.sql);
+    expect(await backend.query(`SELECT description FROM "memory" WHERE path = $1`, [placeholder.summaryPath]))
+      .toEqual([{ description: "in progress" }]);
+
+    const query = storageQuery(backend);
+    const rule = await insertRule(query, "hivemind_rules", {
+      text: "Use the local backend",
+      assigned_by: "alice",
+    }, "sqlite");
+    expect(await backend.query(`SELECT text FROM "hivemind_rules" WHERE rule_id = $1`, [rule.rule_id]))
+      .toEqual([{ text: "Use the local backend" }]);
+  });
+});

--- a/tests/shared/storage-sqlite-multiprocess.test.ts
+++ b/tests/shared/storage-sqlite-multiprocess.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SqliteBackend } from "../../src/storage/sqlite.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function runWriter(databasePath: string, id: string, count: number): Promise<void> {
+  const fixture = fileURLToPath(new URL("../fixtures/sqlite-writer.ts", import.meta.url));
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", fixture, databasePath, id, String(count)], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf-8");
+    child.stderr.on("data", chunk => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("exit", code => code === 0 ? resolve() : reject(new Error(`writer ${id} exited ${code}: ${stderr}`)));
+  });
+}
+
+describe("SQLite multi-process writes", () => {
+  it("keeps every event while concurrent writers share a WAL database", async () => {
+    const root = mkdtempSync(join(tmpdir(), "hivemind-sqlite-writers-"));
+    roots.push(root);
+    const databasePath = join(root, "memory.sqlite3");
+    await Promise.all(["a", "b", "c", "d"].map(id => runWriter(databasePath, id, 20)));
+
+    const names = {
+      memory: "memory", sessions: "sessions", skills: "skills", rules: "hivemind_rules",
+      goals: "hivemind_goals", kpis: "hivemind_kpis", docs: "hivemind_docs", codebase: "codebase",
+    };
+    const backend = new SqliteBackend(databasePath, "sessions", names);
+    try {
+      expect(await backend.query(`SELECT COUNT(*) AS count FROM "sessions"`)).toEqual([{ count: 80 }]);
+      expect(await backend.query(`SELECT COUNT(DISTINCT id) AS count FROM "sessions"`)).toEqual([{ count: 80 }]);
+    } finally {
+      await backend.close();
+    }
+  }, 20_000);
+});

--- a/tests/shared/storage-sqlite.test.ts
+++ b/tests/shared/storage-sqlite.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SqliteBackend } from "../../src/storage/sqlite.js";
+import { cosineSimilarity, parseStoredVector, scoreVectorRows } from "../../src/storage/vector-search.js";
+
+let root: string;
+let path: string;
+
+const names = {
+  memory: "memory",
+  sessions: "sessions",
+  skills: "skills",
+  rules: "hivemind_rules",
+  goals: "hivemind_goals",
+  kpis: "hivemind_kpis",
+  docs: "hivemind_docs",
+  codebase: "codebase",
+};
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "hivemind-sqlite-test-"));
+  path = join(root, "memory.sqlite3");
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+describe("SQLite storage contract", () => {
+  it("creates and idempotently heals every owned table", async () => {
+    const backend = new SqliteBackend(path, "memory", names);
+    await backend.execute(`CREATE TABLE "memory" (id TEXT)`);
+    await backend.initializeSchema();
+    await backend.initializeSchema();
+    expect(await backend.listTables()).toEqual([
+      "codebase", "hivemind_docs", "hivemind_goals", "hivemind_kpis",
+      "hivemind_rules", "memory", "sessions", "skills",
+    ]);
+    expect(await backend.getColumns("memory")).toContain("summary_embedding");
+    await backend.close();
+  });
+
+  it("round-trips parameters, quotes, JSON, and vectors", async () => {
+    const backend = new SqliteBackend(path, "sessions", names);
+    await backend.ensureSessionsTable("sessions");
+    await backend.execute(
+      `INSERT INTO "sessions" (id, path, filename, message, message_embedding, author) VALUES ($1, $2, $3, $4, $5, $6)`,
+      ["id'1", "/sessions/a'b.jsonl", "a'b.jsonl", { text: "it's valid" }, [0.1, 0.2], "o'hara"],
+    );
+    const rows = await backend.query(`SELECT id, path, message, message_embedding, author FROM "sessions"`);
+    expect(rows).toEqual([{
+      id: "id'1",
+      path: "/sessions/a'b.jsonl",
+      message: { text: "it's valid" },
+      message_embedding: [0.1, 0.2],
+      author: "o'hara",
+    }]);
+    await backend.close();
+  });
+
+  it("commits successful transactions and rolls back failures", async () => {
+    const backend = new SqliteBackend(path, "memory", names);
+    await backend.ensureTable();
+    await backend.transaction(async tx => {
+      await tx.execute(`INSERT INTO "memory" (id, path) VALUES ($1, $2)`, ["1", "/ok"]);
+    });
+    await expect(backend.transaction(async tx => {
+      await tx.execute(`INSERT INTO "memory" (id, path) VALUES ($1, $2)`, ["2", "/rollback"]);
+      throw new Error("rollback");
+    })).rejects.toThrow("rollback");
+    expect((await backend.query(`SELECT path FROM "memory" ORDER BY path`)).map(row => row.path)).toEqual(["/ok"]);
+    await backend.close();
+  });
+
+  it("upserts queued VFS rows without duplicating paths", async () => {
+    const backend = new SqliteBackend(path, "memory", names);
+    await backend.ensureTable();
+    backend.appendRows([{ path: "/note.md", filename: "note.md", contentText: "first", mimeType: "text/markdown", sizeBytes: 5 }]);
+    await backend.commit();
+    backend.appendRows([{ path: "/note.md", filename: "note.md", contentText: "second", mimeType: "text/markdown", sizeBytes: 6 }]);
+    await backend.commit();
+    expect(await backend.query(`SELECT path, summary FROM "memory"`)).toEqual([{ path: "/note.md", summary: "second" }]);
+    await backend.close();
+  });
+});
+
+describe("application vector scoring", () => {
+  it("computes normalized cosine and skips malformed vectors", () => {
+    expect(cosineSimilarity([1, 0], [2, 0])).toBe(1);
+    expect(parseStoredVector("[0,1]")).toEqual([0, 1]);
+    expect(parseStoredVector("broken")).toBeNull();
+    const scored = scoreVectorRows([
+      { id: "best", embedding: "[1,0]" },
+      { id: "other", embedding: [0, 1] },
+      { id: "bad", embedding: "nope" },
+    ], "embedding", [1, 0]);
+    expect(scored.map(item => item.row.id)).toEqual(["best", "other"]);
+  });
+});

--- a/tests/shared/storage-sqlite.test.ts
+++ b/tests/shared/storage-sqlite.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SqliteBackend } from "../../src/storage/sqlite.js";
 import { cosineSimilarity, parseStoredVector, scoreVectorRows } from "../../src/storage/vector-search.js";
+import { vectorScanLimit } from "../../src/storage/vector-search.js";
+import { escapedStringPrefix, jsonLiteral, likeOperator, nullExpression, textExpression } from "../../src/storage/sql-dialect.js";
 
 let root: string;
 let path: string;
@@ -82,6 +84,52 @@ describe("SQLite storage contract", () => {
     expect(await backend.query(`SELECT path, summary FROM "memory"`)).toEqual([{ path: "/note.md", summary: "second" }]);
     await backend.close();
   });
+
+  it("supports maintenance helpers, empty commits, and idempotent close", async () => {
+    const backend = new SqliteBackend(path, "memory", names);
+    await backend.ensureTable();
+    await backend.commit();
+    await backend.updateColumns("/missing", {});
+    backend.appendRows([{ path: "/note.md", filename: "note.md", contentText: "body", mimeType: "text/plain", sizeBytes: 4 }]);
+    await backend.commit();
+    await backend.updateColumns("/note.md", { description: "updated", size_bytes: 7 });
+    await backend.createIndex("description");
+    expect(await backend.knownTablesOrNull()).toContain("memory");
+    expect(await backend.query(`SELECT description, size_bytes FROM "memory" WHERE path = $1`, ["/note.md"]))
+      .toEqual([{ description: "updated", size_bytes: 7 }]);
+    await backend.close();
+    await backend.close();
+    await expect(backend.query("SELECT 1")).rejects.toThrow("SQLite backend is closed");
+  });
+
+  it("binds dates, booleans, arrays, objects, and nulls and validates query parameters", async () => {
+    const backend = new SqliteBackend(path, "sessions", names);
+    await backend.ensureSessionsTable("sessions");
+    await backend.execute(
+      `INSERT INTO "sessions" (id, path, filename, message, message_embedding, creation_date) VALUES ($1, $2, $3, $4, $5, $6)`,
+      ["types", "/types", "types", { ok: true }, [1, 2], new Date("2026-01-01T00:00:00.000Z")],
+    );
+    await backend.execute(`UPDATE "sessions" SET size_bytes = $1, message = $2 WHERE id = $3`, [true, null, "types"]);
+    expect(await backend.query(`SELECT size_bytes, message, message_embedding, creation_date FROM "sessions"`))
+      .toEqual([{ size_bytes: 1, message: null, message_embedding: [1, 2], creation_date: "2026-01-01T00:00:00.000Z" }]);
+    await expect(backend.query("SELECT $2", ["only-one"])).rejects.toThrow("Missing SQL parameter $2");
+    await expect(backend.query("SELECT 1", AbortSignal.abort())).rejects.toThrow("Query aborted");
+    await expect(backend.query("SELECT 1", [], AbortSignal.abort())).rejects.toThrow("Query aborted");
+    await backend.close();
+  });
+
+  it("supports query DML, RETURNING rows, and nested transaction views", async () => {
+    const backend = new SqliteBackend(path, "memory", names);
+    await backend.ensureTable();
+    expect(await backend.query(`INSERT INTO "memory" (id, path) VALUES ($1, $2)`, ["q", "/q"])).toEqual([]);
+    expect(await backend.query(`INSERT INTO "memory" (id, path) VALUES ($1, $2) RETURNING path`, ["r", "/r"]))
+      .toEqual([{ path: "/r" }]);
+    const nested = await backend.transaction(tx => tx.transaction(inner => inner.query(
+      `SELECT path FROM "memory" ORDER BY path`,
+    )));
+    expect(nested).toEqual([{ path: "/q" }, { path: "/r" }]);
+    await backend.close();
+  });
 });
 
 describe("application vector scoring", () => {
@@ -95,5 +143,48 @@ describe("application vector scoring", () => {
       { id: "bad", embedding: "nope" },
     ], "embedding", [1, 0]);
     expect(scored.map(item => item.row.id)).toEqual(["best", "other"]);
+  });
+
+  it("rejects empty, mismatched, non-finite, zero, and malformed vectors", () => {
+    expect(parseStoredVector(null)).toBeNull();
+    expect(parseStoredVector([])).toBeNull();
+    expect(parseStoredVector("not-json")).toBeNull();
+    expect(parseStoredVector([1, Number.NaN])).toBeNull();
+    expect(cosineSimilarity([], [])).toBeNull();
+    expect(cosineSimilarity([1], [1, 2])).toBeNull();
+    expect(cosineSimilarity([Number.NaN], [1])).toBeNull();
+    expect(cosineSimilarity([0, 0], [1, 0])).toBeNull();
+    expect(scoreVectorRows([{ embedding: [1] }], "embedding", [1, 0])).toEqual([]);
+  });
+
+  it("uses a positive vector scan limit and falls back for invalid values", () => {
+    const previous = process.env.HIVEMIND_VECTOR_SCAN_LIMIT;
+    try {
+      process.env.HIVEMIND_VECTOR_SCAN_LIMIT = "17";
+      expect(vectorScanLimit()).toBe(17);
+      process.env.HIVEMIND_VECTOR_SCAN_LIMIT = "0";
+      expect(vectorScanLimit()).toBe(2000);
+      process.env.HIVEMIND_VECTOR_SCAN_LIMIT = "invalid";
+      expect(vectorScanLimit()).toBe(2000);
+    } finally {
+      if (previous === undefined) delete process.env.HIVEMIND_VECTOR_SCAN_LIMIT;
+      else process.env.HIVEMIND_VECTOR_SCAN_LIMIT = previous;
+    }
+  });
+});
+
+describe("SQL dialect rendering", () => {
+  it("renders native SQLite expressions and PostgreSQL casts", () => {
+    expect(textExpression("message", "sqlite")).toBe("message");
+    expect(textExpression("message", "postgres")).toBe("message::text");
+    expect(nullExpression("bigint", "sqlite")).toBe("NULL");
+    expect(nullExpression("bigint", "postgres")).toBe("NULL::bigint");
+    expect(likeOperator("ILIKE", "sqlite")).toBe("LIKE");
+    expect(likeOperator("LIKE", "sqlite")).toBe("LIKE");
+    expect(likeOperator("ILIKE", "postgres")).toBe("ILIKE");
+    expect(escapedStringPrefix("sqlite")).toBe("");
+    expect(escapedStringPrefix("postgres")).toBe("E");
+    expect(jsonLiteral('{"ok":true}', "sqlite")).toBe(`'{"ok":true}'`);
+    expect(jsonLiteral('{"ok":true}', "postgres")).toBe(`'{"ok":true}'::jsonb`);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -75,6 +75,51 @@ export default defineConfig({
       // on the new code without having to first bring the whole
       // (~500-file) codebase up to 80%.
       thresholds: {
+        // SQL storage providers — exercised against real SQLite files on
+        // every run, a PostgreSQL 16 service in CI, plus pool/factory unit
+        // boundaries so local coverage does not depend on a live server.
+        "src/storage/backend.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        "src/storage/factory.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        "src/storage/postgres.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        "src/storage/sqlite.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        "src/storage/sql-dialect.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        "src/storage/vector-search.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        "src/commands/backend.ts": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
         // PR #302 — feat: per-directory .hivemind config. The resolver is
         // fully unit-tested; the hook gate is exercised via the capture/
         // session-start wiring tests. Lock both at 90.


### PR DESCRIPTION
## Summary

- add shared real-backend feature parity coverage for SQLite and PostgreSQL across goals and KPIs, skills, graph snapshots, MCP operations, pruning, and lexical fallback
- expand provider, factory, dialect, vector, schema, transaction, and configuration coverage with 80% per-file floors for SQL storage modules
- initialize and heal schemas during backend checks and allow provider-neutral session pruning on SQL backends
- keep PostgreSQL URLs environment-only and worker handoffs metadata-only

## Impact

SQLite verification uses a fresh temporary database per scenario. PostgreSQL verification uses a unique disposable schema against the PostgreSQL 16 GitHub Actions service. Live Deeplake verification remains out of scope; existing mocked regressions still run.

No release bump is intended.

## Test plan

- npm run ci (5,878 passed, 17 skipped locally)
- focused SQL storage suites (47 passed; 7 PostgreSQL parity cases skip locally and run in CI)
- shipped-bundle isolated-home SQLite backend use/status/check smoke, including all eight tables and non-secret persisted config
- npm run build
- npm run pack:check
- npm run audit:openclaw -- --criticals-only (0 critical findings)
- git diff --check
- npx vitest run --coverage executed all 5,878 local tests; SQL storage files exceeded their new 80% floors, while Node 24 reported existing unrelated threshold deficits in legacy modules. GitHub Actions on the repository Node 22 baseline is authoritative.