### PR TITLE
fix(auth): open a browser on Windows instead of a console window, and document the Windows install route

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,6 @@ curl -fsSL https://deeplake.ai/hivemind.sh | sh
 irm https://deeplake.ai/hivemind.ps1 | iex
 ```
 
-`iex` evaluates the downloaded text and has nowhere to put arguments, so
-installing for one assistant means building a script block rather than
-appending flags:
-
-```powershell
-& ([scriptblock]::Create((irm https://deeplake.ai/hivemind.ps1))) claude install
-```
-
 **Any platform, via npm** — for CI and Dockerfiles, or where policy blocks
 piping a downloaded script to a shell. Skips the checks the installers do, so
 Node 22+ and a writable npm prefix are on you:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ appending flags:
 & ([scriptblock]::Create((irm https://deeplake.ai/hivemind.ps1))) claude install
 ```
 
-**Already have npm** — any platform:
+**Any platform, via npm** — for CI and Dockerfiles, or where policy blocks
+piping a downloaded script to a shell. Skips the checks the installers do, so
+Node 22+ and a writable npm prefix are on you:
 
 ```bash
 npm i -g @deeplake/hivemind && hivemind install

--- a/README.md
+++ b/README.md
@@ -62,7 +62,29 @@ The agent reaches the answer in fewer turns with less context, because the prior
 
 ## Quick start
 
-One command, all your agents:
+One command, all your agents.
+
+**macOS / Linux**
+
+```bash
+curl -fsSL https://deeplake.ai/hivemind.sh | sh
+```
+
+**Windows** — in PowerShell:
+
+```powershell
+irm https://deeplake.ai/hivemind.ps1 | iex
+```
+
+`iex` evaluates the downloaded text and has nowhere to put arguments, so
+installing for one assistant means building a script block rather than
+appending flags:
+
+```powershell
+& ([scriptblock]::Create((irm https://deeplake.ai/hivemind.ps1))) claude install
+```
+
+**Already have npm** — any platform:
 
 ```bash
 npm i -g @deeplake/hivemind && hivemind install

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -3,9 +3,9 @@
  * and org/workspace management.
  */
 
-import { execSync } from "node:child_process";
 import { deeplakeClientHeader } from "../utils/client-header.js";
 import { hivemindInstallIDHeader } from "./install-id.js";
+import { openInBrowser } from "../dashboard/open.js";
 import {
   type Credentials,
   loadCredentials,
@@ -148,16 +148,23 @@ export async function pollForToken(deviceCode: string, apiUrl = DEFAULT_API_URL)
   throw new Error(`Token polling failed: HTTP ${resp.status}`);
 }
 
+/**
+ * Opens the device-flow URL, via the shared helper in dashboard/open.ts.
+ *
+ * This used to build its own shell string, and got Windows wrong in the one
+ * way open.ts already documents: `start "<url>"` under cmd.exe treats its
+ * first quoted argument as the WINDOW TITLE, so it opened a new console
+ * titled with the URL and never opened a browser. openCommandFor passes the
+ * empty title (`cmd /c start "" <url>`) that makes the URL an argument.
+ *
+ * The old version also could not report that honestly: `start "<url>"`
+ * *succeeds*, so execSync did not throw, so it returned true and the CLI
+ * printed "Browser opened. Waiting for sign in..." to someone staring at a
+ * shell. openInBrowser pre-checks the helper is on PATH and reports what it
+ * actually attempted.
+ */
 function openBrowser(url: string): boolean {
-  try {
-    const cmd = process.platform === "darwin" ? `open "${url}"`
-      : process.platform === "win32" ? `start "${url}"`
-      : `xdg-open "${url}" 2>/dev/null`;
-    execSync(cmd, { stdio: "ignore", timeout: 5000 });
-    return true;
-  } catch {
-    return false;
-  }
+  return openInBrowser(url).attempted;
 }
 
 export async function deviceFlowLogin(apiUrl = DEFAULT_API_URL, ref?: string): Promise<{ token: string; expiresIn: number }> {

--- a/tests/cli/auth-open-browser-windows.test.ts
+++ b/tests/cli/auth-open-browser-windows.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { openCommandFor } from "../../src/dashboard/open.js";
+
+const AUTH_SRC = readFileSync(
+  join(import.meta.dirname, "../../src/commands/auth.ts"),
+  "utf-8",
+);
+
+// The device-flow login opened a new console window instead of a browser on
+// Windows, for a reason this repo had already found and written down in
+// dashboard/open.ts: under cmd.exe, `start "<url>"` treats its first quoted
+// argument as the WINDOW TITLE. auth.ts had its own copy of the open logic and
+// never got the fix, so Windows users installed fine and then could not log in
+// — a drop-off indistinguishable from someone walking away.
+describe("device-flow login opens a browser on Windows", () => {
+  it("passes the empty title argument that makes the URL an argument", () => {
+    const { command, args } = openCommandFor("win32", "https://example.com/device?code=ABCD");
+
+    expect(command).toBe("cmd");
+    // The "" is the whole bug. Without it the URL becomes the window title.
+    expect(args).toEqual(["/c", "start", "", "https://example.com/device?code=ABCD"]);
+    expect(args[2]).toBe("");
+  });
+
+  // A unit test of openCommandFor cannot catch auth.ts keeping a second,
+  // divergent implementation — which is exactly how this shipped. Assert the
+  // caller actually routes through the shared helper.
+  it("auth.ts delegates to the shared helper instead of building its own command", () => {
+    expect(AUTH_SRC).toContain("openInBrowser");
+    expect(AUTH_SRC).not.toMatch(/start\s+"\$\{url\}"/);
+    expect(AUTH_SRC).not.toMatch(/execSync\(\s*cmd/);
+  });
+});

--- a/tests/cli/auth-open-browser-windows.test.ts
+++ b/tests/cli/auth-open-browser-windows.test.ts
@@ -28,7 +28,13 @@ describe("device-flow login opens a browser on Windows", () => {
   // divergent implementation — which is exactly how this shipped. Assert the
   // caller actually routes through the shared helper.
   it("auth.ts delegates to the shared helper instead of building its own command", () => {
-    expect(AUTH_SRC).toContain("openInBrowser");
+    // Match the import and the call, not the bare name: the explanation of this
+    // bug lives in a comment in auth.ts, so a substring check for
+    // "openInBrowser" would pass on a file that only talks about it.
+    expect(AUTH_SRC).toMatch(
+      /import\s*\{\s*openInBrowser\s*\}\s*from\s*["']\.\.\/dashboard\/open\.js["']/,
+    );
+    expect(AUTH_SRC).toMatch(/return\s+openInBrowser\(\s*url\s*\)\s*\.attempted/);
     expect(AUTH_SRC).not.toMatch(/start\s+"\$\{url\}"/);
     expect(AUTH_SRC).not.toMatch(/execSync\(\s*cmd/);
   });


### PR DESCRIPTION
**What + type:** `hivemind login` opened a new console window instead of a browser on Windows. One-line behaviour fix plus a regression test. Windows-only; macOS and Linux were never affected.

Found on a real Windows box (10.0.26100) while verifying the new PowerShell installer in [deeplake-ui#352](https://github.com/activeloopai/deeplake-ui/pull/352). The install succeeded; login dead-ended.

## The bug

`src/commands/auth.ts` built its own shell string:

```ts
process.platform === "win32" ? `start "${url}"` : ...
execSync(cmd, { stdio: "ignore", timeout: 5000 });
```

Under `cmd.exe`, **`start` treats its first quoted argument as the window title.** So `start "https://..."` opens a console window titled with the URL and opens no browser.

This repo already knew. `src/dashboard/open.ts:38` says so, verbatim:

> *Windows uses `cmd /c start "" <path>`; the empty `""` is the window title argument that `start` requires when its first quoted arg is a path. Without it, `start "C:\..."` treats the path AS a window title and opens a new shell.*

`auth.ts` was a second, divergent copy that never got that fix.

### It also reported the failure as success

`start "<url>"` **succeeds** — it really does open a window — so `execSync` did not throw, so `openBrowser` returned `true`, so the CLI printed:

```
Browser opened. Waiting for sign in...
```

to someone staring at a shell. That is the part that turns a small bug into an unattributable one.

## The fix

Fixed at the source rather than patched in place: `auth.ts` now calls `openInBrowser` from `dashboard/open.ts`, which passes `cmd /c start "" <url>`, pre-checks the helper is on PATH, and reports what it actually attempted. The now-unused `execSync` import is gone.

## Test

Two assertions, because a unit test of `openCommandFor` alone could **not** have caught this — the defect was a caller keeping its own copy. So the test also asserts that `auth.ts` routes through the shared helper.

Verified to fail on `origin/main`, which is the only thing that makes a passing test mean anything:

```
  FAIL  contains openInBrowser
  FAIL  no start "${url}"
  FAIL  no execSync(cmd)

origin/main would fail 3 of 3 assertions -> the test catches the bug.
```

And on this branch:

```
$ npm run typecheck
> tsc --noEmit          (clean)

$ npx vitest run tests/cli/
 Test Files  26 passed (26)
      Tests  431 passed (431)
```

## Why now

It has been Windows-only and therefore near-harmless, because Windows had no documented install route at all — which is what deeplake-ui#352 changes. Once that ships, every new Windows user installs successfully and then stops at login, and the funnel reads it as a drop-off rather than a bug. That PR exists to measure exactly this band; it would have measured a lie.

## Not verified

The fix itself has not been run on Windows — I have no Windows machine, and the report came from someone else's. `openCommandFor("win32", ...)` is asserted by test, and the command shape is the one this repo already ships and documents for the dashboard path, but the actual browser launch on a Windows host is unconfirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication browser launching across supported platforms.
  * Windows authentication now opens the device sign-in page reliably.

* **Documentation**
  * Clarified npm installation as an any-platform option for CI, Docker, and restricted environments.
  * Documented Node 22+ and writable-prefix requirements for npm installation.
  * Removed the assistant-specific PowerShell installation example.

* **Tests**
  * Added Windows-specific coverage for authentication browser launching and sign-in page access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->