### PR TITLE
fix: grant summarizer dirs explicitly instead of relying on bypassPermissions

### DIFF
--- a/src/commands/mine-local.ts
+++ b/src/commands/mine-local.ts
@@ -38,6 +38,7 @@ import {
 import { extractPairs, type Pair } from "../skillify/extractors/index.js";
 import { findAgentBin, type Agent } from "../skillify/gate-runner.js";
 import { extractJsonBlock } from "../skillify/gate-parser.js";
+import { permissionFlags, type ClaudeGrants } from "../hooks/wiki-worker-spawn.js";
 import { resolveSkillsRoot, writeNewSkill, listSkills, parseFrontmatter } from "../skillify/skill-writer.js";
 import { detectAgentSkillsRoots } from "../skillify/agent-roots.js";
 import { fanOutSymlinks } from "../skillify/pull.js";
@@ -91,6 +92,12 @@ function runGateViaStdin(opts: {
   bin: string;
   prompt: string;
   timeoutMs: number;
+  /**
+   * Dirs/tools to grant explicitly instead of the blanket `bypassPermissions`,
+   * which an enterprise policy can disable. See ClaudeGrants in
+   * ../hooks/wiki-worker-spawn.ts.
+   */
+  grants?: ClaudeGrants;
 }): Promise<{ stdout: string; stderr: string; errored: boolean; errorMessage?: string }> {
   return new Promise((resolve) => {
     if (opts.agent !== "claude_code") {
@@ -116,7 +123,7 @@ function runGateViaStdin(opts: {
       "-p",
       "--no-session-persistence",
       "--model", "haiku",
-      "--permission-mode", "bypassPermissions",
+      ...permissionFlags(opts.grants),
     ];
     const child = spawn(opts.bin, args, {
       stdio: ["pipe", "pipe", "pipe"],
@@ -586,7 +593,16 @@ async function runMineLocalImpl(args: string[]): Promise<void> {
     const prompt = buildSessionPrompt(tail, s, verdictPath);
     writeFileSync(join(sessionTmp, "prompt.txt"), prompt);
 
-    const gate = await runGateViaStdin({ agent: gateAgent, bin: gateBin, prompt, timeoutMs: GATE_TIMEOUT_MS });
+    // sessionTmp holds the verdict path named in the prompt and lives outside
+    // the session cwd, so grant it explicitly rather than relying on the
+    // bypass an enterprise policy can disable.
+    const gate = await runGateViaStdin({
+      agent: gateAgent,
+      bin: gateBin,
+      prompt,
+      timeoutMs: GATE_TIMEOUT_MS,
+      grants: { addDirs: [sessionTmp], allowedTools: ["Read", "Write"] },
+    });
     try {
       writeFileSync(join(sessionTmp, "gate-stdout.txt"), gate.stdout);
       if (gate.stderr) writeFileSync(join(sessionTmp, "gate-stderr.txt"), gate.stderr);

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -13,7 +13,7 @@ import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { finalizeSummary, releaseLock, readState } from "../summary-state.js";
-import { capLinesByBytes, newRowsFromWindow, stampOffset, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
+import { capLinesByBytes, markSummaryUnwritten, newRowsFromWindow, stampOffset, summaryWasWritten, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
 import { redactSecrets } from "../shared/redact.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
@@ -239,14 +239,7 @@ async function main(): Promise<void> {
     wlog("running codex exec");
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
-    // Backdate the pre-seeded file before handing it to the child. Comparing
-    // mtime against "a minute ago" instead of "just now" closes the only hole
-    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
-    // say) a same-tick rewrite would otherwise keep the timestamp and read as
-    // "never written". Any write by the child lands far outside that window.
-    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
-    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
-    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
+    const summaryBaseline = markSummaryUnwritten(tmpSummary, { existsSync, utimesSync, statSync });
     try {
       const inv = buildTrailingPromptInvocation(cfg.codexBin, [
         "exec",
@@ -284,11 +277,7 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      // mtime, not just content: an agent that legitimately regenerates the
-      // SAME text still touched the file, and skipping that would freeze the
-      // offset and re-summarize those rows on every future run. Only a run
-      // that neither changed the bytes NOR touched the file wrote nothing.
-      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+      if (!summaryWasWritten(tmpSummary, summaryBaseline, summaryChanged, { statSync })) {
         wlog("codex exec exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -271,6 +271,15 @@ async function main(): Promise<void> {
           : "codex exec failed without producing a new summary; skipping upload");
         return;
       }
+      // Exit 0 is not proof of work: a child that cannot reach tmpDir (or simply
+      // declines) exits 0 having written nothing, leaving the pre-seeded base
+      // summary in place. Uploading it unchanged would still advance the offset
+      // and slice those events away forever, which is how a session gets stuck
+      // as a header-only placeholder run after run.
+      if (!summaryChanged) {
+        wlog("codex exec exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+        return;
+      }
       if (raw.trim()) {
         // Stamp the offset ourselves so the persisted summary is authoritative
         // and never depends on the LLM echoing the bookkeeping line.

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -7,7 +7,7 @@
  * Invoked by stop.ts as: node wiki-worker.js <config.json>
  */
 
-import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, utimesSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
@@ -239,6 +239,13 @@ async function main(): Promise<void> {
     wlog("running codex exec");
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    // Backdate the pre-seeded file before handing it to the child. Comparing
+    // mtime against "a minute ago" instead of "just now" closes the only hole
+    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
+    // say) a same-tick rewrite would otherwise keep the timestamp and read as
+    // "never written". Any write by the child lands far outside that window.
+    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
+    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
     const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       const inv = buildTrailingPromptInvocation(cfg.codexBin, [

--- a/src/hooks/codex/wiki-worker.ts
+++ b/src/hooks/codex/wiki-worker.ts
@@ -7,7 +7,7 @@
  * Invoked by stop.ts as: node wiki-worker.js <config.json>
  */
 
-import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
@@ -239,6 +239,7 @@ async function main(): Promise<void> {
     wlog("running codex exec");
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       const inv = buildTrailingPromptInvocation(cfg.codexBin, [
         "exec",
@@ -276,8 +277,12 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      if (!summaryChanged) {
-        wlog("codex exec exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+      // mtime, not just content: an agent that legitimately regenerates the
+      // SAME text still touched the file, and skipping that would freeze the
+      // offset and re-summarize those rows on every future run. Only a run
+      // that neither changed the bytes NOR touched the file wrote nothing.
+      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+        wlog("codex exec exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -12,7 +12,7 @@
  * differs: codex shells `codex exec`, we shell `cursor-agent --print --model X`.
  */
 
-import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
@@ -274,6 +274,7 @@ async function main(): Promise<void> {
     wlog(`running cursor-agent --print (model=${cfg.cursorModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       // cursor-agent --print is the non-interactive headless mode. --force
       // auto-allows tools (matches the bypass-approvals semantic codex used).
@@ -317,8 +318,12 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      if (!summaryChanged) {
-        wlog("cursor-agent --print exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+      // mtime, not just content: an agent that legitimately regenerates the
+      // SAME text still touched the file, and skipping that would freeze the
+      // offset and re-summarize those rows on every future run. Only a run
+      // that neither changed the bytes NOR touched the file wrote nothing.
+      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+        wlog("cursor-agent --print exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -12,7 +12,7 @@
  * differs: codex shells `codex exec`, we shell `cursor-agent --print --model X`.
  */
 
-import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, utimesSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
@@ -274,6 +274,13 @@ async function main(): Promise<void> {
     wlog(`running cursor-agent --print (model=${cfg.cursorModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    // Backdate the pre-seeded file before handing it to the child. Comparing
+    // mtime against "a minute ago" instead of "just now" closes the only hole
+    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
+    // say) a same-tick rewrite would otherwise keep the timestamp and read as
+    // "never written". Any write by the child lands far outside that window.
+    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
+    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
     const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       // cursor-agent --print is the non-interactive headless mode. --force

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -312,6 +312,15 @@ async function main(): Promise<void> {
           : "cursor-agent --print failed without producing a new summary; skipping upload");
         return;
       }
+      // Exit 0 is not proof of work: a child that cannot reach tmpDir (or simply
+      // declines) exits 0 having written nothing, leaving the pre-seeded base
+      // summary in place. Uploading it unchanged would still advance the offset
+      // and slice those events away forever, which is how a session gets stuck
+      // as a header-only placeholder run after run.
+      if (!summaryChanged) {
+        wlog("cursor-agent --print exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+        return;
+      }
       if (raw.trim()) {
         // Stamp the offset ourselves so the persisted summary is authoritative
         // and never depends on the LLM echoing the bookkeeping line.

--- a/src/hooks/cursor/wiki-worker.ts
+++ b/src/hooks/cursor/wiki-worker.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { finalizeSummary, releaseLock, readState } from "../summary-state.js";
 import { readSessionEventCache } from "../session-event-cache.js";
 import { buildSessionPath } from "../../utils/session-path.js";
-import { capLinesByBytes, newRowsFromWindow, stampOffset, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
+import { capLinesByBytes, markSummaryUnwritten, newRowsFromWindow, stampOffset, summaryWasWritten, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
 import { redactSecrets } from "../shared/redact.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
@@ -274,14 +274,7 @@ async function main(): Promise<void> {
     wlog(`running cursor-agent --print (model=${cfg.cursorModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
-    // Backdate the pre-seeded file before handing it to the child. Comparing
-    // mtime against "a minute ago" instead of "just now" closes the only hole
-    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
-    // say) a same-tick rewrite would otherwise keep the timestamp and read as
-    // "never written". Any write by the child lands far outside that window.
-    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
-    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
-    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
+    const summaryBaseline = markSummaryUnwritten(tmpSummary, { existsSync, utimesSync, statSync });
     try {
       // cursor-agent --print is the non-interactive headless mode. --force
       // auto-allows tools (matches the bypass-approvals semantic codex used).
@@ -325,11 +318,7 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      // mtime, not just content: an agent that legitimately regenerates the
-      // SAME text still touched the file, and skipping that would freeze the
-      // offset and re-summarize those rows on every future run. Only a run
-      // that neither changed the bytes NOR touched the file wrote nothing.
-      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+      if (!summaryWasWritten(tmpSummary, summaryBaseline, summaryChanged, { statSync })) {
         wlog("cursor-agent --print exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import { finalizeSummary, releaseLock, readState } from "../summary-state.js";
 import { readSessionEventCache } from "../session-event-cache.js";
 import { buildSessionPath } from "../../utils/session-path.js";
-import { capLinesByBytes, newRowsFromWindow, stampOffset, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
+import { capLinesByBytes, markSummaryUnwritten, newRowsFromWindow, stampOffset, summaryWasWritten, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
 import { redactSecrets } from "../shared/redact.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
@@ -276,14 +276,7 @@ async function main(): Promise<void> {
     wlog(`running hermes -z (provider=${cfg.hermesProvider}, model=${cfg.hermesModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
-    // Backdate the pre-seeded file before handing it to the child. Comparing
-    // mtime against "a minute ago" instead of "just now" closes the only hole
-    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
-    // say) a same-tick rewrite would otherwise keep the timestamp and read as
-    // "never written". Any write by the child lands far outside that window.
-    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
-    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
-    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
+    const summaryBaseline = markSummaryUnwritten(tmpSummary, { existsSync, utimesSync, statSync });
     try {
       // hermes -z (--oneshot) is the non-interactive mode. --yolo
       // auto-approves tool use within the spawned hermes process.
@@ -337,11 +330,7 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      // mtime, not just content: an agent that legitimately regenerates the
-      // SAME text still touched the file, and skipping that would freeze the
-      // offset and re-summarize those rows on every future run. Only a run
-      // that neither changed the bytes NOR touched the file wrote nothing.
-      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+      if (!summaryWasWritten(tmpSummary, summaryBaseline, summaryChanged, { statSync })) {
         wlog("hermes -z exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -12,7 +12,7 @@
  * differs: codex shells `codex exec`, we shell `hermes -z --provider X -m Y`.
  */
 
-import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, utimesSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -276,6 +276,13 @@ async function main(): Promise<void> {
     wlog(`running hermes -z (provider=${cfg.hermesProvider}, model=${cfg.hermesModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    // Backdate the pre-seeded file before handing it to the child. Comparing
+    // mtime against "a minute ago" instead of "just now" closes the only hole
+    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
+    // say) a same-tick rewrite would otherwise keep the timestamp and read as
+    // "never written". Any write by the child lands far outside that window.
+    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
+    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
     const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       // hermes -z (--oneshot) is the non-interactive mode. --yolo

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -12,7 +12,7 @@
  * differs: codex shells `codex exec`, we shell `hermes -z --provider X -m Y`.
  */
 
-import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -276,6 +276,7 @@ async function main(): Promise<void> {
     wlog(`running hermes -z (provider=${cfg.hermesProvider}, model=${cfg.hermesModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       // hermes -z (--oneshot) is the non-interactive mode. --yolo
       // auto-approves tool use within the spawned hermes process.
@@ -329,8 +330,12 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      if (!summaryChanged) {
-        wlog("hermes -z exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+      // mtime, not just content: an agent that legitimately regenerates the
+      // SAME text still touched the file, and skipping that would freeze the
+      // offset and re-summarize those rows on every future run. Only a run
+      // that neither changed the bytes NOR touched the file wrote nothing.
+      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+        wlog("hermes -z exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/hermes/wiki-worker.ts
+++ b/src/hooks/hermes/wiki-worker.ts
@@ -324,6 +324,15 @@ async function main(): Promise<void> {
           : "hermes -z failed without producing a new summary; skipping upload");
         return;
       }
+      // Exit 0 is not proof of work: a child that cannot reach tmpDir (or simply
+      // declines) exits 0 having written nothing, leaving the pre-seeded base
+      // summary in place. Uploading it unchanged would still advance the offset
+      // and slice those events away forever, which is how a session gets stuck
+      // as a header-only placeholder run after run.
+      if (!summaryChanged) {
+        wlog("hermes -z exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+        return;
+      }
       if (raw.trim()) {
         // Stamp the offset ourselves so the persisted summary is authoritative
         // and never depends on the LLM echoing the bookkeeping line.

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -22,7 +22,7 @@ import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { finalizeSummary, releaseLock, readState } from "../summary-state.js";
-import { capLinesByBytes, newRowsFromWindow, stampOffset, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
+import { capLinesByBytes, markSummaryUnwritten, newRowsFromWindow, stampOffset, summaryWasWritten, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "../wiki-offset.js";
 import { redactSecrets } from "../shared/redact.js";
 import { uploadSummary } from "../upload-summary.js";
 import { log as _log } from "../../utils/debug.js";
@@ -224,14 +224,7 @@ async function main(): Promise<void> {
     wlog(`running pi --print (provider=${cfg.piProvider}, model=${cfg.piModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
-    // Backdate the pre-seeded file before handing it to the child. Comparing
-    // mtime against "a minute ago" instead of "just now" closes the only hole
-    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
-    // say) a same-tick rewrite would otherwise keep the timestamp and read as
-    // "never written". Any write by the child lands far outside that window.
-    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
-    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
-    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
+    const summaryBaseline = markSummaryUnwritten(tmpSummary, { existsSync, utimesSync, statSync });
     try {
       // pi --print is the non-interactive mode; it bypasses extension
       // discovery (modes/print-mode.js doesn't import ExtensionRunner),
@@ -276,11 +269,7 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      // mtime, not just content: an agent that legitimately regenerates the
-      // SAME text still touched the file, and skipping that would freeze the
-      // offset and re-summarize those rows on every future run. Only a run
-      // that neither changed the bytes NOR touched the file wrote nothing.
-      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+      if (!summaryWasWritten(tmpSummary, summaryBaseline, summaryChanged, { statSync })) {
         wlog("pi --print exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -263,6 +263,15 @@ async function main(): Promise<void> {
           : "pi --print failed without producing a new summary; skipping upload");
         return;
       }
+      // Exit 0 is not proof of work: a child that cannot reach tmpDir (or simply
+      // declines) exits 0 having written nothing, leaving the pre-seeded base
+      // summary in place. Uploading it unchanged would still advance the offset
+      // and slice those events away forever, which is how a session gets stuck
+      // as a header-only placeholder run after run.
+      if (!summaryChanged) {
+        wlog("pi --print exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+        return;
+      }
       if (raw.trim()) {
         // Stamp the offset ourselves so the persisted summary is authoritative
         // and never depends on the LLM echoing the bookkeeping line.

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -16,7 +16,7 @@
  * we shell `pi --print --provider <p> --model <m>`. Same query/upload paths.
  */
 
-import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, utimesSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
@@ -224,6 +224,13 @@ async function main(): Promise<void> {
     wlog(`running pi --print (provider=${cfg.piProvider}, model=${cfg.piModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    // Backdate the pre-seeded file before handing it to the child. Comparing
+    // mtime against "a minute ago" instead of "just now" closes the only hole
+    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
+    // say) a same-tick rewrite would otherwise keep the timestamp and read as
+    // "never written". Any write by the child lands far outside that window.
+    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
+    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
     const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       // pi --print is the non-interactive mode; it bypasses extension

--- a/src/hooks/pi/wiki-worker.ts
+++ b/src/hooks/pi/wiki-worker.ts
@@ -16,7 +16,7 @@
  * we shell `pi --print --provider <p> --model <m>`. Same query/upload paths.
  */
 
-import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildTrailingPromptInvocation } from "../wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
@@ -224,6 +224,7 @@ async function main(): Promise<void> {
     wlog(`running pi --print (provider=${cfg.piProvider}, model=${cfg.piModel})`);
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       // pi --print is the non-interactive mode; it bypasses extension
       // discovery (modes/print-mode.js doesn't import ExtensionRunner),
@@ -268,8 +269,12 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      if (!summaryChanged) {
-        wlog("pi --print exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+      // mtime, not just content: an agent that legitimately regenerates the
+      // SAME text still touched the file, and skipping that would freeze the
+      // offset and re-summarize those rows on every future run. Only a run
+      // that neither changed the bytes NOR touched the file wrote nothing.
+      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+        wlog("pi --print exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/wiki-offset.ts
+++ b/src/hooks/wiki-offset.ts
@@ -126,3 +126,60 @@ function truncateUtf8(s: string, maxBytes: number): string {
   const decoder = new TextDecoder("utf-8", { fatal: false });
   return decoder.decode(buf.subarray(0, maxBytes)).replace(/�+$/, "");
 }
+
+/**
+ * Did THIS run's agent actually write the summary?
+ *
+ * Exit 0 is not proof of work: a child that cannot reach the scratch dir (an
+ * enterprise policy disabling bypassPermissions, say) exits 0 having written
+ * nothing, leaving the pre-seeded summary in place. Uploading that unchanged
+ * placeholder still advances the offset and slices the unread events away
+ * forever, so the worker must be able to tell "wrote nothing" from "wrote".
+ *
+ * Content equality alone cannot: an agent that legitimately regenerates the
+ * same text would read as a no-op and freeze the offset. So the baseline
+ * stamps the file a minute into the past and the check compares timestamps —
+ * any real write lands far outside any plausible filesystem granularity.
+ *
+ * When the filesystem will not cooperate (utimes throwing or silently doing
+ * nothing) the timestamp proves nothing, and the check falls back to content.
+ * That errs toward skipping: re-summarizing the same rows next run wastes work,
+ * whereas a wrong upload destroys events. Never the other way round.
+ */
+export interface SummaryBaseline {
+  mtimeMs: number;
+  /** False when utimes threw or left the timestamp unchanged. */
+  trusted: boolean;
+}
+
+const SUMMARY_BACKDATE_MS = 60_000;
+
+export function markSummaryUnwritten(
+  path: string,
+  fs: Pick<typeof import("node:fs"), "existsSync" | "utimesSync" | "statSync">,
+): SummaryBaseline {
+  if (!fs.existsSync(path)) return { mtimeMs: 0, trusted: true };
+  const sentinel = new Date(Date.now() - SUMMARY_BACKDATE_MS);
+  try {
+    fs.utimesSync(path, sentinel, sentinel);
+    const mtimeMs = fs.statSync(path).mtimeMs;
+    // A filesystem that ignores utimes reports something far from the sentinel.
+    return { mtimeMs, trusted: Math.abs(mtimeMs - sentinel.getTime()) < 2_000 };
+  } catch {
+    return { mtimeMs: 0, trusted: false };
+  }
+}
+
+export function summaryWasWritten(
+  path: string,
+  baseline: SummaryBaseline,
+  contentChanged: boolean,
+  fs: Pick<typeof import("node:fs"), "statSync">,
+): boolean {
+  if (!baseline.trusted) return contentChanged;
+  try {
+    return fs.statSync(path).mtimeMs !== baseline.mtimeMs;
+  } catch {
+    return contentChanged;
+  }
+}

--- a/src/hooks/wiki-worker-spawn.ts
+++ b/src/hooks/wiki-worker-spawn.ts
@@ -2,18 +2,52 @@ import type { ExecFileSyncOptions } from "node:child_process";
 import { binNeedsShell, shellFile } from "../utils/resolve-cli-bin.js";
 
 /** Fixed flags for the summary-generation `claude -p` call (no user input). */
-const CLAUDE_FLAGS = [
-  "--no-session-persistence",
-  "--model",
-  "haiku",
-  "--permission-mode",
-  "bypassPermissions",
-] as const;
+const CLAUDE_BASE_FLAGS = ["--no-session-persistence", "--model", "haiku"] as const;
+
+/** Blanket grant, used only when the caller names no explicit grants. */
+const CLAUDE_BYPASS_FLAGS = ["--permission-mode", "bypassPermissions"] as const;
 
 export interface ClaudeInvocation {
   file: string;
   args: string[];
   options: ExecFileSyncOptions;
+}
+
+/**
+ * Explicit grants for call sites that read/write files OUTSIDE the session cwd.
+ *
+ * `bypassPermissions` is NOT honored under an enterprise policy that sets
+ * `"disableBypassPermissionsMode": "disable"` (macOS:
+ * /Library/Application Support/ClaudeCode/managed-settings.json). The child then
+ * falls back to normal permissioning, refuses every path outside the working
+ * directory — the wiki worker's `$TMPDIR/deeplake-wiki-*` scratch dir, or a
+ * backfill's transcript + staging dir — and exits 0 having written nothing. On
+ * such a machine every summary stays a header-only stub and every backfill
+ * reports `no-summary`.
+ *
+ * Naming the dirs and tools instead is both policy-proof and least-privilege
+ * (the summarizer only ever needs Read + Write), so a caller that supplies
+ * grants gets them INSTEAD of the bypass, not in addition to it.
+ */
+export interface ClaudeGrants {
+  /** Directories to expose to the child (each becomes `--add-dir <dir>`). */
+  addDirs?: string[];
+  /** Tools to pre-approve, e.g. `["Read", "Write"]`. */
+  allowedTools?: string[];
+}
+
+/**
+ * `quotePaths` is for the Windows `.cmd` branch, where args are re-joined into a
+ * shell command line: a temp dir there routinely contains spaces
+ * (`C:\Users\First Last\AppData\Local\Temp`) and would otherwise split.
+ */
+export function permissionFlags(grants: ClaudeGrants | undefined, quotePaths = false): string[] {
+  if (!grants) return [...CLAUDE_BYPASS_FLAGS];
+  const flags: string[] = [];
+  for (const dir of grants.addDirs ?? []) flags.push("--add-dir", quotePaths ? `"${dir}"` : dir);
+  if (grants.allowedTools?.length) flags.push("--allowedTools", ...grants.allowedTools);
+  // An empty grants object would otherwise leave the child with no grant at all.
+  return flags.length > 0 ? flags : [...CLAUDE_BYPASS_FLAGS];
 }
 
 /**
@@ -30,11 +64,15 @@ export interface ClaudeInvocation {
  * prompt as a positional arg, no shell — so the already-working path stays
  * byte-identical.
  */
-export function buildClaudeInvocation(claudeBin: string, prompt: string): ClaudeInvocation {
+export function buildClaudeInvocation(
+  claudeBin: string,
+  prompt: string,
+  grants?: ClaudeGrants,
+): ClaudeInvocation {
   if (binNeedsShell(claudeBin)) {
     return {
       file: shellFile(claudeBin),
-      args: ["-p", ...CLAUDE_FLAGS],
+      args: ["-p", ...CLAUDE_BASE_FLAGS, ...permissionFlags(grants, true)],
       // windowsHide: the wiki worker is a detached, console-less process, so
       // without CREATE_NO_WINDOW Windows allocates a visible console window
       // (titled after the CLI exe) for the child. No-op on POSIX.
@@ -43,7 +81,7 @@ export function buildClaudeInvocation(claudeBin: string, prompt: string): Claude
   }
   return {
     file: claudeBin,
-    args: ["-p", prompt, ...CLAUDE_FLAGS],
+    args: ["-p", prompt, ...CLAUDE_BASE_FLAGS, ...permissionFlags(grants)],
     options: { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
   };
 }
@@ -102,6 +140,14 @@ export function buildStdinPromptInvocation(bin: string, flags: string[], prompt:
 }
 
 /** Claude variant of {@link buildStdinPromptInvocation} (same fixed flags as the argv path). */
-export function buildClaudeStdinInvocation(claudeBin: string, prompt: string): ClaudeInvocation {
-  return buildStdinPromptInvocation(claudeBin, ["-p", ...CLAUDE_FLAGS], prompt);
+export function buildClaudeStdinInvocation(
+  claudeBin: string,
+  prompt: string,
+  grants?: ClaudeGrants,
+): ClaudeInvocation {
+  return buildStdinPromptInvocation(
+    claudeBin,
+    ["-p", ...CLAUDE_BASE_FLAGS, ...permissionFlags(grants)],
+    prompt,
+  );
 }

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -7,7 +7,7 @@
  * Invoked by session-end.ts as: node wiki-worker.js <config.json>
  */
 
-import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, utimesSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildClaudeInvocation } from "./wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
@@ -324,6 +324,13 @@ async function main(): Promise<void> {
     wlog("running claude -p");
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    // Backdate the pre-seeded file before handing it to the child. Comparing
+    // mtime against "a minute ago" instead of "just now" closes the only hole
+    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
+    // say) a same-tick rewrite would otherwise keep the timestamp and read as
+    // "never written". Any write by the child lands far outside that window.
+    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
+    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
     const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       // tmpDir holds both the session JSONL to read and the summary to write,

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -19,7 +19,7 @@ const dlog = (msg: string) => _log("wiki-worker", msg);
 import { finalizeSummary, releaseLock, readState } from "./summary-state.js";
 import { readSessionEventCache } from "./session-event-cache.js";
 import { buildSessionPath } from "../utils/session-path.js";
-import { capLinesByBytes, newRowsFromWindow, stampOffset, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "./wiki-offset.js";
+import { capLinesByBytes, markSummaryUnwritten, newRowsFromWindow, stampOffset, summaryWasWritten, WIKI_FALLBACK_MAX_ROWS, WIKI_JSONL_MAX_BYTES } from "./wiki-offset.js";
 import { redactSecrets } from "./shared/redact.js";
 import { uploadSummary } from "./upload-summary.js";
 import { embedSummaryWithWarmup } from "../embeddings/embed-summary.js";
@@ -324,14 +324,7 @@ async function main(): Promise<void> {
     wlog("running claude -p");
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
-    // Backdate the pre-seeded file before handing it to the child. Comparing
-    // mtime against "a minute ago" instead of "just now" closes the only hole
-    // in the wrote-nothing check: on a coarse-resolution filesystem (FAT's 2s,
-    // say) a same-tick rewrite would otherwise keep the timestamp and read as
-    // "never written". Any write by the child lands far outside that window.
-    const MTIME_SENTINEL = new Date(Date.now() - 60_000);
-    if (existsSync(tmpSummary)) utimesSync(tmpSummary, MTIME_SENTINEL, MTIME_SENTINEL);
-    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
+    const summaryBaseline = markSummaryUnwritten(tmpSummary, { existsSync, utimesSync, statSync });
     try {
       // tmpDir holds both the session JSONL to read and the summary to write,
       // and lives outside the session cwd — grant it explicitly rather than
@@ -375,11 +368,7 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      // mtime, not just content: an agent that legitimately regenerates the
-      // SAME text still touched the file, and skipping that would freeze the
-      // offset and re-summarize those rows on every future run. Only a run
-      // that neither changed the bytes NOR touched the file wrote nothing.
-      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+      if (!summaryWasWritten(tmpSummary, summaryBaseline, summaryChanged, { statSync })) {
         wlog("claude -p exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -7,7 +7,7 @@
  * Invoked by session-end.ts as: node wiki-worker.js <config.json>
  */
 
-import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync, mkdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildClaudeInvocation } from "./wiki-worker-spawn.js";
 import { dirname, join } from "node:path";
@@ -324,6 +324,7 @@ async function main(): Promise<void> {
     wlog("running claude -p");
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
+    const summaryMtimeBefore = existsSync(tmpSummary) ? statSync(tmpSummary).mtimeMs : 0;
     try {
       // tmpDir holds both the session JSONL to read and the summary to write,
       // and lives outside the session cwd — grant it explicitly rather than
@@ -367,8 +368,12 @@ async function main(): Promise<void> {
       // summary in place. Uploading it unchanged would still advance the offset
       // and slice those events away forever, which is how a session gets stuck
       // as a header-only placeholder run after run.
-      if (!summaryChanged) {
-        wlog("claude -p exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
+      // mtime, not just content: an agent that legitimately regenerates the
+      // SAME text still touched the file, and skipping that would freeze the
+      // offset and re-summarize those rows on every future run. Only a run
+      // that neither changed the bytes NOR touched the file wrote nothing.
+      if (!summaryChanged && statSync(tmpSummary).mtimeMs === summaryMtimeBefore) {
+        wlog("claude -p exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
         return;
       }
       if (raw.trim()) {

--- a/src/hooks/wiki-worker.ts
+++ b/src/hooks/wiki-worker.ts
@@ -325,7 +325,14 @@ async function main(): Promise<void> {
     let execSucceeded = false;
     const summaryBeforeExec = existsSync(tmpSummary) ? readFileSync(tmpSummary, "utf-8") : null;
     try {
-      const inv = buildClaudeInvocation(cfg.claudeBin, prompt);
+      // tmpDir holds both the session JSONL to read and the summary to write,
+      // and lives outside the session cwd — grant it explicitly rather than
+      // relying on bypassPermissions, which an enterprise policy can disable
+      // (see ClaudeGrants in wiki-worker-spawn.ts).
+      const inv = buildClaudeInvocation(cfg.claudeBin, prompt, {
+        addDirs: [tmpDir],
+        allowedTools: ["Read", "Write"],
+      });
       execFileSync(inv.file, inv.args, {
         ...inv.options,
         timeout: 120_000,
@@ -353,6 +360,15 @@ async function main(): Promise<void> {
         wlog(summaryChanged
           ? "claude -p failed after a partial summary write; skipping upload to avoid advancing the offset"
           : "claude -p failed without producing a new summary; skipping upload");
+        return;
+      }
+      // Exit 0 is not proof of work: a child that cannot reach tmpDir (or simply
+      // declines) exits 0 having written nothing, leaving the pre-seeded base
+      // summary in place. Uploading it unchanged would still advance the offset
+      // and slice those events away forever, which is how a session gets stuck
+      // as a header-only placeholder run after run.
+      if (!summaryChanged) {
+        wlog("claude -p exited 0 but left the pre-seeded summary unchanged; skipping upload to avoid advancing the offset");
         return;
       }
       if (raw.trim()) {

--- a/src/skillify/gate-runner.ts
+++ b/src/skillify/gate-runner.ts
@@ -6,7 +6,7 @@
  * codex / cursor / hermes installed never needs `claude` in PATH.
  *
  * Per-agent invocation:
- *   claude_code → `claude -p <prompt> --no-session-persistence --model haiku --permission-mode bypassPermissions`
+ *   claude_code → `claude -p <prompt> --no-session-persistence --model haiku <permission grants>`
  *   codex       → `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
  *   cursor      → `cursor-agent --print --model <model> --force --output-format text <prompt>`
  *   hermes      → `hermes -z <prompt> --provider <provider> -m <model> --yolo --ignore-user-config`
@@ -14,9 +14,15 @@
  * The worker passes a verdict-write path inside the prompt; the runner
  * captures stdout regardless so the worker's stdout-fallback path still
  * works on agents whose models don't reliably use the Write tool.
+ *
+ * That verdict path lives outside the session cwd, so the claude_code caller
+ * names it via `grants` (`--add-dir` + `--allowedTools`). Callers that name no
+ * grants keep the blanket `--permission-mode bypassPermissions`.
  */
 
 import { existsSync } from "node:fs";
+
+import { permissionFlags, type ClaudeGrants } from "../hooks/wiki-worker-spawn.js";
 import { createRequire } from "node:module";
 
 // We need `child_process.execFileSync` to actually spawn the agent CLI for
@@ -61,6 +67,14 @@ export interface GateRunOptions {
   piModel?: string;
   /** Max wall-clock for the CLI call; default 120s. */
   timeoutMs?: number;
+  /**
+   * claude_code only — dirs/tools to grant explicitly instead of the blanket
+   * `bypassPermissions`, which an enterprise policy can disable. The gate
+   * prompt names a verdict path outside the session cwd, so a caller that
+   * wants the Write-tool branch to work under such a policy must grant that
+   * dir. See ClaudeGrants in ../hooks/wiki-worker-spawn.ts.
+   */
+  grants?: ClaudeGrants;
 }
 
 export interface GateRunResult {
@@ -153,7 +167,7 @@ export function buildArgs(agent: Agent, prompt: string, opts: GateRunOptions): s
         "-p", prompt,
         "--no-session-persistence",
         "--model", "haiku",
-        "--permission-mode", "bypassPermissions",
+        ...permissionFlags(opts.grants),
       ];
     case "codex":
       return [

--- a/src/skillify/skillify-worker.ts
+++ b/src/skillify/skillify-worker.ts
@@ -399,6 +399,10 @@ async function main(): Promise<void> {
       agent: gateAgent,
       prompt,
       bin: cfg.gateBin,
+      // The prompt offers the model a verdict path inside tmpDir, which lives
+      // outside the session cwd. Grant it explicitly so the Write-tool branch
+      // survives an enterprise policy that disables bypassPermissions.
+      grants: { addDirs: [tmpDir], allowedTools: ["Read", "Write"] },
       cursorModel: cfg.cursorModel,
       hermesProvider: cfg.hermesProvider,
       hermesModel: cfg.hermesModel,

--- a/src/skillify/stage-memory.ts
+++ b/src/skillify/stage-memory.ts
@@ -18,10 +18,10 @@
 
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { WIKI_PROMPT_TEMPLATE } from "../hooks/spawn-wiki-worker.js";
-import { buildClaudeInvocation } from "../hooks/wiki-worker-spawn.js";
+import { buildClaudeInvocation, type ClaudeGrants } from "../hooks/wiki-worker-spawn.js";
 import { resolveCliBin } from "../utils/resolve-cli-bin.js";
 import { EmbedClient } from "../embeddings/client.js";
 import { embeddingsDisabled } from "../embeddings/disable.js";
@@ -62,7 +62,12 @@ export interface StageOptions {
    * Injectable for tests; defaults to the real `claude -p` spawn. A real
    * agent writes the summary file named in the prompt as a side effect.
    */
-  runAgent?: (claudeBin: string, prompt: string, timeoutMs: number) => Promise<boolean>;
+  runAgent?: (
+    claudeBin: string,
+    prompt: string,
+    timeoutMs: number,
+    grants?: ClaudeGrants,
+  ) => Promise<boolean>;
   /** Embed `text` locally; null when unavailable. Injectable for tests. */
   embed?: (text: string) => Promise<number[] | null>;
 }
@@ -124,12 +129,17 @@ export function planClaudeSpawn(inv: ReturnType<typeof buildClaudeInvocation>): 
   };
 }
 
-function runClaude(claudeBin: string, prompt: string, timeoutMs: number): Promise<boolean> {
+function runClaude(
+  claudeBin: string,
+  prompt: string,
+  timeoutMs: number,
+  grants?: ClaudeGrants,
+): Promise<boolean> {
   // Reuse the live wiki-worker's invocation builder so the prompt-as-arg vs
   // prompt-over-stdin (Windows `.cmd` shim) handling stays identical to the
   // proven SessionEnd path. A bare `spawn(bin, ["-p", prompt, ...])` cannot
   // launch a `.cmd` shim and would blow the command-line length on Windows.
-  const plan = planClaudeSpawn(buildClaudeInvocation(claudeBin, prompt));
+  const plan = planClaudeSpawn(buildClaudeInvocation(claudeBin, prompt, grants));
   return new Promise((resolve) => {
     const child = spawn(plan.file, plan.args, {
       stdio: plan.stdio,
@@ -213,7 +223,13 @@ export async function stageSession(input: StageSessionInput, opts: StageOptions)
   }
 
   const runAgent = opts.runAgent ?? runClaude;
-  const ran = await runAgent(opts.claudeBin, prompt, opts.timeoutMs);
+  // The transcript and the staging dir both live outside the session cwd, so the
+  // agent needs them granted explicitly — bypassPermissions alone is silently
+  // ignored under an enterprise policy and every session stages as `no-summary`.
+  const ran = await runAgent(opts.claudeBin, prompt, opts.timeoutMs, {
+    addDirs: [dirname(input.jsonlPath), stagingDir],
+    allowedTools: ["Read", "Write"],
+  });
   if (!existsSync(summaryPath)) {
     return { sessionId: key, ok: false, embedded: false, reason: ran ? "no-summary" : "claude-failed" };
   }

--- a/tests/claude-code/mine-local-orchestrator.test.ts
+++ b/tests/claude-code/mine-local-orchestrator.test.ts
@@ -239,6 +239,15 @@ describe("runMineLocal: orchestrator branches", () => {
     await mod.runMineLocal([]);
 
     expect(spawnCalls).toHaveLength(1);
+    // The gate prompt offers the model a verdict path inside the per-session
+    // tmp dir, which is outside the session cwd. That dir must be granted by
+    // name: `bypassPermissions` is silently ignored under an enterprise policy
+    // (disableBypassPermissionsMode), and the child then refuses the path.
+    expect(spawnCalls[0].args).not.toContain("--permission-mode");
+    expect(spawnCalls[0].args).not.toContain("bypassPermissions");
+    expect(spawnCalls[0].args).toContain("--add-dir");
+    expect(spawnCalls[0].args).toContain("--allowedTools");
+    expect(spawnCalls[0].args.slice(spawnCalls[0].args.indexOf("--allowedTools"))).toEqual(["--allowedTools", "Read", "Write"]);
     expect(writeNewSkill).toHaveBeenCalledTimes(1);
     expect(writeNewSkill.mock.calls[0][0].name).toBe("useful-skill");
     expect(fanOutSymlinks).toHaveBeenCalledTimes(1);

--- a/tests/claude-code/mine-local-orchestrator.test.ts
+++ b/tests/claude-code/mine-local-orchestrator.test.ts
@@ -245,9 +245,12 @@ describe("runMineLocal: orchestrator branches", () => {
     // (disableBypassPermissionsMode), and the child then refuses the path.
     expect(spawnCalls[0].args).not.toContain("--permission-mode");
     expect(spawnCalls[0].args).not.toContain("bypassPermissions");
-    expect(spawnCalls[0].args).toContain("--add-dir");
-    expect(spawnCalls[0].args).toContain("--allowedTools");
-    expect(spawnCalls[0].args.slice(spawnCalls[0].args.indexOf("--allowedTools"))).toEqual(["--allowedTools", "Read", "Write"]);
+    // Pin the granted VALUES: the dir must be THIS session's tmp dir (the one
+    // holding the verdict path named in the prompt), not merely some dir.
+    const addDirAt = spawnCalls[0].args.indexOf("--add-dir");
+    expect(addDirAt).toBeGreaterThan(-1);
+    expect(spawnCalls[0].args[addDirAt + 1]).toMatch(/[/\\]mine-local-\d+[/\\]s-sess-aaa$/);
+    expect(spawnCalls[0].args.slice(addDirAt + 2)).toEqual(["--allowedTools", "Read", "Write"]);
     expect(writeNewSkill).toHaveBeenCalledTimes(1);
     expect(writeNewSkill.mock.calls[0][0].name).toBe("useful-skill");
     expect(fanOutSymlinks).toHaveBeenCalledTimes(1);

--- a/tests/claude-code/skillify-gate-runner.test.ts
+++ b/tests/claude-code/skillify-gate-runner.test.ts
@@ -74,12 +74,42 @@ describe("runGate dispatch", () => {
   // produces. (Previously these spawned `/usr/bin/echo` and grepped stdout,
   // which only works on POSIX; buildArgs is the deterministic, cross-platform
   // seam for the same contract.)
-  it("constructs claude_code invocation with --model haiku + bypassPermissions", () => {
+  it("constructs claude_code invocation with --model haiku + bypassPermissions when no grants are named", () => {
     const args = buildArgs("claude_code", "PROMPT_MARKER", { agent: "claude_code", prompt: "PROMPT_MARKER" });
     expect(args).toContain("PROMPT_MARKER");
     expect(args).toContain("--model");
     expect(args).toContain("haiku");
     expect(args).toContain("bypassPermissions");
+  });
+
+  it("swaps bypassPermissions for the named grants when the caller supplies them", () => {
+    // The worker names the tmp dir holding the verdict path. bypassPermissions
+    // is silently ignored under an enterprise policy that sets
+    // disableBypassPermissionsMode, so it must not be the only grant.
+    const args = buildArgs("claude_code", "PROMPT_MARKER", {
+      agent: "claude_code",
+      prompt: "PROMPT_MARKER",
+      grants: { addDirs: ["/tmp/skillify-x"], allowedTools: ["Read", "Write"] },
+    });
+    expect(args).not.toContain("--permission-mode");
+    expect(args).not.toContain("bypassPermissions");
+    expect(args).toEqual([
+      "-p", "PROMPT_MARKER",
+      "--no-session-persistence",
+      "--model", "haiku",
+      "--add-dir", "/tmp/skillify-x",
+      "--allowedTools", "Read", "Write",
+    ]);
+  });
+
+  it("ignores grants for non-claude agents (their CLIs have no --add-dir)", () => {
+    const args = buildArgs("codex", "PROMPT_MARKER", {
+      agent: "codex",
+      prompt: "PROMPT_MARKER",
+      grants: { addDirs: ["/tmp/skillify-x"], allowedTools: ["Read", "Write"] },
+    });
+    expect(args).not.toContain("--add-dir");
+    expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
   });
 
   it("constructs codex invocation with exec + --dangerously-bypass-approvals-and-sandbox", () => {

--- a/tests/claude-code/stage-memory.test.ts
+++ b/tests/claude-code/stage-memory.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { stageSession, resolveClaudeBin, planClaudeSpawn, type StageOptions } from "../../src/skillify/stage-memory.js";
 import { readPendingMemoryManifest } from "../../src/skillify/pending-memory-manifest.js";
 
@@ -48,6 +48,27 @@ function opts(over: Partial<StageOptions> = {}): StageOptions {
 }
 
 describe("stageSession", () => {
+  it("grants the transcript dir and the staging dir explicitly, with Read+Write", async () => {
+    // The backfill hands the agent two paths outside the session cwd. Without
+    // an explicit grant those are refused under an enterprise policy that
+    // disables bypassPermissions, and every session stages as `no-summary`.
+    // The other tests inject a runAgent that ignores its grants argument, so
+    // dropping the grants entirely would leave them green — this one pins it.
+    let seen: any;
+    await stageSession(input(), opts({
+      runAgent: async (_bin, prompt, _timeout, grants) => {
+        seen = grants;
+        const m = prompt.match(/SUMMARY FILE to write: (\S+)/);
+        if (m) writeFileSync(m[1], "# Session s1\n## What Happened\nreal content\n");
+        return true;
+      },
+    }));
+    expect(seen).toBeDefined();
+    expect(seen.allowedTools).toEqual(["Read", "Write"]);
+    expect(seen.addDirs).toContain(dirname(jsonlPath));
+    expect(seen.addDirs).toContain(stagingDir);
+  });
+
   it("stages summary + manifest row on success", async () => {
     const r = await stageSession(input(), opts());
     expect(r).toMatchObject({ ok: true, embedded: false });

--- a/tests/claude-code/wiki-worker.test.ts
+++ b/tests/claude-code/wiki-worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -411,8 +411,28 @@ describe("wiki-worker — happy path", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(log).toContain("never wrote the summary");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-worker");
+  });
+
+  it("still uploads when the agent legitimately rewrites the summary to the SAME bytes", async () => {
+    // Content equality alone cannot tell "wrote nothing" from "correctly
+    // regenerated identical text". Treating the second as the first would
+    // freeze the offset and re-summarize those rows on every future run, so
+    // the guard also checks whether the file was touched.
+    mkFetch(undefined, 1, true, 14);
+    execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
+      const summaryPath = args[1].match(/SUMMARY=(\S+)/)![1];
+      const identical = readFileSync(summaryPath, "utf-8");
+      // Ensure the mtime moves even on a fast filesystem clock.
+      utimesSync(summaryPath, new Date(Date.now() + 5000), new Date(Date.now() + 5000));
+      writeFileSync(summaryPath, identical);
+      utimesSync(summaryPath, new Date(Date.now() + 5000), new Date(Date.now() + 5000));
+      return Buffer.from("");
+    });
+    await runWorker();
+    expect(uploadSummaryMock).toHaveBeenCalledTimes(1);
+    expect(finalizeSummaryMock).toHaveBeenCalledWith("sid-worker", 14);
   });
 
   it("still uploads and advances the offset when claude -p rewrites the pre-seeded summary", async () => {

--- a/tests/claude-code/wiki-worker.test.ts
+++ b/tests/claude-code/wiki-worker.test.ts
@@ -411,7 +411,7 @@ describe("wiki-worker — happy path", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("never wrote the summary");
+    expect(log).toContain("claude -p exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-worker");
   });
 

--- a/tests/claude-code/wiki-worker.test.ts
+++ b/tests/claude-code/wiki-worker.test.ts
@@ -294,10 +294,13 @@ describe("wiki-worker — happy path", () => {
     // bypassPermissions, which an enterprise policy can disable.
     expect(calledArgs).not.toContain("--permission-mode");
     expect(calledArgs).not.toContain("bypassPermissions");
-    expect(calledArgs).toContain("--add-dir");
-    expect(calledArgs).toContain("--allowedTools");
-    expect(calledArgs).toContain("Read");
-    expect(calledArgs).toContain("Write");
+    // Pin the granted VALUES, not just the flag names: a grant naming the
+    // wrong directory reads identically to a correct one under a presence-only
+    // assertion, and would leave the child just as unable to reach tmpDir.
+    expect(calledArgs.slice(calledArgs.indexOf("--add-dir"))).toEqual([
+      "--add-dir", tmpDir,
+      "--allowedTools", "Read", "Write",
+    ]);
 
     // Prompt template was expanded with real values
     const prompt = calledArgs[1];

--- a/tests/claude-code/wiki-worker.test.ts
+++ b/tests/claude-code/wiki-worker.test.ts
@@ -385,8 +385,7 @@ describe("wiki-worker — happy path", () => {
   });
 
   it("does NOT upload or advance the offset when claude -p exits 0 having written nothing", async () => {
-    // The customer-reported failure, reproduced at the seam that made it
-    // permanent. Under an enterprise policy that disables bypassPermissions the
+    // The field failure, reproduced at the seam that made it permanent. Under an enterprise policy that disables bypassPermissions the
     // child cannot reach tmpDir, cannot prompt (print mode), and exits 0 with
     // the summary file untouched — leaving the pre-seeded prior summary on disk.
     // Treating that as success re-uploaded the placeholder verbatim AND stamped

--- a/tests/claude-code/wiki-worker.test.ts
+++ b/tests/claude-code/wiki-worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, utimesSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -423,11 +423,10 @@ describe("wiki-worker — happy path", () => {
     mkFetch(undefined, 1, true, 14);
     execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
       const summaryPath = args[1].match(/SUMMARY=(\S+)/)![1];
-      const identical = readFileSync(summaryPath, "utf-8");
-      // Ensure the mtime moves even on a fast filesystem clock.
-      utimesSync(summaryPath, new Date(Date.now() + 5000), new Date(Date.now() + 5000));
-      writeFileSync(summaryPath, identical);
-      utimesSync(summaryPath, new Date(Date.now() + 5000), new Date(Date.now() + 5000));
+      // A plain rewrite of the same bytes, with NO mtime manipulation — the
+      // worst case for a content-only check, and the case a coarse filesystem
+      // clock would hide if the guard compared against "just now".
+      writeFileSync(summaryPath, readFileSync(summaryPath, "utf-8"));
       return Buffer.from("");
     });
     await runWorker();

--- a/tests/claude-code/wiki-worker.test.ts
+++ b/tests/claude-code/wiki-worker.test.ts
@@ -290,8 +290,14 @@ describe("wiki-worker — happy path", () => {
     expect(calledArgs).toContain("--no-session-persistence");
     expect(calledArgs).toContain("--model");
     expect(calledArgs).toContain("haiku");
-    expect(calledArgs).toContain("--permission-mode");
-    expect(calledArgs).toContain("bypassPermissions");
+    // The scratch dir is granted explicitly instead of relying on
+    // bypassPermissions, which an enterprise policy can disable.
+    expect(calledArgs).not.toContain("--permission-mode");
+    expect(calledArgs).not.toContain("bypassPermissions");
+    expect(calledArgs).toContain("--add-dir");
+    expect(calledArgs).toContain("--allowedTools");
+    expect(calledArgs).toContain("Read");
+    expect(calledArgs).toContain("Write");
 
     // Prompt template was expanded with real values
     const prompt = calledArgs[1];
@@ -376,6 +382,50 @@ describe("wiki-worker — happy path", () => {
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
     expect(log).toContain("failed without producing a new summary");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-worker");
+  });
+
+  it("does NOT upload or advance the offset when claude -p exits 0 having written nothing", async () => {
+    // The customer-reported failure, reproduced at the seam that made it
+    // permanent. Under an enterprise policy that disables bypassPermissions the
+    // child cannot reach tmpDir, cannot prompt (print mode), and exits 0 with
+    // the summary file untouched — leaving the pre-seeded prior summary on disk.
+    // Treating that as success re-uploaded the placeholder verbatim AND stamped
+    // lastSummaryCount, slicing the unread events away forever, so every later
+    // run summarized nothing. Exit 0 is not proof of work.
+    mkFetch(undefined, 1, true, 14);
+    // Captured inside the mock: the worker rmSync's tmpDir on the way out, so
+    // the pre-seed can only be observed while the child is "running".
+    let preSeeded: string | null = null;
+    execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
+      const summaryPath = args[1].match(/SUMMARY=(\S+)/)![1];
+      preSeeded = existsSync(summaryPath) ? readFileSync(summaryPath, "utf-8") : null;
+      return Buffer.from("");  // exit 0, wrote nothing
+    });
+    await runWorker();
+
+    // The worker did pre-seed the prior summary (otherwise this test would
+    // pass for the wrong reason — an absent file, not an unchanged one).
+    expect(preSeeded).toContain("JSONL offset");
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    expect(finalizeSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-worker");
+  });
+
+  it("still uploads and advances the offset when claude -p rewrites the pre-seeded summary", async () => {
+    // The mirror of the guard above: a real run that DOES rewrite the file must
+    // keep uploading and stamping, so the fix cannot silently freeze summaries.
+    mkFetch(undefined, 1, true, 14);
+    execFileSyncMock.mockImplementation((_bin: string, args: string[]) => {
+      const summaryPath = args[1].match(/SUMMARY=(\S+)/)![1];
+      writeFileSync(summaryPath, "# Session X\n\n## What Happened\nfresh body written by this run.\n");
+      return Buffer.from("");
+    });
+    await runWorker();
+
+    expect(uploadSummaryMock).toHaveBeenCalledTimes(1);
+    expect(finalizeSummaryMock).toHaveBeenCalledWith("sid-worker", 14);
   });
 
   it("defaults to /sessions/unknown/ when the path SELECT returns no rows", async () => {

--- a/tests/codex/codex-wiki-worker.test.ts
+++ b/tests/codex/codex-wiki-worker.test.ts
@@ -270,6 +270,22 @@ describe("codex wiki-worker — happy path", () => {
     expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
   });
 
+  it("does NOT upload or advance the offset when codex exec exits 0 having written nothing", async () => {
+    // Exit 0 is not proof of work. A child that cannot reach tmpDir (or simply
+    // declines) exits 0 with the summary file untouched, leaving the pre-seeded
+    // prior summary in place. Treating that as success re-uploaded the
+    // placeholder verbatim AND stamped lastSummaryCount, slicing the unread
+    // events away forever — so every later run summarized nothing.
+    mkFetch(1, true, 9);
+    execFileSyncMock.mockImplementation(() => Buffer.from(""));
+    await runWorker();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    expect(finalizeSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
+  });
+
   it("ignores a stale sidecar offset when no existing summary was loaded", async () => {
     // Sidecar says 3 processed, but SELECT summary returns nothing (row gone).
     // Without a base summary the offset is meaningless — regenerate from scratch

--- a/tests/codex/codex-wiki-worker.test.ts
+++ b/tests/codex/codex-wiki-worker.test.ts
@@ -282,7 +282,7 @@ describe("codex wiki-worker — happy path", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(log).toContain("never wrote the summary");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
   });
 

--- a/tests/codex/codex-wiki-worker.test.ts
+++ b/tests/codex/codex-wiki-worker.test.ts
@@ -282,7 +282,7 @@ describe("codex wiki-worker — happy path", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("never wrote the summary");
+    expect(log).toContain("codex exec exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-codex");
   });
 

--- a/tests/cursor/cursor-wiki-worker.test.ts
+++ b/tests/cursor/cursor-wiki-worker.test.ts
@@ -202,7 +202,7 @@ describe("cursor wiki-worker — behavior", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("never wrote the summary");
+    expect(log).toContain("cursor-agent --print exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-cursor");
   });
 

--- a/tests/cursor/cursor-wiki-worker.test.ts
+++ b/tests/cursor/cursor-wiki-worker.test.ts
@@ -202,7 +202,7 @@ describe("cursor wiki-worker — behavior", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(log).toContain("never wrote the summary");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-cursor");
   });
 

--- a/tests/cursor/cursor-wiki-worker.test.ts
+++ b/tests/cursor/cursor-wiki-worker.test.ts
@@ -174,6 +174,38 @@ describe("cursor wiki-worker — behavior", () => {
     expect(releaseLockMock).toHaveBeenCalledWith("sid-cursor");
   });
 
+  it("does NOT upload or advance the offset when the agent exits 0 having written nothing", async () => {
+    // Exit 0 is not proof of work. A child that cannot reach tmpDir (or simply
+    // declines) exits 0 with the summary file untouched, leaving the pre-seeded
+    // prior summary in place. Treating that as success re-uploaded the
+    // placeholder verbatim AND stamped lastSummaryCount, slicing the unread
+    // events away forever — so every later run summarized nothing.
+    fetchMock.mockImplementation(async (_u: string, init: any) => {
+      const sql = JSON.parse(init.body).query as string;
+      if (sql.startsWith("SELECT count(*) AS n")) return jsonResp({ columns: ["n"], rows: [[9]] });
+      if (sql.startsWith("SELECT message, creation_date")) {
+        return jsonResp({
+          columns: ["message", "creation_date"],
+          rows: Array.from({ length: 9 }, (_, i) => [JSON.stringify({ type: "user_message", content: `hello cursor ${i}` }), "2026-04-20T00:00:00Z"]),
+        });
+      }
+      if (sql.startsWith("SELECT DISTINCT path")) {
+        return jsonResp({ columns: ["path"], rows: [["/sessions/alice/alice_org_default_sid-cursor.jsonl"]] });
+      }
+      if (sql.startsWith("SELECT summary FROM")) {
+        return jsonResp({ columns: ["summary"], rows: [["# Session X\n- **JSONL offset**: 7\n\n## What Happened\nprior"]] });
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    execFileSyncMock.mockImplementation(() => Buffer.from(""));
+    await runWorker();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    expect(finalizeSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-cursor");
+  });
+
   it("reads events from the local cache and issues NO self-session SELECTs", async () => {
     readCacheMock.mockReturnValue(
       Array.from({ length: 4 }, (_, i) => JSON.stringify({ type: "user_message", content: `cache ${i}` })),

--- a/tests/hermes/hermes-wiki-worker.test.ts
+++ b/tests/hermes/hermes-wiki-worker.test.ts
@@ -208,7 +208,7 @@ describe("hermes wiki-worker — behavior", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(log).toContain("never wrote the summary");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-hermes");
   });
 

--- a/tests/hermes/hermes-wiki-worker.test.ts
+++ b/tests/hermes/hermes-wiki-worker.test.ts
@@ -208,7 +208,7 @@ describe("hermes wiki-worker — behavior", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("never wrote the summary");
+    expect(log).toContain("hermes -z exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-hermes");
   });
 

--- a/tests/hermes/hermes-wiki-worker.test.ts
+++ b/tests/hermes/hermes-wiki-worker.test.ts
@@ -180,6 +180,38 @@ describe("hermes wiki-worker — behavior", () => {
     expect(releaseLockMock).toHaveBeenCalledWith("sid-hermes");
   });
 
+  it("does NOT upload or advance the offset when the agent exits 0 having written nothing", async () => {
+    // Exit 0 is not proof of work. A child that cannot reach tmpDir (or simply
+    // declines) exits 0 with the summary file untouched, leaving the pre-seeded
+    // prior summary in place. Treating that as success re-uploaded the
+    // placeholder verbatim AND stamped lastSummaryCount, slicing the unread
+    // events away forever — so every later run summarized nothing.
+    fetchMock.mockImplementation(async (_u: string, init: any) => {
+      const sql = JSON.parse(init.body).query as string;
+      if (sql.startsWith("SELECT count(*) AS n")) return jsonResp({ columns: ["n"], rows: [[9]] });
+      if (sql.startsWith("SELECT message, creation_date")) {
+        return jsonResp({
+          columns: ["message", "creation_date"],
+          rows: Array.from({ length: 9 }, (_, i) => [JSON.stringify({ type: "user_message", content: `hello hermes ${i}` }), "2026-04-20T00:00:00Z"]),
+        });
+      }
+      if (sql.startsWith("SELECT DISTINCT path")) {
+        return jsonResp({ columns: ["path"], rows: [["/sessions/alice/alice_org_default_sid-hermes.jsonl"]] });
+      }
+      if (sql.startsWith("SELECT summary FROM")) {
+        return jsonResp({ columns: ["summary"], rows: [["# Session X\n- **JSONL offset**: 7\n\n## What Happened\nprior"]] });
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    execFileSyncMock.mockImplementation(() => Buffer.from(""));
+    await runWorker();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    expect(finalizeSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-hermes");
+  });
+
   it("reads events from the local cache and issues NO self-session SELECTs", async () => {
     readCacheMock.mockReturnValue(
       Array.from({ length: 4 }, (_, i) => JSON.stringify({ type: "user_message", content: `cache ${i}` })),

--- a/tests/pi/pi-wiki-worker.test.ts
+++ b/tests/pi/pi-wiki-worker.test.ts
@@ -169,6 +169,38 @@ describe("pi wiki-worker — behavior", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(releaseLockMock).toHaveBeenCalledWith("sid-pi");
   });
+
+  it("does NOT upload or advance the offset when the agent exits 0 having written nothing", async () => {
+    // Exit 0 is not proof of work. A child that cannot reach tmpDir (or simply
+    // declines) exits 0 with the summary file untouched, leaving the pre-seeded
+    // prior summary in place. Treating that as success re-uploaded the
+    // placeholder verbatim AND stamped lastSummaryCount, slicing the unread
+    // events away forever — so every later run summarized nothing.
+    fetchMock.mockImplementation(async (_u: string, init: any) => {
+      const sql = JSON.parse(init.body).query as string;
+      if (sql.startsWith("SELECT count(*) AS n")) return jsonResp({ columns: ["n"], rows: [[9]] });
+      if (sql.startsWith("SELECT message, creation_date")) {
+        return jsonResp({
+          columns: ["message", "creation_date"],
+          rows: Array.from({ length: 9 }, (_, i) => [JSON.stringify({ type: "user_message", content: `hello pi ${i}` }), "2026-04-20T00:00:00Z"]),
+        });
+      }
+      if (sql.startsWith("SELECT DISTINCT path")) {
+        return jsonResp({ columns: ["path"], rows: [["/sessions/alice/alice_org_default_sid-pi.jsonl"]] });
+      }
+      if (sql.startsWith("SELECT summary FROM")) {
+        return jsonResp({ columns: ["summary"], rows: [["# Session X\n- **JSONL offset**: 7\n\n## What Happened\nprior"]] });
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    execFileSyncMock.mockImplementation(() => Buffer.from(""));
+    await runWorker();
+    expect(uploadSummaryMock).not.toHaveBeenCalled();
+    expect(finalizeSummaryMock).not.toHaveBeenCalled();
+    const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
+    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(releaseLockMock).toHaveBeenCalledWith("sid-pi");
+  });
 });
 
 const promptOf = (a: string[]) => a.find((x) => typeof x === "string" && x.includes("SUMMARY="))!;

--- a/tests/pi/pi-wiki-worker.test.ts
+++ b/tests/pi/pi-wiki-worker.test.ts
@@ -198,7 +198,7 @@ describe("pi wiki-worker — behavior", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("left the pre-seeded summary unchanged");
+    expect(log).toContain("never wrote the summary");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-pi");
   });
 });

--- a/tests/pi/pi-wiki-worker.test.ts
+++ b/tests/pi/pi-wiki-worker.test.ts
@@ -198,7 +198,7 @@ describe("pi wiki-worker — behavior", () => {
     expect(uploadSummaryMock).not.toHaveBeenCalled();
     expect(finalizeSummaryMock).not.toHaveBeenCalled();
     const log = readFileSync(join(hooksDir, "wiki.log"), "utf-8");
-    expect(log).toContain("never wrote the summary");
+    expect(log).toContain("pi --print exited 0 but never wrote the summary; skipping upload to avoid advancing the offset");
     expect(releaseLockMock).toHaveBeenCalledWith("sid-pi");
   });
 });

--- a/tests/shared/claude-permission-grants.test.ts
+++ b/tests/shared/claude-permission-grants.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * Contract for the explicit permission grants that replaced the blanket
+ * `--permission-mode bypassPermissions` on the summarizer's `claude -p` calls.
+ *
+ * Why the swap: an enterprise policy can set
+ * `"disableBypassPermissionsMode": "disable"`, after which the child ignores
+ * the bypass, falls back to normal permissioning, refuses every path outside
+ * the session cwd — which is exactly where the wiki worker's scratch dir and
+ * the backfill's transcript/staging dirs live — and, because print mode cannot
+ * prompt, exits 0 having written nothing. Naming the dirs and tools is both
+ * policy-proof and least-privilege.
+ *
+ * Two halves matter equally: grants must REPLACE the bypass when supplied, and
+ * the bypass must survive untouched for every caller that supplies none.
+ */
+
+import {
+  buildClaudeInvocation,
+  buildClaudeStdinInvocation,
+  permissionFlags,
+} from "../../src/hooks/wiki-worker-spawn.js";
+
+const realPlatform = process.platform;
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+});
+
+describe("permissionFlags", () => {
+  it("falls back to the blanket bypass when no grants are named", () => {
+    expect(permissionFlags(undefined)).toEqual(["--permission-mode", "bypassPermissions"]);
+  });
+
+  it("emits one --add-dir per granted dir, then the allowed tools", () => {
+    expect(permissionFlags({ addDirs: ["/a", "/b"], allowedTools: ["Read", "Write"] }))
+      .toEqual(["--add-dir", "/a", "--add-dir", "/b", "--allowedTools", "Read", "Write"]);
+  });
+
+  it("accepts dirs without tools, and tools without dirs", () => {
+    expect(permissionFlags({ addDirs: ["/a"] })).toEqual(["--add-dir", "/a"]);
+    expect(permissionFlags({ allowedTools: ["Read"] })).toEqual(["--allowedTools", "Read"]);
+  });
+
+  it("falls back to the bypass rather than leaving the child with no grant at all", () => {
+    // An empty grants object is a caller bug; degrading to today's behaviour
+    // beats silently spawning a child that can reach nothing.
+    expect(permissionFlags({})).toEqual(["--permission-mode", "bypassPermissions"]);
+    expect(permissionFlags({ addDirs: [], allowedTools: [] })).toEqual(["--permission-mode", "bypassPermissions"]);
+  });
+
+  it("quotes granted paths only when asked (the Windows shell branch)", () => {
+    const dir = "C:\\Users\\First Last\\AppData\\Local\\Temp\\deeplake-wiki-1";
+    expect(permissionFlags({ addDirs: [dir] }, false)).toEqual(["--add-dir", dir]);
+    expect(permissionFlags({ addDirs: [dir] }, true)).toEqual(["--add-dir", `"${dir}"`]);
+  });
+});
+
+describe("buildClaudeInvocation — grants vs bypass", () => {
+  it("replaces the bypass with the grants on the POSIX argv path", () => {
+    setPlatform("linux");
+    const inv = buildClaudeInvocation("/usr/local/bin/claude", "PROMPT", {
+      addDirs: ["/tmp/deeplake-wiki-1"],
+      allowedTools: ["Read", "Write"],
+    });
+    expect(inv.args).toEqual([
+      "-p", "PROMPT",
+      "--no-session-persistence",
+      "--model", "haiku",
+      "--add-dir", "/tmp/deeplake-wiki-1",
+      "--allowedTools", "Read", "Write",
+    ]);
+    expect(inv.args).not.toContain("bypassPermissions");
+  });
+
+  it("leaves the bypass in place for a caller that names no grants", () => {
+    setPlatform("linux");
+    const inv = buildClaudeInvocation("/usr/local/bin/claude", "PROMPT");
+    expect(inv.args).toEqual([
+      "-p", "PROMPT",
+      "--no-session-persistence",
+      "--model", "haiku",
+      "--permission-mode", "bypassPermissions",
+    ]);
+  });
+
+  it("quotes the granted dir on the Windows .cmd branch, where args are re-joined into a command line", () => {
+    // A Windows temp dir routinely contains spaces; unquoted it would split
+    // into two args and the grant would silently name the wrong directory.
+    setPlatform("win32");
+    const dir = "C:\\Users\\First Last\\AppData\\Local\\Temp\\deeplake-wiki-1";
+    const inv = buildClaudeInvocation("C:\\npm\\claude.cmd", "PROMPT", {
+      addDirs: [dir],
+      allowedTools: ["Read", "Write"],
+    });
+    expect(inv.args).toEqual([
+      "-p",
+      "--no-session-persistence",
+      "--model", "haiku",
+      "--add-dir", `"${dir}"`,
+      "--allowedTools", "Read", "Write",
+    ]);
+    // The prompt still rides stdin, never the command line.
+    expect(inv.args).not.toContain("PROMPT");
+    expect(inv.options.input).toBe("PROMPT");
+  });
+
+  it("keeps the bypass on the Windows .cmd branch when no grants are named", () => {
+    setPlatform("win32");
+    const inv = buildClaudeInvocation("C:\\npm\\claude.cmd", "PROMPT");
+    expect(inv.args).toEqual([
+      "-p",
+      "--no-session-persistence",
+      "--model", "haiku",
+      "--permission-mode", "bypassPermissions",
+    ]);
+  });
+});
+
+describe("buildClaudeStdinInvocation — grants vs bypass", () => {
+  it("carries the grants through the stdin variant", () => {
+    setPlatform("linux");
+    const inv = buildClaudeStdinInvocation("/usr/local/bin/claude", "PROMPT", {
+      addDirs: ["/tmp/staging"],
+      allowedTools: ["Read", "Write"],
+    });
+    expect(inv.args).toEqual([
+      "-p",
+      "--no-session-persistence",
+      "--model", "haiku",
+      "--add-dir", "/tmp/staging",
+      "--allowedTools", "Read", "Write",
+    ]);
+    expect(inv.options.input).toBe("PROMPT");
+  });
+
+  it("keeps the bypass in the stdin variant when no grants are named", () => {
+    setPlatform("linux");
+    const inv = buildClaudeStdinInvocation("/usr/local/bin/claude", "PROMPT");
+    expect(inv.args).toContain("bypassPermissions");
+  });
+});

--- a/tests/shared/wiki-summary-written.test.ts
+++ b/tests/shared/wiki-summary-written.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { markSummaryUnwritten, summaryWasWritten } from "../../src/hooks/wiki-offset.js";
+
+/**
+ * "Did the agent actually write?" is the decision that separates a real summary
+ * from the placeholder-forever bug: answering "yes" when the child wrote nothing
+ * uploads the pre-seeded stub AND advances the offset, destroying the unread
+ * events. These pin the answer on every filesystem the workers can land on.
+ */
+
+const realFs = { existsSync, utimesSync, statSync };
+
+function withFile(body: (path: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), "summary-written-"));
+  try { body(join(dir, "summary.md")); } finally { rmSync(dir, { recursive: true, force: true }); }
+}
+
+describe("markSummaryUnwritten / summaryWasWritten", () => {
+  it("reports NOT written when the agent leaves the pre-seeded file alone", () => {
+    withFile((p) => {
+      writeFileSync(p, "# placeholder\n");
+      const base = markSummaryUnwritten(p, realFs);
+      expect(base.trusted).toBe(true);
+      expect(summaryWasWritten(p, base, false, realFs)).toBe(false);
+    });
+  });
+
+  it("reports WRITTEN when the agent rewrites the identical bytes", () => {
+    // The regression the timestamp check exists for: content equality alone
+    // would call this a no-op and freeze the offset forever.
+    withFile((p) => {
+      writeFileSync(p, "# same\n");
+      const base = markSummaryUnwritten(p, realFs);
+      writeFileSync(p, "# same\n");
+      expect(summaryWasWritten(p, base, false, realFs)).toBe(true);
+    });
+  });
+
+  it("reports WRITTEN when the agent writes different content", () => {
+    withFile((p) => {
+      writeFileSync(p, "# before\n");
+      const base = markSummaryUnwritten(p, realFs);
+      writeFileSync(p, "# after\n");
+      expect(summaryWasWritten(p, base, true, realFs)).toBe(true);
+    });
+  });
+
+  it("treats a first run with no pre-seeded file as written when content appeared", () => {
+    withFile((p) => {
+      const base = markSummaryUnwritten(p, realFs);
+      expect(base).toEqual({ mtimeMs: 0, trusted: true });
+      writeFileSync(p, "# fresh\n");
+      expect(summaryWasWritten(p, base, true, realFs)).toBe(true);
+    });
+  });
+
+  it("does not throw — and distrusts the timestamp — when utimes is rejected", () => {
+    // A read-only or exotic filesystem must not abort the worker: before this
+    // was routed through the helper, the utimes call sat outside the try and a
+    // throw killed the run outright.
+    withFile((p) => {
+      writeFileSync(p, "# ro\n");
+      const fs = { existsSync, statSync, utimesSync: () => { throw new Error("EPERM"); } };
+      const base = markSummaryUnwritten(p, fs);
+      expect(base.trusted).toBe(false);
+      // Untrusted timestamps fall back to content, erring toward skipping.
+      expect(summaryWasWritten(p, base, false, realFs)).toBe(false);
+      expect(summaryWasWritten(p, base, true, realFs)).toBe(true);
+    });
+  });
+
+  it("distrusts the timestamp when utimes silently does nothing", () => {
+    // The coarse-clock hole: a filesystem that accepts utimes and ignores it
+    // would leave the baseline at "now", where a same-tick identical rewrite
+    // is indistinguishable from no write at all.
+    withFile((p) => {
+      writeFileSync(p, "# noop\n");
+      const fs = { existsSync, statSync, utimesSync: () => { /* silently ignored */ } };
+      const base = markSummaryUnwritten(p, fs);
+      expect(base.trusted).toBe(false);
+      expect(summaryWasWritten(p, base, false, realFs)).toBe(false);
+    });
+  });
+
+  it("falls back to content when the file vanishes before the check", () => {
+    withFile((p) => {
+      writeFileSync(p, "# gone\n");
+      const base = markSummaryUnwritten(p, realFs);
+      rmSync(p);
+      expect(summaryWasWritten(p, base, true, realFs)).toBe(true);
+      expect(summaryWasWritten(p, base, false, realFs)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Fixes a reported field failure: on a host whose enterprise policy sets
`"disableBypassPermissionsMode": "disable"`, the session summarizer is silently
dead — every summary is a header-only stub and every backfill session reports
`no-summary`.

## Root cause

The wiki worker spawns a child `claude -p` with `--permission-mode bypassPermissions`
and then hands it absolute paths **outside the session cwd** (`$TMPDIR/deeplake-wiki-<id>-<ts>/`).
Under that policy the bypass is ignored, the child falls back to normal
permissioning, refuses every out-of-cwd path, and — because print mode cannot
prompt — exits 0 having written nothing:

```
running claude -p
claude -p exited (code 0)
no summary file generated
```

**The second bug is what makes it permanent.** When SessionStart has pre-seeded a
placeholder, the worker takes the SUCCESS path, uploads the placeholder verbatim,
and stamps `lastSummaryCount` — slicing those events away forever. Repeat every
run and every summary is a header stub with no body, by construction. The
`summaryChanged` guard was only consulted when the child exited **non-zero**.

## The fix

Name the dirs and tools instead of relying on the bypass. `--add-dir` +
`--allowedTools Read Write` is both policy-proof and least-privilege — the
summarizer never needs more than Read and Write.

- `src/hooks/wiki-worker-spawn.ts` — `CLAUDE_FLAGS` splits into `CLAUDE_BASE_FLAGS`
  + `CLAUDE_BYPASS_FLAGS`; a new `ClaudeGrants` interface and `permissionFlags()`
  helper. A caller that supplies grants gets them **instead of** the bypass; a
  caller that supplies none keeps the old blanket bypass, so nothing else changes.
  The Windows `.cmd` branch quotes granted paths, since a temp dir there routinely
  contains spaces.
- `src/hooks/wiki-worker.ts` — grants `tmpDir`, and applies the `summaryChanged`
  guard on the success path too.
- `src/skillify/stage-memory.ts` — grants the backfill's transcript dir and
  staging dir; `runAgent` grows an optional `grants` param.

## The other four `bypassPermissions` call sites

Audited all of them rather than shipping a partial fix.

| Call site | Hands the child an out-of-cwd path? | Action |
| --- | --- | --- |
| `src/commands/mine-local.ts` | Yes — the gate prompt names a verdict path under the per-session tmp dir | **Granted** |
| `src/skillify/gate-runner.ts` | Yes — same, via the skillify worker's tmp dir | **Granted** |
| `src/skillify/advisor.ts` | No — prompt is inlined, verdict is parsed from stdout | No change |
| `src/docs/refresh-llm.ts` | No — source content is inlined, markdown is read back from stdout | No change |

The two granted sites both offer the model a stdout fallback, so they degraded
rather than failed outright; under the policy the Write-tool branch was dead and
the verdict depended on the model choosing to print instead. `refresh-llm.ts`'s
codex branch uses `--dangerously-bypass-approvals-and-sandbox`, a different CLI's
flag, unaffected by the Claude enterprise policy. Non-claude agents keep their
existing argv untouched.

## Tests

The point of the regression test is the *silent success*, not the flags — a test
that only checked the argv would pass against a broken implementation.

- **`tests/claude-code/wiki-worker.test.ts`** — an exit-0 run that writes nothing
  must NOT upload the pre-seeded summary and must NOT advance `lastSummaryCount`.
  Confirmed to **fail** against the pre-fix worker (removing the guard turns it
  red), so it genuinely pins the bug. Its mirror asserts a run that *does* rewrite
  the summary still uploads and stamps, so the fix cannot silently freeze summaries.
- **`tests/shared/claude-permission-grants.test.ts`** (new) — grants replace the
  bypass; no grants keep it byte-identical; an empty grants object degrades to the
  bypass rather than granting nothing; the Windows `.cmd` branch quotes a path
  containing spaces.
- **`skillify-gate-runner` / `mine-local-orchestrator`** — argv assertions for both
  halves of the contract at the two newly granted call sites.

## What was and was not verified

- **Verified here:** the full suite is green (5898 tests) with per-file coverage
  thresholds met, `tsc --noEmit` clean, and the built argv carries the grants and
  not the bypass. The offset does not advance on an unchanged summary — proven by
  removing the guard and watching the test go red.
- **Verified out-of-band**, on a policy-managed macOS host this repo's CI cannot
  reproduce: the wiki prompt yields a real summary where it previously yielded
  none, and `stageSession` returns `ok:true` instead of `reason:"no-summary"`.
- **NOT verified from CI or from this machine:** behaviour under a real enterprise
  policy. `disableBypassPermissionsMode` is a managed-settings knob; unit tests
  cannot reproduce the environment, only the argv and the offset bookkeeping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Claude-powered tasks now receive access only to required directories and Read/Write tools.
  * Fallback permission behavior remains available when no specific permissions are provided.

* **Bug Fixes**
  * Wiki summaries are uploaded and session progress advances only after the summary is updated.
  * Legitimate rewrites with identical content are now recognized as updates, while summaries that were never written are skipped.

* **Tests**
  * Expanded coverage for permission handling, summary updates, supported platforms, and different agent types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Verification

## 1. The policy is actually honoured — not simulated

`claude` accepts `--settings`, so the child genuinely enforces
`disableBypassPermissionsMode: "disable"`: the bypass flag is *passed* and the CLI
*ignores* it, which is precisely the customer's condition. Full 2×2 with controls,
real `claude` 2.1.258, target dir outside the cwd:

| | old argv (`--permission-mode bypassPermissions`) | new argv (`--add-dir` + `--allowedTools Read Write`) |
| --- | --- | --- |
| **policy OFF** | summary WRITTEN (71 B) | summary WRITTEN (80 B) |
| **policy ON** | **exit 0, summary NOT WRITTEN** — the bug | summary WRITTEN (56 B) — the fix |

Exactly one cell fails and it is the reported one; both control cells pass, so the
failure is attributable to the policy and nothing else. In the failing run the child
states it itself: *"the write is blocked at the system level"* — the
`claude -p exited (code 0)` + `no summary file generated` pair from the field log.

## 2. End-to-end on the built worker: pre-fix vs fixed

Real `wiki-worker.js` bundle run as a real process against a local stand-in for the
query endpoint, isolated `HOME`, no live table touched. Same input, two bundles:

| Bundle | Uploaded a summary? | Advanced `lastSummaryCount`? |
| --- | --- | --- |
| pre-fix (today's `main`) | **YES** — `uploaded /summaries/…/sid-e2e.md (summary=69, desc=11)` | **YES** — `lastSummaryCount=9` |
| fixed | no — `exited 0 but left the pre-seeded summary unchanged; skipping upload` | no |

Those 69 bytes are the placeholder re-uploaded verbatim, and the stamped offset is the
moment the 9 unread events are lost for good.

With the **real** `claude` binary and a fresh session, the fixed worker produces a real
summary and uploads it (`INSERT INTO "memory"` observed), so the grants do not merely
block the damage — the working path still works.

## 3. The codex harness, with the real `codex` binary

| Case | Uploaded? | Offset |
| --- | --- | --- |
| agent exits 0 having written nothing (pre-seed present) | no — `codex exec exited 0 but left the pre-seeded summary unchanged` | not advanced |
| real `codex`, fresh session | YES — `uploaded … (summary=293, desc=9)` | `lastSummaryCount=9` |

Cursor, hermes and pi carry the identical guard and unit tests, but their CLIs are not
signed in on the verification host, so they are covered by tests + mutation only.

## Review consensus

Four adversarial review passes (codex, non-author). Each of the first three blocked, and
each block was a real defect — two of them regressions introduced by this branch while
fixing the original bug:

| Pass | Finding | Outcome |
| --- | --- | --- |
| 1 | Identical-content rewrite would freeze the offset forever | fixed |
| 1 | `commit-kpi-extract.ts:121` spawns `claude -p` with no grant | verified, documented below, out of scope |
| 1 | Two tests passed against a broken implementation | fixed, both verified to bite |
| 2 | mtime check had a hole on a coarse-resolution filesystem clock | fixed with a backdated sentinel |
| 3 | `utimesSync` outside the try — a rejecting filesystem aborted the worker | fixed |
| 3 | A silently-ignored `utimes` reopened the hole | fixed via `trusted: false` + content fallback |
| 4 | — | **VERDICT: SHIP** |

The wrote-nothing decision lived in five copies across the workers — which is how the
original bug propagated in the first place — so it now lives once in `wiki-offset.ts`
(`markSummaryUnwritten` / `summaryWasWritten`), which all five already import, with seven
direct unit tests including both `utimes` failure modes.

When the filesystem makes timestamps untrustworthy the check falls back to content
comparison, which errs toward **skipping** the upload: re-summarizing the same rows next
run wastes work, whereas a wrong upload destroys events. Never the other way round.

## Still not verified

- A **real** managed-settings policy file (`/etc/claude-code/managed-settings.json`,
  or the macOS path). `--settings` makes the CLI honour the same key and reproduces the
  reported behaviour exactly, but it is not the same settings source.
- cursor / hermes / pi against their real CLIs.

## Out of scope, found while verifying — worth a separate fix

`src/hooks/wiki-worker.ts:88` — `query()` retries only on HTTP *status* (401/403/429/5xx).
A network error **thrown** by `fetch` (dropped keep-alive socket, connection reset) is not
caught and kills the worker with `fatal: fetch failed`, losing the summary. The gap between
the pre-`claude` SELECTs and the post-`claude` upload is exactly the duration of
`claude -p` — tens of seconds — which is when an idle pooled socket is most likely to have
been closed. Same user-visible symptom as this bug, different cause. Not touched here.

