### PR TITLE
docs: document OrcaRouter as a named hermes provider for wiki and skillify workers

### DIFF
--- a/docs/SKILLIFY.md
+++ b/docs/SKILLIFY.md
@@ -116,6 +116,17 @@ The skillify worker calls each agent's own headless CLI for the gate prompt — 
 
 For hermes via OpenRouter (the default), set `OPENROUTER_API_KEY` in the environment; the worker inherits the parent process env. Other providers (anthropic, openai, etc.) need their respective API keys.
 
+To route the hermes gate calls through [OrcaRouter](https://www.orcarouter.ai) instead, set `HIVEMIND_HERMES_PROVIDER=orcarouter` (plus a matching `HIVEMIND_HERMES_MODEL`, e.g. `anthropic/claude-haiku-4.5`) and register OrcaRouter as a named provider in `~/.hermes/config.yaml` so hermes knows its base URL and API key env var:
+
+```yaml
+providers:
+  orcarouter:
+    base_url: https://api.orcarouter.ai/v1
+    key_env: ORCAROUTER_API_KEY
+```
+
+OrcaRouter is an OpenAI-compatible gateway, so hermes talks to it like any other custom endpoint; set `ORCAROUTER_API_KEY` in the environment and the worker inherits it. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
 ## Logs
 
 Worker activity logs to `~/.claude/hooks/skillify.log`. Each line shows which session pool was mined, what the gate decided, and whether a file was written.

--- a/docs/SUMMARIES.md
+++ b/docs/SUMMARIES.md
@@ -39,4 +39,15 @@ A lock file at `~/.claude/hooks/summary-state/<sessionId>.lock` prevents two wor
 | `HIVEMIND_PI_MODEL`                | `gemini-2.5-flash` | (pi only) model passed to `pi --print --model` |
 | `HIVEMIND_CAPTURE=false`           | unset          | Disable both capture and summary generation         |
 
+For hermes summaries, the provider is whatever you pass as `HIVEMIND_HERMES_PROVIDER`. Besides `openrouter` (the default), any provider hermes knows is valid — including a named custom endpoint. To route wiki summaries through [OrcaRouter](https://www.orcarouter.ai), set `HIVEMIND_HERMES_PROVIDER=orcarouter` (with a matching `HIVEMIND_HERMES_MODEL`, e.g. `anthropic/claude-haiku-4.5`) and register OrcaRouter in `~/.hermes/config.yaml`:
+
+```yaml
+providers:
+  orcarouter:
+    base_url: https://api.orcarouter.ai/v1
+    key_env: ORCAROUTER_API_KEY
+```
+
+Then set `ORCAROUTER_API_KEY` in the environment — the worker inherits it from the parent process. OrcaRouter is an OpenAI-compatible AI gateway, so hermes reaches it like any custom endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
 For pi specifically, the wiki worker is bundled separately at `~/.pi/agent/hivemind/wiki-worker.js` (deposited by `hivemind pi install`). The other agents ship the wiki worker inside their per-agent plugin bundle.


### PR DESCRIPTION
## Summary

This PR documents [OrcaRouter](https://www.orcarouter.ai) as a named provider for Hivemind's hermes-backed wiki and skillify workers, right next to the existing OpenRouter default. Hivemind already passes `--provider <HIVEMIND_HERMES_PROVIDER>` to the hermes CLI for gate and summary calls, and the provider registry itself lives in hermes-agent — so the only thing missing was making OrcaRouter a first-class, by-name option. Setting `HIVEMIND_HERMES_PROVIDER=orcarouter` (plus a matching `HIVEMIND_HERMES_MODEL`, e.g. `anthropic/claude-haiku-4.5`) now routes those calls through OrcaRouter's OpenAI-compatible endpoint, exactly like `openrouter` today, and the added `~/.hermes/config.yaml` `providers.orcarouter` block + `ORCAROUTER_API_KEY` env var is what hermes needs to resolve it.

- `docs/SKILLIFY.md` — hermes gate-call section: how to point the skillify judge/proposer at OrcaRouter.
- `docs/SUMMARIES.md` — wiki-summary configuration: same setup for the hermes summary worker.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Version Bump

> **To trigger a release**, bump `"version"` in `package.json` before merging.
>
> | Change type     | Version bump          | Example              |
> | --------------- | --------------------- | -------------------- |
> | Bug fix         | patch (1.2.0 → 1.2.1) | `"version": "1.2.1"` |
> | New feature     | minor (1.2.0 → 1.3.0) | `"version": "1.3.0"` |
> | Breaking change | major (1.2.0 → 2.0.0) | `"version": "2.0.0"` |
>
> If you don't bump the version, no release will be created.

## Test plan

- [x] Tests pass locally (`npm test`) — docs-only change; hermes + agent-model suites (120 tests) pass, remaining full-suite failures are pre-existing build-bundle/environment issues unrelated to this PR
- [ ] Relevant new tests added — docs-only, no new code paths
- [ ] Version bumped in `package.json`, or no release needed for this change — docs-only, no release needed

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for routing Hermes gate calls and wiki summaries through OrcaRouter.
  * Documented provider and model configuration, API key setup, and endpoint registration.
  * Clarified OrcaRouter’s OpenAI-compatible interface and gateway-level security screening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->